### PR TITLE
ci: deflake libsodium test-binary download

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -264,6 +264,8 @@ jobs:
           key: integration-test-libsodium-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum', 'Makefile') }}
 
       - name: Download test binaries
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: make libsodium
 
       - name: Run test binaries

--- a/Makefile
+++ b/Makefile
@@ -339,8 +339,9 @@ fuzz:
 
 libsodium:
 	mkdir -p ./internal/integration_test/libsodium/testdata && cd ./internal/integration_test/libsodium/testdata && \
-		curl -s "https://api.github.com/repos/jedisct1/webassembly-benchmarks/contents/2022-12/wasm?ref=7e86d68e99e60130899fbe3b3ab6e9dce9187a7c" \
-		| jq -r '.[] | .download_url' | xargs -n 1 curl -LO
+		curl -fsSL --retry 5 --retry-all-errors $(if $(GITHUB_TOKEN),-H "Authorization: Bearer $(GITHUB_TOKEN)") \
+		"https://api.github.com/repos/jedisct1/webassembly-benchmarks/contents/2022-12/wasm?ref=7e86d68e99e60130899fbe3b3ab6e9dce9187a7c" \
+		| jq -r '.[].download_url' | xargs -n 1 curl -fsSL --retry 5 --retry-all-errors -O
 
 #### CLI release related ####
 


### PR DESCRIPTION
## Problem

The `libsodium` integration job downloads ~70 wasm test binaries via an unauthenticated GitHub API listing piped through `jq | xargs curl -LO`, with no failure detection or retries. Two flake modes:

- **Silent skip:** the API listing call (60 req/hr, shared across GitHub-hosted runner IPs) returns `403` on rate limit; the error JSON piped to `jq` yields no URLs, so the suite downloads 0 files and skips (`len(cases) < 10`) — green but testing nothing.
- **Red build:** a transient CDN error saves the error page as a `.wasm`, later failing `CompileModule`.

## Fix

- `-f` on both curls — fail loudly on HTTP errors instead of writing error bodies to disk.
- `--retry 5 --retry-all-errors` — ride out transient CDN/network hiccups.
- Optional bearer token — the listing call uses the 5000 req/hr authenticated limit. Passed via `github.token` in CI; optional locally so `make libsodium` still works unauthenticated.

## Verification

Ran the hardened `make libsodium` (70 valid wasm downloaded) and the full suite: `ok ... 853s`, 0 failures.