### PR TITLE
perf(native): recycle grown stack buffers through the pool (compliance -42% alloc)

### DIFF
--- a/internal/engine/native/call_engine.go
+++ b/internal/engine/native/call_engine.go
@@ -32,6 +32,11 @@ type (
 		preambleExecutable *byte
 		// parent is the *moduleEngine from which this callEngine is created.
 		parent *moduleEngine
+		// eng is the *engine that owns the shared stack pool (== parent.parent.
+		// parent). Cached here by callWithStack's non-guard setup so growStack /
+		// the grow loop can acquire and release stack buffers without re-walking
+		// the parent chain (and so unit tests can wire a bare engine).
+		eng *engine
 		// indexInModule is the index of the function in the module.
 		indexInModule wasm.Index
 		// sizeOfParamResultSlice is the size of the parameter/result slice.
@@ -453,6 +458,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 		// buffer is handed back to the pool for some other goroutine to
 		// reuse.
 		eng := c.parent.parent.parent
+		c.eng = eng // so growStack / the grow loop can reach the pool
 		var stackBoxed *[]byte
 		c.stack, stackBoxed = eng.acquireStack(c.requiredInitialStackSize())
 		c.stackTop = alignedStackTop(c.stack)
@@ -566,17 +572,39 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			oldTop := c.stackTop
 			oldStack := c.stack
 			var newsp, newfp uintptr
+			pooled := false
 			if nativeapi.StackGuardCheckEnabled {
 				newsp, newfp, err = c.growStackWithGuarded()
 			} else {
 				newsp, newfp, err = c.growStack()
+				pooled = true // non-guard path buffers come from / go back to the stack pool
 			}
 			if err != nil {
 				return err
 			}
 			adjustClonedStack(oldsp, oldTop, newsp, newfp, c.stackTop)
-			// Old stack must be alive until the new stack is adjusted.
-			runtime.KeepAlive(oldStack)
+			if pooled {
+				// oldStack is dead here: adjustClonedStack only reads/writes the
+				// NEW buffer (translating the copied frame pointers), using the
+				// old addresses purely as arithmetic bounds -- it never
+				// dereferences oldStack. growStack replaced c.stack/c.stackTop and
+				// reset stackBottomPtr to the new buffer, and execution resumes on
+				// newsp/newfp below. So recycle oldStack into the stack pool
+				// instead of dropping it to GC: growStack DOUBLES on every grow, so
+				// a deep-growth guest would otherwise allocate AND discard every
+				// intermediate buffer of the doubling sequence (measured at 2.12 GB
+				// across the spec suite's stack-overflow tests). releaseStack keeps
+				// oldStack alive across the pool hand-off, subsuming the KeepAlive
+				// the GC-only path below still needs. The final (grown) buffer is
+				// released once more by callWithStack's defer -- each buffer in the
+				// chain is released exactly once. Guard-check builds never pool
+				// (init's debug path make()s the buffer), so they keep the
+				// GC path.
+				c.eng.releaseStack(oldStack, nil)
+			} else {
+				// Old stack must be alive until the new stack is adjusted.
+				runtime.KeepAlive(oldStack)
+			}
 			c.execCtx.exitCode = nativeapi.ExitCodeOK
 			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr, newsp, newfp)
 		case nativeapi.ExitCodeGrowMemory:
@@ -1146,14 +1174,42 @@ func (c *callEngine) growStack() (newSP, newFP uintptr, err error) {
 	}
 
 	newLen := 2*currentLen + c.execCtx.stackGrowRequiredSize + 16 // Stack might be aligned to 16 bytes, so add 16 bytes just in case.
-	newSP, newFP, c.stackTop, c.stack = c.cloneStack(newLen)
+
+	// Source the new buffer from the stack pool rather than make()-ing it fresh,
+	// so a deep-growth guest reuses the buffers released by callWithStack's grow
+	// loop (growStack doubles, so without this every intermediate buffer of the
+	// doubling sequence is allocated once and discarded -- 2.12 GB across the
+	// spec suite's stack-overflow tests). acquireStack returns a buffer of the
+	// smallest class >= newLen; the extra headroom is harmless. Guard-check
+	// builds keep make() -- their buffers are never pooled (CheckStackGuardPage
+	// needs the guard region to still be all-zero, which a reused buffer can't
+	// promise), matching init's debug path.
+	var newStack []byte
+	if nativeapi.StackGuardCheckEnabled {
+		newStack = make([]byte, newLen)
+	} else {
+		newStack, _ = c.eng.acquireStack(int(newLen))
+	}
+	newSP, newFP, c.stackTop = c.cloneStackInto(newStack)
+	c.stack = newStack
 	c.execCtx.stackBottomPtr = stackCheckLimitPtr(c.stack, 0)
 	return
 }
 
