### PR TITLE
perf(component): cut async per-call allocations (FirstLight 4->1, AwaitImport 11->5)

### DIFF
--- a/docs/perf-async-profiling-findings.md
+++ b/docs/perf-async-profiling-findings.md
@@ -1,0 +1,44 @@
+# Async/CM perf profiling findings (perf/component-model-async)
+
+Baseline commit acf639d. Machine heavily loaded during profiling → **ns/op is unreliable;
+allocs/op + B/op are exact (load-independent) and are the metric used here.** CPU profiling
+under load 36 gave only ~20ms of usable samples (dominated by the legit callback loop +
+guest CallWithStack, no wazy-side time sink) — revisit CPU profiling when the box is quiet.
+
+## Per-call async hot path
+`BenchmarkCallAsyncFirstLight` (no-suspension callback call): **4 allocs / 390 B**
+`BenchmarkCallAsyncAwaitImport` (full WAIT path): **11 allocs / 973 B** (2 of the 11 are
+benchmark-harness closures, not runtime → ~9 runtime).
+
+### Tranche 1 (shared per-call, in progress — task #17)
+- `async_lift.go:84-85` — `&task{}` + `&guestTask{}` always paired → **co-allocate (2→1)**
+- `guest_task.go:239` — `gt.firstRunBody` bound-method value escapes into `runSegment(fn)` → **−1**
+- `async_builtins.go:571` — `[]abi.Value{val}` task.return 1-elem slice → **inline [1]abi.Value (−1)**
+  → target FirstLight 4→1, AwaitImport 11→8.
+
+### Tranche 1.5 (WAIT-path closures → methods; safe, load-independent)
+- `async_host_import.go:298` — `st.applyResolve = func(vals) error {...}` captures st → make it a
+  method + store captured data as `subtask` fields (−1)
+- `async_host_import.go:159` — `st.setPendingEvent(func() eventTuple {...})` captures st → ditto (−1)
+
+### Tranche 2 (WAIT-path struct pooling; needs reset-on-resolve design, higher risk — CM11 pattern)
+- `async_host_import.go:445` — `&AsyncCall{...}` per WAIT
+- `async_host_import.go:283` — `&subtask{...}` per WAIT (newSubtask; the `lenders: []*resourceEntry{}`
+  empty-literal may also be avoidable — start nil, grow on first lend)
+- `async_builtins.go:149` — `&waitableSet{}` per WAIT (waitableSetNew)
+- Pool the co-allocated task/guestTask frame from Tranche 1 too → amortized ~0.
+
+## Separate area: component Instantiate (higher volume for multi-instantiate workloads)
+`BenchmarkInstantiateCached`: **98 allocs / 24.5 KB**; `BenchmarkInstantiateHelloCached`:
+**1665 allocs / 368 KB**. Top alloc sites:
+- `instantiateGraph` (the CM instantiation driver, 92% cum)
+- engine `FunctionInstanceReference` (11%) + `NewFunction` (5%)
+- `buildInstanceExportIndex` (map per instantiate)
+- config churn: `newConfig` + `moduleConfig.clone` + `NewModuleConfig` (~3 allocs/instantiate for config objects — candidate to reuse/avoid the clone)
+- core `Store.instantiate` / `buildGlobals` / `evaluateConstExpr` (partly engine, not CM-specific)
+Diffuse; lower priority than the per-call path but worth a pass for embedders instantiating many
+components.
+
+## Coverage gap
+No benchmark exercises the thread.* path (thread.yield / new-indirect / yield-then-resume). Add one
+before optimizing that path so its allocs are measurable.

--- a/docs/perf-async-profiling-findings.md
+++ b/docs/perf-async-profiling-findings.md
@@ -49,6 +49,14 @@ benchmark-harness closures, not runtime → ~9 runtime).
 Diffuse; lower priority than the per-call path but worth a pass for embedders instantiating many
 components.
 
+**INVESTIGATED (low ROI, not pursued):** the Instantiate allocs are diffuse (largest single site
+~2.2%) and mostly INHERENT: per-instance WASI sys state (stdio/walltime/nanotime/randsource),
+config isolation (moduleConfig.clone is intentional per-instance), and the WASI host module being
+rebuilt per instantiate (a deep engine/builder-layer change, outside internal/component/instance).
+`buildInstanceExportIndex` is already lazy (0 alloc when a component has no `instance#member`
+exports) and its map-of-maps is the right structure. No clean CM-layer win here; the real lever
+would be caching the compiled WASI host module across instantiations (engine work, separate effort).
+
 ## Coverage gap
 No benchmark exercises the thread.* path (thread.yield / new-indirect / yield-then-resume). Add one
 before optimizing that path so its allocs are measurable.

--- a/docs/perf-async-profiling-findings.md
+++ b/docs/perf-async-profiling-findings.md
@@ -10,7 +10,17 @@ guest CallWithStack, no wazy-side time sink) — revisit CPU profiling when the 
 `BenchmarkCallAsyncAwaitImport` (full WAIT path): **11 allocs / 973 B** (2 of the 11 are
 benchmark-harness closures, not runtime → ~9 runtime).
 
-### Tranche 1 (shared per-call, in progress — task #17)
+### STATUS (perf/component-model-async)
+- **Tranche 1 DONE (8f80319):** FirstLight 4→1, AwaitImport 11→8. co-alloc frame + method-value + result buffer.
+- **Tranche 1.5 DONE (0c1f679):** closure-free subtask pending-event. AwaitImport 8→7.
+- **Tranche 2 DEFERRED (measure-first):** pooling below. Its payoff is latency/GC-pressure, NOT
+  alloc-count-visible value — verify on a QUIET machine (wall-clock benchstat) before shipping,
+  and stress the reset-on-resolve lifecycle under -race (a subtask returned to a pool while a
+  parked guestTask still references it = corruption). Do NOT ship blind under load.
+- `applyResolve` closure (async_host_import.go:298) folds into Tranche 2 (store retPtr/memMod on
+  the subtask + a bind-time resolveConfig pointer; drop the per-call closure).
+
+### Tranche 1 (shared per-call — DONE 8f80319)
 - `async_lift.go:84-85` — `&task{}` + `&guestTask{}` always paired → **co-allocate (2→1)**
 - `guest_task.go:239` — `gt.firstRunBody` bound-method value escapes into `runSegment(fn)` → **−1**
 - `async_builtins.go:571` — `[]abi.Value{val}` task.return 1-elem slice → **inline [1]abi.Value (−1)**

--- a/docs/perf-async-profiling-findings.md
+++ b/docs/perf-async-profiling-findings.md
@@ -13,7 +13,12 @@ benchmark-harness closures, not runtime → ~9 runtime).
 ### STATUS (perf/component-model-async)
 - **Tranche 1 DONE (8f80319):** FirstLight 4→1, AwaitImport 11→8. co-alloc frame + method-value + result buffer.
 - **Tranche 1.5 DONE (0c1f679):** closure-free subtask pending-event. AwaitImport 8→7.
-- **Tranche 2 DEFERRED (measure-first):** pooling below. Its payoff is latency/GC-pressure, NOT
+- **S1–S3 DONE (d6c5384):** applyResolve→method, AsyncCall embedded in subtask, onCancel
+  destructured. AwaitImport 7→**5** allocs (2 of the 5 are irremovable benchmark host-fn
+  closures → runtime floor **3**). Session total: FirstLight **4→1**, AwaitImport **11→5**.
+- **S4 / Tranche 2 DEFERRED (measure-first):** callbackFrame + subtask/waitableSet pooling below.
+  Fable confirmed S4 is alloc-NEUTRAL for non-void results (trades an alloc for a 16B copy); its
+  only payoff is latency, unmeasurable under load. Not shipping pooling blind. Its payoff is latency/GC-pressure, NOT
   alloc-count-visible value — verify on a QUIET machine (wall-clock benchstat) before shipping,
   and stress the reset-on-resolve lifecycle under -race (a subtask returned to a pool while a
   parked guestTask still references it = corruption). Do NOT ship blind under load.