+// cloneStack allocates a fresh buffer of length l and copies the live stack
+// into it. Used by the experimental Snapshotter (doRestore's counterpart),
+// which retains the returned buffer long-term and so must NOT draw it from the
+// transient stack pool; growStack instead sources its buffer from the pool and
+// calls cloneStackInto directly.
 func (c *callEngine) cloneStack(l uintptr) (newSP, newFP, newTop uintptr, newStack []byte) {
 	newStack = make([]byte, l)
+	newSP, newFP, newTop = c.cloneStackInto(newStack)
+	return
+}
 
+// cloneStackInto copies the live stack into newStack (already allocated, and at
+// least the current stack's used size) and returns the relocated SP/FP/top.
+func (c *callEngine) cloneStackInto(newStack []byte) (newSP, newFP, newTop uintptr) {
 	relSp := c.stackTop - uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall))
 	relFp := c.stackTop - c.execCtx.framePointerBeforeGoCall
 

--- a/internal/engine/native/call_engine_test.go
+++ b/internal/engine/native/call_engine_test.go
@@ -36,6 +36,7 @@ func TestCallEngine_growStack(t *testing.T) {
 		}
 		c := &callEngine{
 			stack:    s,
+			eng:      &engine{}, // growStack now sources the new buffer from the pool
 			stackTop: uintptr(unsafe.Pointer(&s[15])),
 			execCtx: executionContext{
 				// stackGrowRequiredSize is large enough here (rather than
@@ -53,7 +54,12 @@ func TestCallEngine_growStack(t *testing.T) {
 		}
 		newSP, newFp, err := c.growStack()
 		require.NoError(t, err)
-		require.Equal(t, 1000+32*2+16, len(c.stack))
+		// growStack now acquires the new buffer from the shared stack pool
+		// (stack_pool.go) rather than make()-ing it at exactly newLen, so it is
+		// the smallest pool class >= newLen (here class 0 = stackPoolBaseSize) --
+		// the extra headroom is harmless. Assert the invariant (>= newLen), not
+		// an exact length.
+		require.True(t, len(c.stack) >= 1000+32*2+16)
 
 		require.True(t, c.stackTop%16 == 0)
 		require.Equal(t, &c.stack[backend.StackBoundsCheckMarginBytes], c.execCtx.stackBottomPtr)


### PR DESCRIPTION
Profiling the WebAssembly spec compliance suite (`spectest/v2`, 148 modules, on a quiet box) surfaced a clear allocation bottleneck: **`cloneStack` was 72% of all allocation (2.12 GB)** and ~19% of CPU.

## Root cause
`growStack` doubles the value stack on each grow (correct, amortized). But every *intermediate* buffer of the doubling sequence was `make()`'d fresh and dropped to GC — the old buffer only returned to the stack pool on the *outermost* call's return, never between grows, and the new buffer was always a fresh allocation. The spec suite's deliberate deep-recursion / stack-overflow tests (`call.wast`, `stack.wast` recurse to the ~50 MB ceiling) hammer this: each descent doubles ~12× and discards every step.

## Fix
`growStack` now **sources the new buffer from the shared stack pool** (`acquireStack`), and the grow loop **releases the old buffer back** to it — right after `adjustClonedStack`, which only translates frame pointers in the *new* buffer, so the old one is provably dead there (the release subsumes the `KeepAlive` the GC-only path needed). A deep-growth guest reuses each size class's buffer across descents instead of allocating and discarding it.

- Extracted `cloneStackInto` (copy into a caller-provided buffer); `cloneStack` (make + copy) is kept for the experimental Snapshotter, which retains its buffer long-term and must not draw from the transient pool.
- Guard-check builds keep `make()` + the GC path (`CheckStackGuardPage` needs a zeroed guard region a reused buffer can't promise) — matching `init`'s debug path.
- Cached the `*engine` on `callEngine` (`c.eng`) so `growStack`/the grow loop reach the pool without re-walking `parent.parent.parent`. The grown buffer is now a pool-class size (`>= newLen`); the unit test asserts that invariant, not an exact length.

## Result

| | Before | After |
|---|---|---|
| `spectest/v2` total allocation | 2990 MB | **1736 MB (−42%)** |
| stack-buffer share | 2.12 GB (`cloneStack`) | **883 MB (`acquireStack`) (−58%)** |

**Scope, honestly:** `cloneStack` is *absent* from normal-execution profiles (it doesn't appear in the `Execute3` benchmark) — this is a deep-recursion / spec-suite concern, not a hot path for typical guests. It helps the compliance suite's footprint and genuinely deep-recursion guests (parsers, tree-walkers, interpreters-in-Wasm). CPU `memmove` is unchanged (the copy is inherent to a moving stack); the win is allocation / GC pressure.

## Testing (this is the runtime's most delicate code — unsafe stack relocation)
- All `spectest` suites pass, compiler **and** interpreter.
- `spectest/v1` + `spectest/v2` under **`-race`** (real deep-recursion modules exercising the grow/recycle path + the shared pool) — clean.
- Native engine `-race` — clean.
- Whole-repo `go test ./...` green (incl. the 31/31 async conformance).
- `gofmt` + `go vet` clean.