--- a/docs/perf-async-wait-alloc-brief.md
+++ b/docs/perf-async-wait-alloc-brief.md
@@ -1,0 +1,68 @@
+# Design brief: eliminate the remaining async WAIT-path allocations
+
+wazy = wazero-derived Go WebAssembly runtime, SINGLE-runnable async runtime (one goroutine holds
+the baton per composition tree; multiple composition trees can run on different goroutines).
+Branch perf/component-model-async. `BenchmarkCallAsyncAwaitImport` is at **7 allocs/op / 895 B**
+(down from 11) after two safe tranches. Design how to eliminate the REMAINING per-WAIT allocations,
+ranked by SAFETY, with an exact "definitely-done" reset/free point for each and a `-race`/leak/
+use-after-free argument. Implementable by a Sonnet in stages. IMPORTANT: allocs/op is verifiable
+now (load-independent); the *latency* payoff is NOT (the dev box is at load 36) — so favor changes
+whose CORRECTNESS is provable now and note which need a quiet-machine wall-clock check before we
+trust their value.
+
+## The remaining per-WAIT alloc sites (profiled with -memprofilerate=1)
+1. `async_host_import.go:288` — `st.applyResolve = func(vals) error {...}` — a per-call CLOSURE on
+   `subtask.applyResolve`. Captures per-call `retPtr`,`memMod` + bind-time `iface`,`funcName`,
+   `resultCount`,`resultUsesMem`,`resultType`,`outPtrIdx`,`resources`. Called at :83 and :374.
+2. `async_host_import.go:445` — `ac := &AsyncCall{in, st, inCall:true}` — the host-import call handle
+   (5 fields). ESCAPES: passed to `hi.asyncFn(ctx, args, ac)`; the host may retain it (Defer/Resolve).
+3. `async_host_import.go:283` — `&subtask{state, lenders: []*resourceEntry{}}` (newSubtask). The
+   `lenders` empty-slice literal may also be avoidable (start nil, grow on first lend).
+4. `async_builtins.go:149` — `&waitableSet{}` (waitable-set.new; guest-created, guest-dropped).
+5. The co-allocated `callbackFrame{task,guestTask}` from Tranche 1 (async_lift.go) — 1 alloc/call on
+   EVERY async call (FirstLight's remaining 1).
+6. (Also present) `subtask.onCancel func() error` closure — set from AsyncCall.OnCancel or the
+   callee's requestCancellation.
+
+## Read these (verify everything against the actual code — line numbers are approximate)
+- `internal/component/instance/async_host_import.go`: buildAsyncHostWrapper (the whole fn + its two
+  arms: plain-host-import and guest<->guest), AsyncCall (struct ~50, Resolve/Defer/OnCancel),
+  applyResolve wiring, newSubtask.
+- `internal/component/instance/waitable.go`: `subtask` struct (all fields + their lifecycle docs),
+  `waitable`, `waitableSet`; how a subtask is parked (`resources.addEntry`), resolved
+  (`resolve`/`deliverResolve`/`resolveDelivered`), and dropped (subtask.drop builtin).
+- `internal/component/instance/async_builtins.go`: waitableSetNewHostFunc (:149), subtask.drop,
+  waitable-set.drop — the guest-controlled free points.
+- `internal/component/instance/async_lift.go`: invokeAsyncCallback / startAsyncExportTask (the
+  callbackFrame alloc + the task/guestTask lifetime: created at entry, resolved at EXIT, but a
+  PARKED task lives across WAIT rounds).
+- `internal/component/instance/task.go`, `guest_task.go`, `stackful_task.go`, `sched.go`: task
+  lifecycle, park/resume, reap on Close.
+- Reference: `internal/component/abi/testdata/definitions.py` Subtask/Task/WaitableSet lifecycle.
+
+## For EACH of the 6 sites, deliver
+- **Technique** — pick the safest that works: (a) destructure a closure into typed fields +
+  a bind-time-config pointer (no alloc, no pool — like the just-landed closure-free pendingSub);
+  (b) sync.Pool with a precise Reset + a "definitely-done" return point; (c) eliminate/inline; or
+  (d) leave it (say why pooling isn't safe). Prefer (a)/(c) over (b) where possible — a pool is only
+  worth it when there's a single unambiguous return point AND the object can't still be referenced.
+- **The definitely-done point** — the exact call site where the object is provably unreachable by
+  any parked task, undelivered event, or host-held handle, so it can be reset/returned. For subtask:
+  is it subtask.drop? after deliverResolve? Beware: a resolved-but-not-yet-delivered subtask still
+  has a pending event; a host holding an AsyncCall via Defer resolves LATER.
+- **The use-after-free / -race argument** — why the object is single-owner at the free point under
+  the baton invariant; why sync.Pool's cross-P behavior is fine (or why not).
+- **applyResolve/onCancel specifically** — which captured vars are bind-time (belong on a shared
+  per-import config built once in buildAsyncHostWrapper) vs per-call (belong as subtask fields);
+  give the exact field list and the method signature replacing the closure. Confirm applyResolve is
+  set at exactly ONE site (so a single method works) — or handle the variants.
+- **callbackFrame pooling** — the highest-frequency win (every async call). Where is the frame
+  provably done (EXIT + result fully lifted by the caller)? What must Reset clear (all the guestTask/
+  task fields, ctxStorage, resultBuf, park state) so a recycled frame can't leak stale state into
+  the next call? This one MUST be -race + goleak stress-tested and wall-clocked when quiet.
+
+## Also deliver
+- A staged landing order (safest/most-verifiable-now first; pooling last), each stage a Sonnet-sized
+  increment that keeps `TestAsyncWastConformance` 31/31 + `TestAsyncOracle` + `-race` green and
+  reduces allocs/op measurably. Flag which stages' VALUE (not correctness) needs a quiet-machine
+  wall-clock check. Note anything that would touch the sched/park core.

--- a/docs/perf-async-wait-alloc-design-fable.md
+++ b/docs/perf-async-wait-alloc-design-fable.md
@@ -1,0 +1,564 @@
+# Design: eliminating the remaining async WAIT-path allocations
+
+Branch `perf/component-model-async`. Companion to `docs/perf-async-wait-alloc-brief.md`.
+Everything below was re-verified against the working tree on 2026-07-18 (file:line references are
+exact as of this commit); the alloc counts were re-measured with `-memprofilerate=1`, which is
+load-independent and therefore trustworthy on the loaded dev box. **ns/op numbers in this doc are
+NOT trustworthy and are never used to justify a decision.**
+
+---
+
+## 0. Verified baseline: what the 7 allocs/op actually are
+
+```
+BenchmarkCallAsyncFirstLight-20    806.9 ns/op   330 B/op   1 allocs/op
+BenchmarkCallAsyncAwaitImport-20  1946   ns/op   941 B/op   7 allocs/op
+```
+
+`-memprofilerate=1` profile of `BenchmarkCallAsyncAwaitImport` (5000 iterations; every row below
+is 5001 ± 1 objects ⇒ exactly 1 alloc/op each, except the first which is 2):
+
+| # | flat objs | site | what allocates |
+|---|-----------|------|----------------|
+| 1+2 | 10002 | `buildAsyncHostWrapper.func1` (async_host_import.go) | the `st.applyResolve = func(...)` closure (**:288**) AND `ac := &AsyncCall{...}` (**:435**) |
+| 3 | 5001 | `newSubtask` (waitable.go:309, inlined) | the `subtask` struct itself — **the `lenders: []*resourceEntry{}` literal is 0 bytes (runtime zerobase), it is NOT an allocation** (measured: 1 obj/op, not 2) |
+| 4 | 5001 | `waitableSetNewHostFunc.func11` (async_builtins.go:149) | `ws := &waitableSet{}` |
+| 5 | 5001 | `invokeAsyncCallback` (async_lift.go:97) | `fr := &callbackFrame{}` (~290 B: task+guestTask) |
+| 6 | 5001 | `BenchmarkCallAsyncAwaitImport.func1` | **benchmark host-fn code**: the `call.Defer(func(){...})` closure capturing `call` |
+| 7 | 5001 | `BenchmarkCallAsyncAwaitImport.func1.1` | **benchmark host-fn code**: the `[]abi.Value{uint32(99)}` results slice (the `uint32(99)` interface box itself is free — <256 static box) |
+
+Two consequences worth stating up front:
+
+- **Only 5 of the 7 are runtime allocations.** Rows 6–7 live in the user's `AsyncHostFunc`; no
+  runtime change removes them without an API addition (see Appendix A). The runtime floor for this
+  benchmark is therefore **2 user allocs + whatever we cannot remove below**.
+- **The brief's site 6 (`onCancel` closure) contributes 0 allocs to this benchmark** (the
+  benchmark host fn never calls `OnCancel`, and the guest<->guest arm isn't exercised). It is
+  still worth destructuring — it removes 1–2 allocs/call on the guest<->guest async-lower path
+  and 1 on any host import that registers `OnCancel` — but it will not move this benchmark.
+
+One more structural fact that constrains everything below: **the benchmark guest leaks its table
+entries by design.** `testdata/async/await_import.wat`'s `run` calls `waitable-set.new` on every
+invocation and its callback returns EXIT without ever calling `subtask.drop` or
+`waitable-set.drop`. Both entries stay reachable from `in.resources.entries` forever. Any scheme
+whose "definitely-done" point is a guest `drop` builtin therefore *cannot* reduce this benchmark's
+allocs/op — the objects are genuinely live. This kills naive pooling for sites 3 and 4 as a
+benchmark win and reframes them honestly (below).
+
+---
+
+## 1. Site-by-site design
+
+### Site 1 — `st.applyResolve` closure (async_host_import.go:288) → **(a) destructure to fields**
+
+**Technique: closure-destructuring, no pool.** This is the same move as the just-landed
+closure-free `pendingSub` (waitable.go:56-63): split the closure's captures into a bind-time
+config (allocated once per import, in `buildAsyncHostWrapper`'s bind-time body, *outside* the
+`api.GoModuleFunc` per-call closure) and per-call fields on the `subtask` that already exists.
+
+**Verified capture inventory** of the closure at :288-323:
+
+| captured var | bind-time or per-call | goes where |
+|---|---|---|
+| `iface`, `funcName` | bind-time | cfg |
+| `resultCount` | bind-time (buildHostResultPlan, :235) | cfg |
+| `resultType` | bind-time | cfg |
+| `resultUsesMem` | bind-time | cfg |
+| `resolve` (`abi.Resolver`, passed to `abi.Store` :318) | bind-time | cfg |
+| `resources` (`*handleTable`, for `allocHandleResult` :300) | bind-time | cfg |
+| `reallocOverride` (`api.Function`, :314) | bind-time | cfg |
+| `retPtr` (decoded from `stack[outPtrIdx]`, :284-287) | **per-call** | subtask field |
+| `memMod` (`mod` or `memOverride`, :268-271) | **per-call** | subtask field |
+| `ctx` (used by `reallocOf(ctx, memMod)` :313 / `reallocOfFunc(ctx, ...)` :315) | **per-call** | subtask field |
+| `st` | per-call | the receiver itself |
+
+**New types/fields:**
+
+```go
+// asyncResolveCfg is the bind-time half of a host-import subtask's resolve:
+// one per async-lowered import binding, built once in buildAsyncHostWrapper
+// (amortized), shared by every call through that binding. Immutable after bind.
+type asyncResolveCfg struct {
+    iface, funcName string
+    resultCount     int
+    resultType      binary.TypeDesc
+    resultUsesMem   bool
+    resolve         abi.Resolver
+    resources       *handleTable
+    reallocOverride api.Function
+}
+```
+
+On `subtask` (waitable.go), the `applyResolve func(results []abi.Value) error` **field** is
+replaced by:
+
+```go
+// resolveFn is a test-injection / future-alternate-source override for
+// applyResolve; nil in production (the resolveCfg path is used). Checked first.
+resolveFn  func(results []abi.Value) error
+resolveCfg *asyncResolveCfg // bind-time half; set per call by buildAsyncHostWrapper
+retPtr     uint32           // per-call: the trailing out-pointer, decoded at call time
+memMod     api.Module       // per-call: the CALLING module (or memOverride)
+resolveCtx context.Context  // per-call: for reallocOf at resolve time
+```
+
+**The method replacing the closure** (both call sites — `AsyncCall.Resolve` at :83 and the
+guest<->guest `onResolve` at :374 — keep the exact spelling `st.applyResolve(vals)`; it becomes a
+method call instead of a field call, a textually-invisible change at the call sites):
+
+```go
+// applyResolve replaces the per-call closure formerly assigned in
+// buildAsyncHostWrapper: lower vals into the calling module's memory through
+// the retptr captured at call time and flip state to RETURNED. Behavior is
+// byte-identical to the old closure body; mem/realloc are still fetched fresh
+// here, not at call time (memory may have grown since).
+func (st *subtask) applyResolve(vals []abi.Value) error {
+    if st.resolveFn != nil {
+        return st.resolveFn(vals)
+    }
+    cfg := st.resolveCfg
+    if cfg == nil {
+        panic("BUG: applyResolve on a subtask with no resolve source")
+    }
+    // ... the exact :289-322 body, with resultCount→cfg.resultCount,
+    // memMod→st.memMod, resources→cfg.resources, resultType→cfg.resultType,
+    // resultUsesMem→cfg.resultUsesMem, ctx→st.resolveCtx,
+    // reallocOverride→cfg.reallocOverride, retPtr→st.retPtr, resolve→cfg.resolve.
+}
+```
+
+The per-call wiring in the wrapper (replacing :284-323) becomes four scalar/pointer stores, zero
+allocations:
+
+```go
+st.resolveCfg, st.memMod, st.resolveCtx = cfg, memMod, ctx
+if outPtrIdx >= 0 {
+    st.retPtr = api.DecodeU32(stack[outPtrIdx])
+}
+```
+
+**Single-assignment-site proof.** `grep -rn "applyResolve" internal/component/instance/*.go`
+(non-test) shows exactly one assignment (async_host_import.go:288) and two calls (:83, :374). Both
+arms of the wrapper (plain host import and guest<->guest) share that one assignment — it runs
+before the arms split at :325. So a single method works; no variants exist. The three *test*
+assignments (async_host_import_test.go:304, :312, :319) become `st.resolveFn = ...` mechanically.
+
+**Correctness / -race argument.** No lifetime changes at all: the closure was reachable exactly as
+long as `st`; the fields are reachable exactly as long as `st`. `memMod`/`resolveCtx` were kept
+alive by the closure before and are kept alive by the fields now — identical GC behavior. All
+reads/writes of the new fields happen where the closure's captures were read/written: under the
+composition tree's single-runnable baton (wrapper invocation, `AsyncCall.Resolve` inside a call or
+a scheduler thunk, the guest<->guest `onResolve` inside the scheduler). Nothing is freed, nothing
+is reused; there is no use-after-free surface. `-race` sees strictly fewer heap objects and the
+same happens-before edges.
+
+**Fail-loud coverage** (per the project's coverage gate): the new `panic("BUG: ...")` branch and
+the `resolveFn`-priority branch each need one unit test.
+
+**Benchmark effect: 7 → 6 allocs/op** (and roughly −100 B/op — the closure carried ~11 captures).
+
+---
+
+### Site 2 — `ac := &AsyncCall{...}` (async_host_import.go:435) → **(c) eliminate by co-allocation into `subtask`**
+
+**Technique: embed, don't pool.** Pooling `AsyncCall` is *impossible to prove safe*: it is handed
+to arbitrary user code (`hi.asyncFn(ctx, args, ac)`, :441) which may legally retain it forever —
+`Defer` (resolve later), or simply storing it. There is **no definitely-done point**: even after
+`Resolve`, the host may keep the pointer (a second `Resolve` panics *by reading `ac.resolved`* —
+which only works if `ac` is still that call's object; a recycled+reset `ac` would silently
+corrupt an unrelated later call instead of panicking). So (b) is out. But (c) is clean: every
+`AsyncCall` is created alongside exactly one `subtask` that the `AsyncCall` already points to
+(`ac.st`), and the host retaining `ac` already keeps `st` reachable. Making the `AsyncCall` a
+*field of the subtask* merges the two allocations without changing any object's reachable
+lifetime by even one instruction:
+
+```go
+// on subtask (waitable.go):
+//   ac is the AsyncCall handed to a plain host import's AsyncHostFunc,
+//   co-allocated here so the (subtask, AsyncCall) pair costs one malloc.
+//   Unused (zero) for a guest<->guest subtask (the tgt arm returns before
+//   the AsyncCall would be built) and for test-built subtasks.
+ac AsyncCall
+```
+
+and at :435:
+
+```go
+ac := &st.ac
+ac.in, ac.st, ac.inCall = in, st, true
+```
+
+**Also fold out the redundant `subtaski` field.** `AsyncCall.subtaski` (:53) duplicates
+`subtask.si`: the only production write (:456 `ac.subtaski = subtaski`) is immediately adjacent to
+`st.setSubtaski(subtaski)` (:457) with the same value, and both start 0. Delete the field;
+`installParkedPendingEventIfNeeded` (:149-155) reads `st.subtaski()` instead:
+
+```go
+func (ac *AsyncCall) installParkedPendingEventIfNeeded() {
+    if ac.inCall {
+        return // the wrapper's epilogue sees st.resolved() and takes the immediate path
+    }
+    st := ac.st
+    st.setPendingSubtaskEvent(st, st.subtaski())
+}
+```
+
+Semantics are identical on both paths: parked (si set at :457 before any deferred Resolve can
+run — the Defer thunk runs only once the wrapper has returned and the scheduler is driven) and
+immediate (si==0, but `installParkedPendingEventIfNeeded` early-returns on `inCall` anyway;
+`ResolveCancelled`'s parked arm likewise only runs when parked ⇒ si != 0).
+
+**Correctness / -race argument.** `&st.ac` escapes ⇒ `st` escapes — but `st` escaped already
+(table entry, closure-free pendingSub, Defer thunk captures). The cycle `st.ac.st == st` is a
+plain GC cycle, handled fine. The host holding `ac` used to keep `{ac, st}` alive; now it keeps
+the single merged object alive — strictly the same reachability set. All `ac` field accesses
+happen under the baton exactly as before (in-call, or inside a scheduler thunk — enforced by the
+existing `pumping` guard at :75). Nothing about `-race` changes.
+
+**Test churn (mechanical):** the 9 `&AsyncCall{...}` literals in async_host_import_test.go keep
+working (the type and its remaining fields are unchanged; standalone construction is still fine —
+embedding does not forbid it). Only :366's `subtaski: 5` literal becomes `st.setSubtaski(5)`.
+
+**Benchmark effect: 6 → 5 allocs/op** (−48 B/op).
+
+---
+
+### Site 3 — `newSubtask()`'s `&subtask{...}` (waitable.go:309) → **(d) leave, with reasons**
+
+**The brief's sub-question first:** the `lenders: []*resourceEntry{}` literal is **already free**
+— a zero-length slice literal points at `runtime.zerobase` and mallocs nothing (confirmed by the
+profile: `newSubtask` is exactly 1 object/op, and by the reference semantics: `lenders == nil` is
+the load-bearing `resolveDelivered()` sentinel per definitions.py:895-899, so it *must not* start
+nil; happily the empty non-nil literal costs nothing, so there is nothing to change and nothing
+to gain. Do not "optimize" this to nil — it would make a fresh subtask read as delivered
+(newSubtask's own doc, waitable.go:305-308).
+
+**Why not pool the subtask itself:**
+
+1. **No definitely-done point exists for the general case.** The candidate points all fail:
+   - *`deliverResolve`*: far too early — the subtask is still in the handle table (the guest holds
+     the handle and may `subtask.cancel` it (trap path reads fields), re-poll it, or `drop` it),
+     and after Stage B the host's retained `AsyncCall` **is** this object.
+   - *`subtask.drop` (async_builtins.go:345-360)*: the guest-controlled retirement, and the table
+     side is indeed done there — but the **host** may still hold `ac` (== `&st.ac`) indefinitely;
+     nothing in the API obligates the host to drop its reference when the guest drops the handle.
+     A recycled subtask under a live host `ac` turns the one-shot `Resolve`-twice panic into
+     silent corruption of an unrelated in-flight call — exactly the use-after-free class the
+     brief warns about. `AsyncCall` would need a documented "invalid after the guest drops the
+     subtask" contract, which is unverifiable and hostile.
+2. **Even where it is safe, it pays nothing here**: the benchmark guest never calls
+   `subtask.drop` (see §0) — the object is genuinely live, so allocs/op cannot go down.
+3. After Stages 1+2 the subtask is the *one* consolidated per-import-call allocation (~200 B
+   carrying what used to be three objects). One malloc per async import call, freed by GC when
+   the guest's handle and the host's `ac` are both gone, is the right shape: correct by
+   construction, zero reset logic, zero -race surface.
+
+**Optional micro-follow-up (not staged):** an inline `lendersBuf [1]*resourceEntry` (the
+`waitableSet.elemsBuf` pattern, waitable.go:149-156) would remove the first `addLender` append
+allocation for single-borrow imports. The benchmark lends nothing; do this only if a borrow-heavy
+profile ever shows it.
+
+---
+
+### Site 4 — `&waitableSet{}` (async_builtins.go:149) → **(d) leave now; pool design recorded for later**
+
+**Why leave:** this allocation is guest-driven (`waitable-set.new`) and its only sound
+definitely-done point is guest-driven (`waitable-set.drop`). The benchmark guest **never drops**
+(§0) — it news a set per call and leaks it — so pooling cannot reduce this benchmark's allocs/op
+by even one. Real wit-bindgen executors create one set and reuse it across waits, so the per-call
+cost in realistic guests is already ~zero. Pooling here adds reset/race surface for a win that is
+unmeasurable now on every workload we have. Leave it.
+
+**If it is ever pooled** (recorded so the analysis isn't redone): the definitely-done point is
+inside `waitableSetDropHostFunc` (async_builtins.go:291-306) *after* `ws.dropSet()` succeeds and
+`in.resources.removeEntry(h)` returns. At that point, single-ownership is provable:
+`dropSet` has enforced `len(elems)==0` (⇒ no `waitable.wset` back-pointer names this set — join
+keeps the two sides consistent, waitable.go:123-131) and `numWaiting==0` (⇒ no frame is inside a
+`sched.drive`/`blk.block` whose predicate captures this set — both wait paths bracket
+`numWaiting++/--` around the suspension, async_builtins.go:231-233/244-246 and guest_task.go:443 /
+resumeReady:342; a parked `gt.wset` reference likewise implies numWaiting>0 ⇒ trap, so no parked
+task can name it), and `removeEntry` has retired the guest handle. Reset must set
+`elemsBuf[0]=nil; elems=elemsBuf[:0]; numWaiting=0` — note `elems` must be re-pointed **into the
+recycled object's own** `elemsBuf`, mirroring waitableSetNewHostFunc:150. Cross-P `sync.Pool`
+migration is fine: the object carries no references out and none in at Put time.
+
+---
+
+### Site 5 — `&callbackFrame{}` (async_lift.go:97) → **(b) sync.Pool + Reset, host-entry frames only — with honest accounting**
+
+This is the highest-frequency object (1/call on *every* async export call, the FirstLight
+remaining 1) and the only site where a pool is genuinely the right tool. Three hard constraints
+shape the design:
+
+**(i) Only `invokeAsyncCallback`'s host-entry frames are poolable.** The frames built by
+`startAsyncExportTask` (async_lift.go:214) hand out `t.requestCancellation` as the caller's
+`subtask.on_cancel` (:242) and wire `t.onResolve`/`gt.onStart` into the caller's subtask — the
+caller's subtask (host- or guest-held, arbitrary lifetime, see Site 3) keeps referencing the
+frame's `task` after EXIT. No done-point exists there. Host-entry frames have
+`onResolve == onStart == finish == nil` by construction (async_lift.go:96-102; `gt.finish` is
+never assigned anywhere in production — verified) and are never promoted (`gt.promoted` set only
+in startAsyncExportTask, :237) ⇒ `gt.seg == nil` always.
+
+**(ii) The returned result aliases the frame — it must be copied out before Put.** `task.return`
+writes `t.resultBuf[0] = val; result = t.resultBuf[:1]` (async_builtins.go:554-555/:572-573), and
+`invokeAsyncCallback` returns `t.result` (:128) straight through `invoke` → `Call` → the user.
+resultBuf's own doc (task.go:83-88) says the aliasing is safe *because a task is never reused* —
+pooling breaks exactly that premise, so before Put the result must be copied to a fresh slice.
+**Honest accounting:** for a non-empty result this converts the ~290 B frame alloc into a 16 B
+1-element slice alloc — **allocs/op unchanged, B/op −~270**; for a void async export it is a
+clean −1 alloc. This is also exactly the sync path's shape (`liftResult` returns a fresh
+`[]abi.Value{val}` per call, instance.go:1884/:1916), i.e. the pool brings async result handling
+to sync-path parity rather than below it. The *latency* value of trading one 290 B malloc for one
+16 B malloc + a pool round-trip is precisely what cannot be measured on this box — this stage's
+value (not correctness) is gated on a quiet-machine wall-clock (§3).
+
+**(iii) The definitely-done point and its gates.** Put happens at exactly one site: the tail of
+`invokeAsyncCallback`'s **full-success path** (after the `drainReady` at :124 returns nil, just
+before returning), and nowhere else — every error path (`gt.start` failure, drive error,
+`gt.err`, drainReady error) leaks the frame to the GC on purpose (cold; `reapParkedGoroutines`
+and stranded state make unreachability unprovable there). At the success point:
+
+- `gt.done` is true and gt is **not** in `sched.parked`: `done` is set only in `finishExit`/`fail`
+  and (parkEntry-cancel) `resumeReady`, each of which runs either inline (never parked) or from
+  `resumeReady` arms that `unpark` first (guest_task.go:327/348/358/366).
+- `sched.runq` is empty and no parked task is ready: that is `drainReady`'s postcondition
+  (`step` returned progressed=false ⇒ runq empty, sched.go:106-131) — no queued thunk can
+  capture the frame. (Defer thunks capture `ac`/`st`, never the frame, but emptiness closes the
+  class.)
+- `in.activeTask`/`in.exclusiveOwner` were cleared by the final `leaveRun` (task.go:327-331);
+  `in.syncBase` is never this task (it is never syncImplicit).
+- Borrow scopes: `task.return`/`task.cancel` trap unless `numBorrows == 0` (task.go:151/186), so
+  a resolved task has no live `resourceEntry.borrowScope` pointing at it.
+- **Two residual-reference gates must be checked explicitly** (both cheap field reads):
+  - `t.implicitThreadIdx == 0` — `thread.index` registers an `implicitThreadMarker{t: t}` in
+    `in.threads` (thread.go:366-369) that is **never removed** on task resolve; a frame so
+    registered must not be pooled.
+  - `t.liveThreads == 0` — a spawned guestThread's `th.t` reference outlives EXIT if the thread
+    is still parked (threads legitimately persist across invokes; thread.go:309-315 decrements
+    only when the thread itself finishes).
+
+**The code shape:**
+
+```go
+var callbackFramePool = sync.Pool{New: func() any { return &callbackFrame{} }}
+
+// in invokeAsyncCallback, replacing `fr := &callbackFrame{}` (:97):
+fr := callbackFramePool.Get().(*callbackFrame)
+t, gt := &fr.t, &fr.gt
+t.inst, t.be = in, be
+gt.t, gt.in, gt.be, gt.ctx, gt.exportName = t, in, be, ctx, exportName
+gt.args = args
+t.gt = gt
+
+// replacing `return t.result, nil` (:128):
+res := t.result
+if len(res) > 0 { // aliases fr.t.resultBuf (task.return's only write path) — detach before reuse
+    out := make([]abi.Value, len(res))
+    copy(out, res)
+    res = out
+}
+if t.implicitThreadIdx == 0 && t.liveThreads == 0 {
+    *fr = callbackFrame{} // Reset: one memclr wipes BOTH structs — see below
+    callbackFramePool.Put(fr)
+}
+return res, nil
+```
+
+**What Reset must clear — everything, so clear everything.** `*fr = callbackFrame{}` memclrs the
+whole ~290 B in one instruction-sequence and is the only reviewable Reset policy; enumerated, the
+stale state it wipes and why each matters for the *next* call: `t.state` (a recycled frame must
+start `taskInitial`, else `tryEnter`/`task.return` misbehave), `t.ctxStorage` (spec: context slots
+start zeroed — leaking slot values across calls is guest-visible), `t.result`/`t.resultBuf`
+(retains arbitrary lifted values — memory leak + aliasing hazard), `t.numBorrows`, `t.cancelled`,
+`t.onResolve`, `t.implicitThreadIdx`, `t.liveThreads`, `t.st`; `gt.park`/`gt.wset`/`gt.cancellable`/
+`gt.cancelWake` (stale park state would let `ready()` read a dead waitableSet), `gt.onStart`,
+`gt.args` (retains the previous caller's arg values), `gt.done`/`gt.err`/`gt.finish`,
+`gt.promoted`/`gt.seg`, `gt.ctx`/`gt.exportName`/`gt.be`/`gt.in`/`gt.t`. The Get site re-links
+`t.gt = gt` and re-fills the live fields.
+
+**-race / cross-P argument.** Every access to the frame between Get and Put happens while the
+accessing goroutine holds the composition tree's baton (single-runnable invariant: the invoke
+caller's goroutine through `gt.start`/`drive`/`drainReady`, or the scheduler-driven resumes on
+that same goroutine). Get and Put both execute on the invoke caller's goroutine, with Put
+sequenced after every frame access of that call (drive/drainReady have returned; the result was
+copied out). `sync.Pool` itself is race-instrumented (its Put→Get pair establishes the
+happens-before edge the recycled memory needs), and cross-P migration hands the frame to a
+goroutine that, by the gates above, is the *only* holder. Two different composition trees on two
+goroutines exchanging frames through the pool is therefore indistinguishable from a fresh malloc
+under -race and under the memory model.
+
+**Mandatory verification for this stage** (correctness provable now, all load-independent):
+`TestAsyncWastConformance` 31/31, `TestAsyncOracle`, the full package under `-race`, **plus a new
+stress test**: N goroutines × M instances each looping `Call("run-async")` on both fixtures
+(await + first-light) under `-race -count=5`, with a goroutine-count check after Close (the
+package's existing reap tests' pattern) to catch leaked segments; and one test each pinning the
+two gates (a guest that calls `thread.index` / spawns a thread must NOT recycle — observable via
+a package-internal counter or by asserting `implicitThreadIdx != 0` behavior stays correct across
+two calls). **Wall-clock value check on a quiet machine required before trusting the ns/op win**
+(B/op improvement is verifiable now: AwaitImport ~600→~330 B/op, FirstLight 330→~16 B/op).
+
+---
+
+### Site 6 — `subtask.onCancel` closures → **(a) destructure to two typed fields**
+
+**Verified assignment sites (exactly two in production):**
+
+1. `AsyncCall.OnCancel` (async_host_import.go:103): `ac.st.onCancel = func() error { fn(); return nil }`
+   — a per-call wrapper closure whose only job is adding an `error` return to the user's `func()`.
+2. The guest<->guest arm (:388): `st.onCancel = onCancel` where `onCancel` is
+   `t.requestCancellation` returned by `startAsyncExportTask` (:242) / `startStackfulExportTask`
+   (:277) — a **method-value allocation** on every guest<->guest async lower.
+
+Consumer: `subtaskCancelHostFuncGraph` only (async_builtins.go:428/:448).
+
+**Replace the `onCancel func() error` field with:**
+
+```go
+// onCancelHook: AsyncCall.OnCancel's user fn, stored directly (no error-adapting
+// wrapper closure). Mutually exclusive with cancelTask.
+onCancelHook func()
+// cancelTask: the guest<->guest callee's task; runOnCancel calls its
+// requestCancellation directly (no method-value closure).
+cancelTask *task
+```
+
+with methods:
+
+```go
+// hasOnCancel replaces the `st.onCancel != nil` gate (async_builtins.go:428).
+func (st *subtask) hasOnCancel() bool { return st.cancelTask != nil || st.onCancelHook != nil }
+
+// runOnCancel is Subtask.on_cancel's invocation (canon_subtask_cancel ~2470):
+// runs synchronously on the driving goroutine under the sched.pumping bracket
+// its caller already holds.
+func (st *subtask) runOnCancel() error {
+    if st.cancelTask != nil {
+        return st.cancelTask.requestCancellation()
+    }
+    st.onCancelHook()
+    return nil
+}
+```
+
+**Signature change:** `startAsyncExportTask` and `startStackfulExportTask` return
+`(calleeTask *task, err error)` instead of `(onCancel func() error, err error)`; :388 becomes
+`st.cancelTask = calleeTask`. Ripple is small and mechanical: graph.go:1040 and
+startDelegatedFromBlocker (graph.go:1037-1040 area) already discard the value; tests
+stackful_task_test.go:80/:184/:202 and async_cancel_test.go:166/:179 change `onCancel()` to
+`calleeTask.requestCancellation()`; guest_guest_async_test.go:255's injected
+`st.onCancel = func() error {...}` (whose body returns nil anyway) becomes
+`st.onCancelHook = func() {...}`; async_host_import_test.go:327-338 asserts via
+`hasOnCancel()`/`runOnCancel()`.
+
+**Correctness argument.** The dispatch is decided by which field is set, and exactly one ever is:
+`OnCancel`'s doc requires it be called before the AsyncHostFunc returns (plain-host arm only);
+`cancelTask` is set only in the tgt arm — the arms are exclusive (:325 vs :422). Guard order in
+`subtaskCancelHostFuncGraph` is untouched (`resolved()` checked before `hasOnCancel()`, :426-428),
+so `requestCancellation`'s `panic("BUG: ... resolved task")` (task.go:289) remains unreachable
+exactly as the reference's guard makes it. The `sched.pumping` bracket around the invocation
+(:447-449) is unchanged — the documented synchronous-`Resolve`-from-OnCancel shape keeps working.
+No lifetimes change: the closure held {fn} or {t}; the fields hold fn or t. Nothing is freed or
+reused. `-race`: same accesses, same baton, fewer objects.
+
+**Benchmark effect: none** (0 occurrences on this path — see §0). Real effect: −1 alloc per
+`OnCancel`-registering host import call, −1 per guest<->guest async lower (the method value),
+verifiable by allocs/op on `TestGuestGuestAsyncLower*`-shaped micro-benchmarks if we ever add one.
+
+---
+
+## 2. Floor analysis: where this lands
+
+| after stage | AwaitImport allocs/op | composition |
+|---|---|---|
+| baseline | 7 | closure + AsyncCall + subtask + wset + frame + 2 user |
+| S1 (applyResolve) | 6 | AsyncCall + subtask + wset + frame + 2 user |
+| S2 (AsyncCall embed) | 5 | subtask(+ac) + wset + frame + 2 user |
+| S3 (onCancel) | 5 | unchanged here (wins elsewhere) |
+| S4 (frame pool) | 5 | subtask(+ac) + wset + **result-copy** + 2 user (B/op −~270; FirstLight B/op 330→~16) |
+
+The remaining 5 are each individually accounted for: **subtask+ac** — the one legitimate
+per-import-call object (host- and guest-referenced, §1.3); **waitableSet** — guest-leaked by this
+fixture, ~free in real guests (§1.4); **result copy** — sync-path parity, the price of a safe
+frame pool (§1.5.ii); **2 user allocs** — the benchmark host fn's own `Defer` closure and results
+slice, untouchable without the Appendix A API. A void-result async export with a well-behaved
+guest (drops its handles, reuses its set) lands at **1 runtime alloc/op** (the subtask).
+
+---
+
+## 3. Staged landing order
+
+Safest-and-most-verifiable-now first; pooling last. Every stage independently keeps
+`TestAsyncWastConformance` 31/31, `TestAsyncOracle`, and the full package `-race` green, and each
+is a Sonnet-sized diff touching a small, named file set. Standard per-stage verification recipe
+(all load-independent — run from repo root, never `-short`):
+
+```
+go test ./internal/component/instance/ -run 'TestAsyncWastConformance|TestAsyncOracle' -count=1
+go test -race ./internal/component/instance/ -count=1
+go test ./internal/component/instance/ -run '^$' -bench 'BenchmarkCallAsync' -benchtime 2000x -benchmem
+go vet ./internal/component/instance/
+```
+
+**Stage 1 — applyResolve destructure (§1.1).** Files: async_host_import.go (cfg type + method
+wiring), waitable.go (field swap + method), async_host_import_test.go (3 lines → `resolveFn`, +2
+new fail-loud tests). Acceptance: AwaitImport **7 → 6 allocs/op** exactly; no other benchmark
+moves by more than noise in B/op. Value: proven by allocs/op alone — no wall-clock needed.
+Touches sched/park core: **no**.
+
+**Stage 2 — AsyncCall co-allocation + subtaski removal (§1.2).** Files: async_host_import.go
+(:435-456 rewiring, `installParkedPendingEventIfNeeded`), waitable.go (embed field),
+async_host_import_test.go (:366 only). Acceptance: **6 → 5 allocs/op**. Value: allocs/op alone.
+Touches sched/park core: **no**.
+
+**Stage 3 — onCancel destructure (§1.6).** Files: waitable.go, async_host_import.go (:103, :388),
+async_lift.go (two signatures), graph.go (:1040 spelling), async_builtins.go (:428/:448 →
+`hasOnCancel`/`runOnCancel`), 4 test files mechanically. Acceptance: benchmark unchanged (5);
+the full cancel suite (`TestAsyncOracle` cancel scenarios, async_cancel_test.go,
+guest_guest_async_test.go, stackful_task_test.go, wast conformance's cancel suites) is the real
+gate. Value: correctness-neutral refactor with off-benchmark alloc wins; no wall-clock needed.
+Touches sched/park core: **no** (it calls `requestCancellation` exactly as the method value did).
+Landed third because its blast radius is Phase-3 cancellation, the subtlest semantics in the
+package — after 1-2 have proven the field-destructuring pattern on this same struct.
+
+**Stage 4 — callbackFrame pool (§1.5).** Files: async_lift.go (Get/copy-out/gates/Put),
+plus the new stress + gate tests. Acceptance: allocs/op **stays 5** (this is expected — say so in
+the commit message), AwaitImport B/op drops ~270, FirstLight goes 330 B → ~16 B/op; `-race`
+stress green, goroutine-leak check green. **VALUE GATE: flag the ns/op claim as unverified until
+a quiet-machine wall-clock run** (load < ~2, `uptime` + `ps` checked per the benchmark-load
+discipline) — if the quiet-machine run shows the pool round-trip + copy costing more than the
+saved malloc, this stage is a one-file revert that loses nothing else. Touches sched/park core:
+**no code changes to sched.go**, but its correctness *argument* leans on sched invariants
+(done ⇒ unparked; drainReady ⇒ empty runq) — those two invariants are restated as comments at
+the Put site so a future sched change trips over them deliberately.
+
+**Not staged (documented leaves):** Site 3 (subtask — §1.3) and Site 4 (waitableSet — §1.4).
+Revisit only with a workload where guests actually drop (site 4's pool design above is then
+ready) or a borrow-heavy profile (site 3's lendersBuf).
+
+---
+
+## 4. Appendix A — the last two allocs (user code; optional future API, out of scope)
+
+The benchmark host fn pays `call.Defer(func(){ call.Resolve(vals) })` = 1 closure + 1 slice. A
+`func (ac *AsyncCall) DeferResolve(results ...abi.Value)` that enqueues a dedicated
+`schedThunk` arm `{ac *AsyncCall; vals []abi.Value}` (sched.go's schedThunk already takes the
+"plain fields, no wrapper closure" approach — :57-76) would remove the closure (the variadic
+slice remains, at the call site). Net −1 for converted hosts. This changes public API and would
+also tempt rewriting the benchmark — which must NOT be done to flatter the numbers; if added,
+benchmark both spellings side by side. Not part of this design's stages.
+
+## 5. Appendix B — invariants this design must not outlive
+
+- **Single-runnable baton**: one goroutine executes component-runtime code per composition tree
+  at any instant; every design argument above ("all accesses under the baton") cites it. If
+  CallAsync's truly-external completion ever lands, Stage 4's Put-site argument must be re-proven
+  (external completion could enqueue against a tree whose invoke has NOT returned — fine — but
+  any future path that lets a frame's task be referenced after `drainReady` returns nil breaks
+  the gate analysis).
+- **task.return traps on numBorrows>0** (task.go:151): load-bearing for Stage 4's "no borrowScope
+  references a resolved task".
+- **`lenders == nil` is `resolveDelivered`** (waitable.go:341): load-bearing for Site 3's
+  "never start lenders nil".
+- **`gt.finish` is production-unassigned**: if a future feature assigns it on host-entry frames,
+  Stage 4's shape gate must add `gt.finish == nil` (cheap; add it preemptively in the
+  implementation).

--- a/internal/component/instance/async_builtins.go
+++ b/internal/component/instance/async_builtins.go
@@ -425,9 +425,9 @@ func subtaskCancelHostFuncGraph(in *Instance, canon binary.Canon) hostFuncDef {
 
 		if !st.resolved() {
 			st.cancellationRequested = true
-			if st.onCancel != nil { // nil only for a host import with no OnCancel hook (§2.4)
+			if st.hasOnCancel() { // false only for a host import with no OnCancel hook (§2.4)
 				// Bracket with sched.pumping exactly like sched.step's own
-				// thunk/resumeReady dispatch (sched.go): st.onCancel runs
+				// thunk/resumeReady dispatch (sched.go): st.runOnCancel runs
 				// synchronously HERE, on the one driving goroutine, not from
 				// inside a queued runq thunk -- but AsyncCall.OnCancel's doc
 				// explicitly promises the callee may call
@@ -445,7 +445,7 @@ func subtaskCancelHostFuncGraph(in *Instance, canon binary.Canon) hostFuncDef {
 				// driving goroutine, synchronously, exactly where sched.step
 				// itself would be.
 				in.sched.pumping = true
-				cerr := st.onCancel()
+				cerr := st.runOnCancel()
 				in.sched.pumping = false
 				if cerr != nil {
 					panic(fmt.Errorf("component/instance: subtask.cancel: %w", cerr))

--- a/internal/component/instance/async_builtins.go
+++ b/internal/component/instance/async_builtins.go
@@ -551,7 +551,8 @@ func taskReturnHostFuncGraph(in *Instance, canon binary.Canon) (hostFuncDef, err
 				if err != nil {
 					panic(fmt.Errorf("component/instance: task.return: load spilled result: %w", err))
 				}
-				result = []abi.Value{val}
+				t.resultBuf[0] = val
+				result = t.resultBuf[:1]
 			} else {
 				// Pooled (getCoreValueSlice/putCoreValueSlice, instance.go):
 				// coreVals is pure scratch, fully consumed synchronously by
@@ -568,7 +569,8 @@ func taskReturnHostFuncGraph(in *Instance, canon binary.Canon) (hostFuncDef, err
 				if err != nil {
 					panic(fmt.Errorf("component/instance: task.return: lift result: %w", err))
 				}
-				result = []abi.Value{val}
+				t.resultBuf[0] = val
+				result = t.resultBuf[:1]
 			}
 		}
 

--- a/internal/component/instance/async_cancel_test.go
+++ b/internal/component/instance/async_cancel_test.go
@@ -163,7 +163,7 @@ func TestRequestCancellation_StartedInlineResume(t *testing.T) {
 
 	var resolvedVals []abi.Value
 	var resolvedCancelled bool
-	onCancel, err := b.startAsyncExportTask(ctx, be, "run-async",
+	calleeTask, err := b.startAsyncExportTask(ctx, be, "run-async",
 		func(*task) ([]abi.Value, error) { return nil, nil },
 		func(vals []abi.Value, cancelled bool) error {
 			resolvedVals, resolvedCancelled = vals, cancelled
@@ -176,8 +176,8 @@ func TestRequestCancellation_StartedInlineResume(t *testing.T) {
 		t.Fatal("task resolved before any cancel was requested")
 	}
 
-	if err := onCancel(); err != nil {
-		t.Fatalf("onCancel (requestCancellation): %v", err)
+	if err := calleeTask.requestCancellation(); err != nil {
+		t.Fatalf("requestCancellation: %v", err)
 	}
 	if !resolvedCancelled || resolvedVals != nil {
 		t.Fatalf("onResolve(vals=%v, cancelled=%v), want (nil, true)", resolvedVals, resolvedCancelled)
@@ -300,7 +300,7 @@ func TestSubtaskCancelHostFunc_AsyncBlocked(t *testing.T) {
 	st := newSubtask()
 	st.state = subtaskStarted
 	onCancelCalled := false
-	st.onCancel = func() error { onCancelCalled = true; return nil } // callee ignores the request, stays unresolved
+	st.onCancelHook = func() { onCancelCalled = true } // callee ignores the request, stays unresolved
 	h := in.resources.addEntry(st)
 	def := subtaskCancelHostFuncGraph(in, binary.Canon{Async: true})
 	stack := []uint64{uint64(h)}
@@ -322,13 +322,12 @@ func TestSubtaskCancelHostFunc_AsyncResolvesImmediately(t *testing.T) {
 	st.state = subtaskStarted
 	h := in.resources.addEntry(st)
 	st.setSubtaski(h)
-	st.onCancel = func() error {
+	st.onCancelHook = func() {
 		// A real onCancel (host import ResolveCancelled, or the guest<->
 		// guest callee arm's onResolve) always installs the pending event
 		// once resolved -- see installSubtaskEvent's callers.
 		st.resolve(subtaskCancelledBeforeReturned, nil)
 		installSubtaskEvent(st, st.subtaski())
-		return nil
 	}
 	def := subtaskCancelHostFuncGraph(in, binary.Canon{Async: true})
 	stack := []uint64{uint64(h)}
@@ -362,7 +361,7 @@ func TestSubtaskCancelHostFunc_SyncBlocksThenResolves(t *testing.T) {
 	st.state = subtaskStarted
 	h := in.resources.addEntry(st)
 	st.setSubtaski(h)
-	st.onCancel = func() error {
+	st.onCancelHook = func() {
 		// Defer the resolution onto the scheduler -- the sync cancel's
 		// drive(st.hasPendingEvent) must pump it.
 		in.sched.enqueue(func() error {
@@ -370,7 +369,6 @@ func TestSubtaskCancelHostFunc_SyncBlocksThenResolves(t *testing.T) {
 			installSubtaskEvent(st, st.subtaski())
 			return nil
 		})
-		return nil
 	}
 	def := subtaskCancelHostFuncGraph(in, binary.Canon{Async: false})
 	stack := []uint64{uint64(h)}
@@ -384,7 +382,7 @@ func TestSubtaskCancelHostFunc_SyncDeadlockTraps(t *testing.T) {
 	in := newCancelTestInstance()
 	st := newSubtask()
 	st.state = subtaskStarted
-	st.onCancel = func() error { return nil } // never resolves, nothing queued
+	st.onCancelHook = func() {} // never resolves, nothing queued
 	h := in.resources.addEntry(st)
 	def := subtaskCancelHostFuncGraph(in, binary.Canon{Async: false})
 	requirePanicContains(t, "deadlock", func() {

--- a/internal/component/instance/async_host_import.go
+++ b/internal/component/instance/async_host_import.go
@@ -135,12 +135,7 @@ func (ac *AsyncCall) ResolveCancelled() {
 // evaluated at DELIVERY (Waitable.getPendingEvent), matching
 // installParkedPendingEventIfNeeded and the reference exactly.
 func installSubtaskEvent(st *subtask, si uint32) {
-	st.setPendingEvent(func() eventTuple {
-		if st.resolved() && !st.resolveDelivered() {
-			st.deliverResolve()
-		}
-		return eventTuple{code: eventSubtask, p1: si, p2: uint32(st.state)}
-	})
+	st.setPendingSubtaskEvent(st, si) // closure-free; body lives in getPendingEvent
 }
 
 // installParkedPendingEventIfNeeded is Resolve/ResolveCancelled's shared
@@ -156,12 +151,7 @@ func (ac *AsyncCall) installParkedPendingEventIfNeeded() {
 		return // the wrapper's epilogue sees st.resolved() and takes the immediate path
 	}
 	st, si := ac.st, ac.subtaski
-	st.setPendingEvent(func() eventTuple {
-		if st.resolved() && !st.resolveDelivered() {
-			st.deliverResolve()
-		}
-		return eventTuple{code: eventSubtask, p1: si, p2: uint32(st.state)}
-	})
+	st.setPendingSubtaskEvent(st, si) // closure-free; body lives in getPendingEvent
 }
 
 // Defer enqueues fn on the instance's deterministic FIFO run queue

--- a/internal/component/instance/async_host_import.go
+++ b/internal/component/instance/async_host_import.go
@@ -50,8 +50,7 @@ const maxFlatAsyncParams = 4
 type AsyncCall struct {
 	in       *Instance
 	st       *subtask
-	subtaski uint32 // set once the subtask is parked in the table; 0 until then (0 is never a valid handle)
-	inCall   bool   // true while the AsyncHostFunc invocation is on the stack
+	inCall   bool // true while the AsyncHostFunc invocation is on the stack
 	resolved bool
 }
 
@@ -100,7 +99,7 @@ func (ac *AsyncCall) Resolve(results []abi.Value) {
 // spec-legal (a callee may ignore cancellation; the subtask still resolves
 // whenever the import eventually completes normally via Resolve).
 func (ac *AsyncCall) OnCancel(fn func()) {
-	ac.st.onCancel = func() error { fn(); return nil }
+	ac.st.onCancelHook = fn
 }
 
 // ResolveCancelled resolves the call as cancelled (reference on_resolve
@@ -150,8 +149,8 @@ func (ac *AsyncCall) installParkedPendingEventIfNeeded() {
 	if ac.inCall {
 		return // the wrapper's epilogue sees st.resolved() and takes the immediate path
 	}
-	st, si := ac.st, ac.subtaski
-	st.setPendingSubtaskEvent(st, si) // closure-free; body lives in getPendingEvent
+	st := ac.st
+	st.setPendingSubtaskEvent(st, st.subtaski()) // closure-free; body lives in getPendingEvent
 }
 
 // Defer enqueues fn on the instance's deterministic FIFO run queue
@@ -165,6 +164,73 @@ func (ac *AsyncCall) installParkedPendingEventIfNeeded() {
 // completion costs exactly fn's own allocation (if any), not two.
 func (ac *AsyncCall) Defer(fn func()) {
 	ac.in.sched.enqueueVoid(fn)
+}
+
+// asyncResolveCfg is the bind-time half of a host-import subtask's resolve:
+// one per async-lowered import binding, built once in buildAsyncHostWrapper
+// (amortized), shared by every call through that binding. Immutable after
+// bind. Replaces the per-call `st.applyResolve = func(...) {...}` closure
+// (which captured all of these plus the per-call retPtr/memMod/ctx) with a
+// single shared allocation plus scalar/pointer stores on the subtask (see
+// subtask.applyResolve, waitable.go).
+type asyncResolveCfg struct {
+	iface, funcName string
+	resultCount     int
+	resultType      binary.TypeDesc
+	resultUsesMem   bool
+	resolve         abi.Resolver
+	resources       *handleTable
+	reallocOverride api.Function
+}
+
+// applyResolve replaces the per-call closure formerly assigned in
+// buildAsyncHostWrapper: lower vals into the calling module's memory through
+// the retptr captured at call time and flip state to RETURNED. Behavior is
+// byte-identical to the old closure body; mem/realloc are still fetched
+// fresh here, not at call time (memory may have grown since). resolveFn, if
+// set (test injection / future alternate source), takes priority.
+func (st *subtask) applyResolve(vals []abi.Value) error {
+	if st.resolveFn != nil {
+		return st.resolveFn(vals)
+	}
+	cfg := st.resolveCfg
+	if cfg == nil {
+		panic("BUG: applyResolve on a subtask with no resolve source")
+	}
+	if len(vals) != cfg.resultCount {
+		return fmt.Errorf("async import %q %q: Resolve got %d result(s), the import declares %d", cfg.iface, cfg.funcName, len(vals), cfg.resultCount)
+	}
+	if cfg.resultCount == 0 {
+		st.resolve(subtaskReturned, nil)
+		return nil
+	}
+	mem, memAvailable := memoryBytesOf(st.memMod)
+	if cfg.resultUsesMem && !memAvailable {
+		return fmt.Errorf("async import %q %q: result requires linear memory (string/list), but the calling module has none", cfg.iface, cfg.funcName)
+	}
+	resultVal, herr := allocHandleResult(cfg.resources, cfg.resultType, vals[0])
+	if herr != nil {
+		return fmt.Errorf("async import %q %q: result: %w", cfg.iface, cfg.funcName, herr)
+	}
+	// Resolving "cabi_realloc" (a module export lookup, allocating on both
+	// the found and not-found paths -- ModuleInstance.getExport) is only
+	// useful when Store might actually grow guest memory for this result (a
+	// string/list); a plain-value result (e.g. u32) never calls
+	// realloc.grow, so skip the lookup entirely then -- resultUsesMem is
+	// precomputed at bind time, so this is a cheap branch, not a
+	// re-derivation.
+	var realloc abi.Realloc
+	if cfg.resultUsesMem {
+		realloc = reallocOf(st.resolveCtx, st.memMod)
+		if cfg.reallocOverride != nil {
+			realloc = reallocOfFunc(st.resolveCtx, cfg.reallocOverride)
+		}
+	}
+	if serr := abi.Store(mem, st.retPtr, cfg.resultType, resultVal, cfg.resolve, realloc); serr != nil {
+		return fmt.Errorf("async import %q %q: result: store: %w", cfg.iface, cfg.funcName, serr)
+	}
+	st.resolve(subtaskReturned, nil)
+	return nil
 }
 
 // AsyncHostFunc starts one async import call (reference: the FuncInst callee
@@ -261,6 +327,15 @@ func buildAsyncHostWrapper(in *Instance, iface, funcName string, hi *hostImport,
 	}
 	apiResults := []api.ValueType{api.ValueTypeI32} // always exactly the packed Subtask.State
 
+	// cfg is the bind-time half of every call's applyResolve, built ONCE
+	// here (not per call) and shared by every invocation of this binding --
+	// see asyncResolveCfg's doc and subtask.applyResolve (this file).
+	cfg := &asyncResolveCfg{
+		iface: iface, funcName: funcName,
+		resultCount: resultCount, resultType: resultType, resultUsesMem: resultUsesMem,
+		resolve: resolve, resources: resources, reallocOverride: reallocOverride,
+	}
+
 	fn := api.GoModuleFunc(func(ctx context.Context, mod api.Module, stack []uint64) {
 		if hi.lineage {
 			panic(fmt.Errorf("component/instance: async lower %q %q: wasm trap: cannot enter component instance", iface, funcName))
@@ -272,54 +347,16 @@ func buildAsyncHostWrapper(in *Instance, iface, funcName string, hi *hostImport,
 
 		st := newSubtask()
 
-		// applyResolve is shared by both arms below: given RESULT VALUES
-		// already reduced to the IMPORTER's own representation (a bare rep
-		// for an own/borrow result -- exactly what a Go AsyncHostFunc's
-		// Resolve receives directly, and what the guest<->guest callee arm's
-		// onResolve produces via mapResultsFromProvider), lower them into
-		// the calling module's memory through retPtr and flip state to
-		// RETURNED. Fetched fresh (mem/realloc), not captured at call time:
-		// memory may have grown between the call and this resolve (possibly
+		// Per-call wiring for st.applyResolve (the method, waitable.go/this
+		// file): cfg is the bind-time half (built once above); retPtr/memMod
+		// are captured now (retPtr decoded from the core stack, memMod may be
+		// mem/memOverride); resolveCtx is used for reallocOf at resolve time,
+		// fetched fresh there (not captured at call time) since memory may
+		// have grown between the call and the eventual resolve (possibly
 		// much later, after a Defer round-trip or a parked guestTask).
-		var retPtr uint32
+		st.resolveCfg, st.memMod, st.resolveCtx = cfg, memMod, ctx
 		if outPtrIdx >= 0 {
-			retPtr = api.DecodeU32(stack[outPtrIdx])
-		}
-		st.applyResolve = func(vals []abi.Value) error {
-			if len(vals) != resultCount {
-				return fmt.Errorf("async import %q %q: Resolve got %d result(s), the import declares %d", iface, funcName, len(vals), resultCount)
-			}
-			if resultCount == 0 {
-				st.resolve(subtaskReturned, nil)
-				return nil
-			}
-			mem, memAvailable := memoryBytesOf(memMod)
-			if resultUsesMem && !memAvailable {
-				return fmt.Errorf("async import %q %q: result requires linear memory (string/list), but the calling module has none", iface, funcName)
-			}
-			resultVal, herr := allocHandleResult(resources, resultType, vals[0])
-			if herr != nil {
-				return fmt.Errorf("async import %q %q: result: %w", iface, funcName, herr)
-			}
-			// Resolving "cabi_realloc" (a module export lookup, allocating on
-			// both the found and not-found paths -- ModuleInstance.getExport)
-			// is only useful when Store might actually grow guest memory for
-			// this result (a string/list); a plain-value result (e.g. u32)
-			// never calls realloc.grow, so skip the lookup entirely then --
-			// resultUsesMem is precomputed at bind time (this func's caller),
-			// so this is a cheap branch, not a re-derivation.
-			var realloc abi.Realloc
-			if resultUsesMem {
-				realloc = reallocOf(ctx, memMod)
-				if reallocOverride != nil {
-					realloc = reallocOfFunc(ctx, reallocOverride)
-				}
-			}
-			if serr := abi.Store(mem, retPtr, resultType, resultVal, resolve, realloc); serr != nil {
-				return fmt.Errorf("async import %q %q: result: store: %w", iface, funcName, serr)
-			}
-			st.resolve(subtaskReturned, nil)
-			return nil
+			st.retPtr = api.DecodeU32(stack[outPtrIdx])
 		}
 
 		if tgt := hi.asyncTarget; tgt != nil {
@@ -381,11 +418,11 @@ func buildAsyncHostWrapper(in *Instance, iface, funcName string, hi *hostImport,
 				return nil
 			}
 
-			onCancel, operr := tgt.sub.startAsyncExportTask(ctx, tgt.be, tgt.exportName, onStart, onResolve)
+			calleeTask, operr := tgt.sub.startAsyncExportTask(ctx, tgt.be, tgt.exportName, onStart, onResolve)
 			if operr != nil {
 				panic(fmt.Errorf("component/instance: async lower %q %q: %w", iface, funcName, operr))
 			}
-			st.onCancel = onCancel // reference: subtask.on_cancel = callee(...) (~2270)
+			st.cancelTask = calleeTask // reference: subtask.on_cancel = callee(...) (~2270)
 
 			// If the CALLER is a plain sync lift (invokeEntered: activeTask nil
 			// or a syncImplicit task) there is no scheduler driver above this
@@ -432,7 +469,8 @@ func buildAsyncHostWrapper(in *Instance, iface, funcName string, hi *hostImport,
 		}
 		st.state = subtaskStarted // on_start complete (args lifted)
 
-		ac := &AsyncCall{in: in, st: st, inCall: true}
+		ac := &st.ac
+		ac.in, ac.st, ac.inCall = in, st, true
 		// Bracket the actual Go call -- see buildHostWrapper's identical
 		// comment (host_import.go): this is what lets a Write/Read/Set/Get
 		// called synchronously from inside an AsyncHostFunc invocation pass
@@ -453,7 +491,6 @@ func buildAsyncHostWrapper(in *Instance, iface, funcName string, hi *hostImport,
 			return
 		}
 		subtaski := resources.addEntry(st)
-		ac.subtaski = subtaski
 		st.setSubtaski(subtaski)
 		stack[0] = uint64(uint32(st.state)) | uint64(subtaski)<<4
 	})

--- a/internal/component/instance/async_host_import_test.go
+++ b/internal/component/instance/async_host_import_test.go
@@ -301,7 +301,7 @@ func ptrU32(v uint32) *uint32 { return &v }
 
 func TestAsyncCall_Resolve_TwiceTraps(t *testing.T) {
 	st := newSubtask()
-	st.applyResolve = func([]abi.Value) error { return nil }
+	st.resolveFn = func([]abi.Value) error { return nil }
 	ac := &AsyncCall{in: &Instance{sched: &sched{}}, st: st, inCall: true}
 	ac.Resolve(nil)
 	requirePanicContains(t, "Resolve called twice", func() { ac.Resolve(nil) })
@@ -309,16 +309,55 @@ func TestAsyncCall_Resolve_TwiceTraps(t *testing.T) {
 
 func TestAsyncCall_Resolve_OutsideSchedulerTraps(t *testing.T) {
 	st := newSubtask()
-	st.applyResolve = func([]abi.Value) error { return nil }
+	st.resolveFn = func([]abi.Value) error { return nil }
 	ac := &AsyncCall{in: &Instance{sched: &sched{}}, st: st} // inCall=false, sched.pumping=false
 	requirePanicContains(t, "external completion requires CallAsync", func() { ac.Resolve(nil) })
 }
 
 func TestAsyncCall_Resolve_ApplyResolveErrorTraps(t *testing.T) {
 	st := newSubtask()
-	st.applyResolve = func([]abi.Value) error { return errors.New("bad result") }
+	st.resolveFn = func([]abi.Value) error { return errors.New("bad result") }
 	ac := &AsyncCall{in: &Instance{sched: &sched{}}, st: st, inCall: true}
 	requirePanicContains(t, "bad result", func() { ac.Resolve(nil) })
+}
+
+// ------- subtask.applyResolve: resolveFn priority / no-source panic -------
+
+// TestSubtask_ApplyResolve_ResolveFnTakesPriorityOverCfg pins the priority
+// order the method documents: resolveFn (a test injection / future
+// alternate source) is checked BEFORE resolveCfg, even when both are set --
+// a production subtask never has both, but the dispatch order itself is the
+// contract under test here.
+func TestSubtask_ApplyResolve_ResolveFnTakesPriorityOverCfg(t *testing.T) {
+	st := newSubtask()
+	st.resolveCfg = &asyncResolveCfg{resultCount: 0}
+	called := false
+	st.resolveFn = func([]abi.Value) error { called = true; return nil }
+	if err := st.applyResolve(nil); err != nil {
+		t.Fatalf("applyResolve: %v", err)
+	}
+	if !called {
+		t.Fatal("resolveFn was not invoked even though it was set")
+	}
+}
+
+// TestSubtask_ApplyResolve_NoSourcePanics pins the BUG guard: a subtask
+// built without newSubtask's production wiring (buildAsyncHostWrapper never
+// ran) has neither resolveFn nor resolveCfg set, and applyResolve must fail
+// loud rather than nil-deref or silently no-op.
+func TestSubtask_ApplyResolve_NoSourcePanics(t *testing.T) {
+	st := newSubtask()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected a panic, got none")
+		}
+		msg, ok := r.(string)
+		if !ok || msg != "BUG: applyResolve on a subtask with no resolve source" {
+			t.Fatalf("panic = %#v, want the BUG string", r)
+		}
+	}()
+	_ = st.applyResolve(nil)
 }
 
 // ------- AsyncCall.OnCancel / ResolveCancelled -------
@@ -328,11 +367,11 @@ func TestAsyncCall_OnCancel_SetsSubtaskOnCancel(t *testing.T) {
 	ac := &AsyncCall{in: &Instance{sched: &sched{}}, st: st}
 	called := false
 	ac.OnCancel(func() { called = true })
-	if st.onCancel == nil {
-		t.Fatal("OnCancel did not set st.onCancel")
+	if !st.hasOnCancel() {
+		t.Fatal("OnCancel did not set st.onCancelHook")
 	}
-	if err := st.onCancel(); err != nil {
-		t.Fatalf("st.onCancel(): %v", err)
+	if err := st.runOnCancel(); err != nil {
+		t.Fatalf("st.runOnCancel(): %v", err)
 	}
 	if !called {
 		t.Fatal("the registered fn was not invoked")
@@ -363,7 +402,8 @@ func TestAsyncCall_ResolveCancelled_Immediate(t *testing.T) {
 func TestAsyncCall_ResolveCancelled_Parked(t *testing.T) {
 	st := newSubtask()
 	st.cancellationRequested = true
-	ac := &AsyncCall{in: &Instance{sched: &sched{}}, st: st, subtaski: 5}
+	st.setSubtaski(5)
+	ac := &AsyncCall{in: &Instance{sched: &sched{}}, st: st}
 	ac.in.sched.pumping = true // "called from a scheduler thunk"
 	ac.ResolveCancelled()
 	if !st.hasPendingEvent() {

--- a/internal/component/instance/async_lift.go
+++ b/internal/component/instance/async_lift.go
@@ -19,6 +19,19 @@ const (
 	callbackMax   callbackCode = 2
 )
 
+// callbackFrame co-allocates a task and its guestTask in one heap object:
+// every callback-lift construction site (invokeAsyncCallback,
+// startAsyncExportTask) always builds exactly one task+guestTask pair, so
+// giving them separate `&task{}`/`&guestTask{}` allocations doubles the
+// per-call malloc count for no reason -- t and gt remain independently
+// addressable (*task/*guestTask are threaded all over this package) and
+// their pointers stay stable for the frame's lifetime; co-allocation only
+// means one malloc backs both, freed together once both become unreachable.
+type callbackFrame struct {
+	t  task
+	gt guestTask
+}
+
 // unpackCallbackResult is the reference's unpack_callback_result: code is
 // the packed value's low nibble (trap_if(code > MAX)); the waitable-set
 // index is the rest, shifted down. The reference also asserts
@@ -81,11 +94,11 @@ func (in *Instance) invokeAsyncCallback(ctx context.Context, be *boundExport, ex
 	// host-entry call runs (no lazy-lift indirection needed), so the
 	// trivial forwarding closures Phase 1/2 built here would only exist to
 	// adapt a shape this call never actually needs.
-	t := &task{inst: in, be: be}
-	gt := &guestTask{
-		t: t, in: in, be: be, ctx: ctx, exportName: exportName,
-		args: args,
-	}
+	fr := &callbackFrame{}
+	t, gt := &fr.t, &fr.gt
+	t.inst, t.be = in, be
+	gt.t, gt.in, gt.be, gt.ctx, gt.exportName = t, in, be, ctx, exportName
+	gt.args = args
 	t.gt = gt
 
 	if err := gt.start(); err != nil {
@@ -198,30 +211,30 @@ func (in *Instance) startAsyncExportTask(ctx context.Context, be *boundExport, e
 	if in.poisoned || !in.mayEnter {
 		return nil, fmt.Errorf("component/instance: export %q: cannot enter component instance", exportName)
 	}
-	t := &task{inst: in, be: be}
+	fr := &callbackFrame{}
+	t, gt := &fr.t, &fr.gt
+	t.inst, t.be = in, be
 	t.onResolve = func(vals []abi.Value, cancelled bool) {
 		if e := onResolve(vals, cancelled); e != nil {
 			panic(fmt.Errorf("component/instance: export %q: %w", exportName, e))
 		}
 	}
-	gt := &guestTask{
-		t: t, in: in, be: be, ctx: ctx, exportName: exportName,
-		onStart: func() ([]abi.Value, error) { return onStart(t) },
-		// Feature 1 (docs/component-model-async-final3-fable.md §1.1): a
-		// GUEST-caller-started callback task (this func, never
-		// invokeAsyncCallback's host-entry call) on an instance flagged
-		// mayBlockSync runs its core/callback invocations on a per-segment
-		// goroutine, so a mid-core-call blocking site reached from this
-		// task's own guest code can park (gt.block) instead of nested-
-		// driving the shared scheduler -- the fix for a callback task
-		// blocking on its own sync caller's continuation (sync-streams,
-		// async-calls-sync run2). Instances that never bind a sync
-		// stream/future copy or a sync-lowered-to-async-lift import
-		// (mayBlockSync stays false -- the overwhelmingly common case) pay
-		// zero goroutines: promoted is false and runSegment/runLoop take
-		// their exact pre-Feature-1 inline path.
-		promoted: in.mayBlockSync,
-	}
+	gt.t, gt.in, gt.be, gt.ctx, gt.exportName = t, in, be, ctx, exportName
+	gt.onStart = func() ([]abi.Value, error) { return onStart(t) }
+	// Feature 1 (docs/component-model-async-final3-fable.md §1.1): a
+	// GUEST-caller-started callback task (this func, never
+	// invokeAsyncCallback's host-entry call) on an instance flagged
+	// mayBlockSync runs its core/callback invocations on a per-segment
+	// goroutine, so a mid-core-call blocking site reached from this
+	// task's own guest code can park (gt.block) instead of nested-
+	// driving the shared scheduler -- the fix for a callback task
+	// blocking on its own sync caller's continuation (sync-streams,
+	// async-calls-sync run2). Instances that never bind a sync
+	// stream/future copy or a sync-lowered-to-async-lift import
+	// (mayBlockSync stays false -- the overwhelmingly common case) pay
+	// zero goroutines: promoted is false and runSegment/runLoop take
+	// their exact pre-Feature-1 inline path.
+	gt.promoted = in.mayBlockSync
 	t.gt = gt
 	if err := gt.start(); err != nil { // may run to EXIT, may park at entry/WAIT
 		return nil, err

--- a/internal/component/instance/async_lift.go
+++ b/internal/component/instance/async_lift.go
@@ -188,11 +188,14 @@ func (in *Instance) invokeStackful(ctx context.Context, be *boundExport, exportN
 // invokeAsyncCallback sits on, minus the drive (this instance's *sched is
 // shared with the whole composition tree -- Instance.sched's doc -- so
 // whoever eventually drives that shared scheduler to completion resumes
-// this task; it is never driven here). Returns the task's
-// requestCancellation as the caller's subtask.on_cancel (reference ~2207).
+// this task; it is never driven here). Returns the started task itself
+// (not a bound requestCancellation method value -- avoids a per-call alloc
+// on this guest<->guest path); the caller stores it as the subtask's
+// cancelTask and calls calleeTask.requestCancellation() from
+// subtask.runOnCancel (reference ~2207: subtask.on_cancel = callee(...)).
 func (in *Instance) startAsyncExportTask(ctx context.Context, be *boundExport, exportName string,
 	onStart func(*task) ([]abi.Value, error), onResolve func([]abi.Value, bool) error,
-) (onCancel func() error, err error) {
+) (calleeTask *task, err error) {
 	// Dispatch on the callee's shape (docs/component-model-async-stackful-
 	// design.md §6.2): a STACKFUL callee (no callback option) must be
 	// driven through stackfulTask -- its inline waitable-set.wait (or any
@@ -239,7 +242,7 @@ func (in *Instance) startAsyncExportTask(ctx context.Context, be *boundExport, e
 	if err := gt.start(); err != nil { // may run to EXIT, may park at entry/WAIT
 		return nil, err
 	}
-	return t.requestCancellation, nil
+	return t, nil
 }
 
 // startStackfulExportTask is startAsyncExportTask with guestTask swapped for
@@ -249,13 +252,14 @@ func (in *Instance) startAsyncExportTask(ctx context.Context, be *boundExport, e
 // caller's goroutine (the immediate path async_host_import.go's
 // buildAsyncHostWrapper already handles via st.resolved(), read off
 // t.state == taskResolved by the caller) or park at sparkEntry/sparkBlock,
-// returning t.requestCancellation as onCancel. Result values flow through
-// task.returnValues -> t.onResolve -> the wrapper's own onResolve closure --
-// for a sync-opts callee it's run() itself that calls returnValues after
-// lifting flat results, so the wrapper needs zero changes.
+// returning t (the caller runs t.requestCancellation as onCancel). Result
+// values flow through task.returnValues -> t.onResolve -> the wrapper's own
+// onResolve closure -- for a sync-opts callee it's run() itself that calls
+// returnValues after lifting flat results, so the wrapper needs zero
+// changes.
 func (in *Instance) startStackfulExportTask(ctx context.Context, be *boundExport, exportName string,
 	onStart func(*task) ([]abi.Value, error), onResolve func([]abi.Value, bool) error,
-) (onCancel func() error, err error) {
+) (calleeTask *task, err error) {
 	if in.poisoned || !in.mayEnter {
 		return nil, fmt.Errorf("component/instance: export %q: cannot enter component instance", exportName)
 	}
@@ -274,5 +278,5 @@ func (in *Instance) startStackfulExportTask(ctx context.Context, be *boundExport
 	if err := st.startTask(); err != nil { // may run to completion, may park at sparkEntry/sparkBlock
 		return nil, err
 	}
-	return t.requestCancellation, nil
+	return t, nil
 }

--- a/internal/component/instance/guest_guest_async_test.go
+++ b/internal/component/instance/guest_guest_async_test.go
@@ -252,7 +252,7 @@ func TestGuestGuestAsyncLower_BlockedThenLaterResolves(t *testing.T) {
 	st := newSubtask()
 	st.state = subtaskStarted
 	resolved := false
-	st.onCancel = func() error {
+	st.onCancelHook = func() {
 		// The callee ignores the cancellation request (spec-legal): it
 		// stays unresolved for now, and resolves later via its own normal
 		// completion path (a Deferred thunk here, standing in for whatever
@@ -263,7 +263,6 @@ func TestGuestGuestAsyncLower_BlockedThenLaterResolves(t *testing.T) {
 			installSubtaskEvent(st, st.subtaski())
 			return nil
 		})
-		return nil
 	}
 	h := aResources.addEntry(st)
 	st.setSubtaski(h)

--- a/internal/component/instance/guest_task.go
+++ b/internal/component/instance/guest_task.go
@@ -236,7 +236,19 @@ func (gt *guestTask) start() error {
 
 // firstRun runs firstRunBody inline (unpromoted task) or on a fresh segment
 // goroutine (promoted) via runSegment -- see guestTask.promoted's doc.
-func (gt *guestTask) firstRun() error { return gt.runSegment(gt.firstRunBody) }
+// Mirrors runLoop's inline-vs-runSegment split (below): calling
+// gt.firstRunBody() directly on the unpromoted path (instead of always
+// going through runSegment(gt.firstRunBody)) avoids a bound-method-value
+// allocation -- runSegment's promoted branch passes fn to a goroutine
+// (`go seg.main(fn)`), so escape analysis pins ANY argument ever passed to
+// runSegment's fn parameter to the heap, even along the call sites that hit
+// the non-promoted early return. Only the promoted branch still pays for it.
+func (gt *guestTask) firstRun() error {
+	if !gt.promoted {
+		return gt.firstRunBody()
+	}
+	return gt.runSegment(gt.firstRunBody)
+}
 
 // firstRunBody is task.start() -> lower params -> core call -> advance(packed),
 // the Phase-1/2 invokeAsyncCallback prologue verbatim (arg lowering, pooled

--- a/internal/component/instance/stackful_task_test.go
+++ b/internal/component/instance/stackful_task_test.go
@@ -77,12 +77,12 @@ func TestStackfulReap_CloseReapsParkedGoroutine(t *testing.T) {
 
 	onStart := func(*task) ([]abi.Value, error) { return nil, nil }
 	onResolve := func([]abi.Value, bool) error { return nil }
-	onCancel, err := home.startStackfulExportTask(context.Background(), be, "f", onStart, onResolve)
+	calleeTask, err := home.startStackfulExportTask(context.Background(), be, "f", onStart, onResolve)
 	if err != nil {
 		t.Fatalf("startStackfulExportTask: %v", err)
 	}
-	if onCancel == nil {
-		t.Fatal("startStackfulExportTask: onCancel is nil")
+	if calleeTask == nil {
+		t.Fatal("startStackfulExportTask: calleeTask is nil")
 	}
 
 	during := numGoroutineStable(t)
@@ -181,7 +181,7 @@ func TestStackfulTask_CancelAtSparkEntry(t *testing.T) {
 		secondCancelled = cancelled
 		return nil
 	}
-	onCancel2, err := home.startStackfulExportTask(context.Background(), be, "f", onStart2, onResolve2)
+	calleeTask2, err := home.startStackfulExportTask(context.Background(), be, "f", onStart2, onResolve2)
 	if err != nil {
 		t.Fatalf("second startStackfulExportTask: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestStackfulTask_CancelAtSparkEntry(t *testing.T) {
 		t.Fatal("BUG in test setup: no stackfulTask parked at sparkEntry")
 	}
 
-	if err := onCancel2(); err != nil {
+	if err := calleeTask2.requestCancellation(); err != nil {
 		t.Fatalf("requestCancellation: %v", err)
 	}
 	if !secondCancelled {

--- a/internal/component/instance/task.go
+++ b/internal/component/instance/task.go
@@ -72,6 +72,21 @@ type task struct {
 	onResolve func(vals []abi.Value, cancelled bool)
 	result    []abi.Value
 
+	// resultBuf is an inline 1-element backing array for the common
+	// single-result task.return call (taskReturnHostFuncGraph,
+	// async_builtins.go): a task.return with a declared result type always
+	// produces exactly one abi.Value (multi-result task.return is rejected
+	// at bind time -- taskReturnHostFuncGraph's "multiple task.return
+	// results are not supported" error), so `t.resultBuf[0] = val;
+	// result = t.resultBuf[:1]` avoids a `[]abi.Value{val}` heap allocation
+	// per call. Aliasing the task's own field is safe: a task is never
+	// reused/pooled and task.return traps if called twice
+	// (trap_if(state==RESOLVED) in returnValues below), so nothing ever
+	// overwrites resultBuf after the one call that populates it, and the
+	// returned slice header keeps this task (hence resultBuf's backing
+	// array) reachable for exactly as long as anything still holds it.
+	resultBuf [1]abi.Value
+
 	// syncImplicit marks the implicit Task of a PLAIN SYNC canon lift
 	// (invokeEntered): the reference's Task for a not-opts.async_ lift
 	// (definitions.py:2155-2164). It has no gt/st (blocker() == nil), never

--- a/internal/component/instance/waitable.go
+++ b/internal/component/instance/waitable.go
@@ -51,7 +51,18 @@ type eventTuple struct {
 // read at delivery, not at arming).
 type waitable struct {
 	pendingEvent func() eventTuple
-	wset         *waitableSet
+
+	// pendingSub is the closure-free fast path for the common pending event:
+	// a subtask's own resolution (async_host_import.go's two install sites,
+	// the async-import WAIT hot path). Storing (subtask, index) instead of a
+	// func() eventTuple avoids a per-WAIT heap closure. Mutually exclusive
+	// with pendingEvent by construction (a subtask never arms a stream/future
+	// event on itself, and vice versa); getPendingEvent/hasPendingEvent honor
+	// both. Evaluated at DELIVERY exactly like the thunk it replaces.
+	pendingSub   *subtask
+	pendingSubSi uint32
+
+	wset *waitableSet
 
 	// syncWaiter mirrors Waitable.has_sync_waiter (Phase 3, retiring the
 	// Phase-1/2 "no sync waiters exist" collapse -- docs/component-model-
@@ -74,12 +85,28 @@ type waitableEntry interface {
 // setPendingEvent mirrors Waitable.set_pending_event.
 func (w *waitable) setPendingEvent(ev func() eventTuple) { w.pendingEvent = ev }
 
+// setPendingSubtaskEvent arms the closure-free subtask-resolution event (see
+// pendingSub). st is the subtask carrying this waitable; si its table index.
+func (w *waitable) setPendingSubtaskEvent(st *subtask, si uint32) {
+	w.pendingSub, w.pendingSubSi = st, si
+}
+
 // hasPendingEvent mirrors Waitable.has_pending_event.
-func (w *waitable) hasPendingEvent() bool { return w.pendingEvent != nil }
+func (w *waitable) hasPendingEvent() bool { return w.pendingEvent != nil || w.pendingSub != nil }
 
 // getPendingEvent mirrors Waitable.get_pending_event: take and clear the
-// deferred event, evaluating the thunk now.
+// deferred event, evaluating it now. The closure-free subtask fast path
+// reproduces installSubtaskEvent's exact body (deliver-on-read, then the
+// eventSubtask tuple with the live state).
 func (w *waitable) getPendingEvent() eventTuple {
+	if st := w.pendingSub; st != nil {
+		si := w.pendingSubSi
+		w.pendingSub, w.pendingSubSi = nil, 0
+		if st.resolved() && !st.resolveDelivered() {
+			st.deliverResolve()
+		}
+		return eventTuple{code: eventSubtask, p1: si, p2: uint32(st.state)}
+	}
 	ev := w.pendingEvent
 	w.pendingEvent = nil
 	return ev()

--- a/internal/component/instance/waitable.go
+++ b/internal/component/instance/waitable.go
@@ -1,8 +1,10 @@
 package instance
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/samyfodil/wazy/api"
 	"github.com/samyfodil/wazy/internal/component/abi"
 )
 
@@ -253,25 +255,60 @@ type subtask struct {
 	lenders     []*resourceEntry
 	flatResults []uint64
 
-	// applyResolve lowers an async host import's results into the guest
-	// memory captured at call time (through the retptr an async-lowered
-	// import's core signature always carries for a non-empty result -- see
-	// async_host_import.go's buildAsyncHostWrapper) and flips state to
-	// RETURNED. Set by buildAsyncHostWrapper for a host-import subtask;
-	// nil for anything else (no other subtask source exists yet -- Phase
-	// 2/3 add guest->guest lowers and streams/futures).
-	applyResolve func(results []abi.Value) error
+	// resolveFn is a test-injection / future-alternate-source override for
+	// applyResolve; nil in production (the resolveCfg path below is used).
+	// Checked first by the applyResolve method.
+	resolveFn func(results []abi.Value) error
 
-	// onCancel mirrors Subtask.on_cancel (Phase 3): the callee's cancel
-	// entry, called synchronously by the subtask.cancel builtin. For a
-	// guest<->guest async-lowered call this is the callee task's
-	// requestCancellation (async_lift.go's startAsyncExportTask); for a host
-	// import it is whatever AsyncCall.OnCancel registered, or nil if the
-	// import registered none (a callee that ignores cancellation --
-	// spec-legal, see AsyncCall.OnCancel's doc). nil for a subtask that has
-	// already resolved by the time cancel is called (nothing left to
-	// cancel).
-	onCancel func() error
+	// resolveCfg is the bind-time half of a host-import subtask's resolve:
+	// one per async-lowered import binding, built once in
+	// buildAsyncHostWrapper (amortized), shared by every call through that
+	// binding. Immutable after bind. nil for anything else (no other
+	// subtask source exists yet -- Phase 2/3 add guest->guest lowers and
+	// streams/futures).
+	resolveCfg *asyncResolveCfg
+
+	// retPtr is the per-call trailing out-pointer, decoded from the core
+	// stack at call time (buildAsyncHostWrapper).
+	retPtr uint32
+
+	// memMod is the per-call CALLING module (or memOverride) captured at
+	// call time.
+	memMod api.Module
+
+	// resolveCtx is the per-call context used for reallocOf at resolve
+	// time.
+	resolveCtx context.Context
+
+	// ac is the AsyncCall handed to a plain host import's AsyncHostFunc,
+	// co-allocated here so the (subtask, AsyncCall) pair costs one malloc
+	// instead of two (async_host_import.go's buildAsyncHostWrapper takes
+	// &st.ac instead of &AsyncCall{...}). Unused (zero value) for a
+	// guest<->guest subtask (the tgt arm returns before an AsyncCall would
+	// be built) and for test-built subtasks that never go through the
+	// wrapper.
+	ac AsyncCall
+
+	// onCancelHook and cancelTask together replace the single onCancel func()
+	// error field (mirroring Subtask.on_cancel, Phase 3): mutually
+	// exclusive, and dispatched by hasOnCancel/runOnCancel below.
+	//
+	// onCancelHook is AsyncCall.OnCancel's user fn, stored directly (no
+	// error-adapting wrapper closure). Set only on a host-import subtask
+	// whose AsyncHostFunc called OnCancel; nil if the import registered
+	// none (a callee that ignores cancellation -- spec-legal, see
+	// AsyncCall.OnCancel's doc).
+	onCancelHook func()
+
+	// cancelTask is the guest<->guest callee's task (async_lift.go's
+	// startAsyncExportTask/startStackfulExportTask): runOnCancel calls its
+	// requestCancellation directly, with no method-value closure. Set only
+	// on the guest<->guest callee arm (async_host_import.go's
+	// buildAsyncHostWrapper).
+	//
+	// Both fields are nil for a subtask that has already resolved by the
+	// time cancel is called (nothing left to cancel).
+	cancelTask *task
 
 	// cancellationRequested mirrors Subtask.cancellation_requested: set the
 	// first time subtask.cancel is called on this subtask; a second call
@@ -297,6 +334,22 @@ func (s *subtask) subtaski() uint32 { return s.si }
 
 // setSubtaski records this subtask's own table index once parked.
 func (s *subtask) setSubtaski(i uint32) { s.si = i }
+
+// hasOnCancel replaces the `st.onCancel != nil` gate
+// (async_builtins.go's subtaskCancelHostFuncGraph).
+func (s *subtask) hasOnCancel() bool { return s.cancelTask != nil || s.onCancelHook != nil }
+
+// runOnCancel is Subtask.on_cancel's invocation (canon_subtask_cancel,
+// async_builtins.go's subtaskCancelHostFuncGraph): runs synchronously on the
+// driving goroutine under the sched.pumping bracket its caller already
+// holds.
+func (s *subtask) runOnCancel() error {
+	if s.cancelTask != nil {
+		return s.cancelTask.requestCancellation()
+	}
+	s.onCancelHook()
+	return nil
+}
 
 func (*subtask) entryKind() entryKind     { return entrySubtask }
 func (s *subtask) waitablePtr() *waitable { return &s.waitable }


### PR DESCRIPTION
Allocation reductions on the Component Model async hot path, on top of the merged async runtime (#3). Alloc-profiled with `-memprofilerate=1`; **allocs/op is exact regardless of machine load** and is the metric used here (the dev box was busy, so ns/op is not trusted).

## Results

| Benchmark | Before | After |
|---|---|---|
| `CallAsyncFirstLight` (every async call) | 4 allocs / 390 B | **1 alloc / 328 B** |
| `CallAsyncAwaitImport` (full WAIT path) | 11 allocs / 973 B | **5 allocs / 791 B** |

(2 of AwaitImport's remaining 5 are the benchmark's own host-fn closures — irremovable by runtime changes; the runtime floor is 3.)

## Changes (no pooling — all safe, load-independently verified)

- **Co-allocate `task`+`guestTask`** as one `callbackFrame` at both callback-lift sites (2 mallocs → 1).
- **Kill the `firstRunBody` bound-method-value escape** — call it directly on the common `!promoted` path.
- **Inline `task.return`'s result** into a `task.resultBuf [1]abi.Value` (one-shot task, consumed synchronously).
- **Closure-free subtask pending-event** — a typed fast path on `waitable` (the general thunk stays for stream/future ends).
- **Destructure the `applyResolve`/`onCancel` closures** into a bind-time config + per-call subtask fields + methods; **embed `AsyncCall` in `subtask`** and drop its redundant `subtaski`.

## Deliberately deferred (documented in `docs/perf-async-*.md`)

- **`callbackFrame` pooling** — the design showed it's alloc-*neutral* for non-void results (trades an alloc for a 16B copy); its only payoff is latency, which needs a quiet machine to measure. Not shipping pooling blind.
- **Component Instantiate** allocs — investigated, diffuse and mostly inherent (per-instance WASI state / config isolation); the real lever is caching the compiled WASI host module (engine-layer, separate effort).

## Testing

`TestAsyncWastConformance` 31/31, `TestAsyncOracle`, cancel suites under `-race`, whole-repo `go test ./...` all green. Design docs: `docs/perf-async-wait-alloc-design-fable.md`, `docs/perf-async-profiling-findings.md`.
