### PR TITLE
fix: add TinyGo build support via !tinygo build constraints

### DIFF
--- a/engine_native.go
+++ b/engine_native.go
@@ -1,0 +1,7 @@
+//go:build !tinygo
+
+package wazy
+
+import "github.com/samyfodil/wazy/internal/engine/native"
+
+var nativeEngine = native.NewEngine

--- a/engine_tinygo.go
+++ b/engine_tinygo.go
@@ -1,0 +1,8 @@
+//go:build tinygo
+
+package wazy
+
+import "github.com/samyfodil/wazy/internal/engine/interpreter"
+
+// TinyGo cannot use the native JIT engine; fall back to the interpreter.
+var nativeEngine = interpreter.NewEngine

--- a/internal/component/instance/resolve_ip.go
+++ b/internal/component/instance/resolve_ip.go
@@ -1,0 +1,12 @@
+//go:build !tinygo
+
+package instance
+
+import (
+	"context"
+	"net"
+)
+
+func defaultResolveIP(ctx context.Context, name string) ([]net.IP, error) {
+	return net.DefaultResolver.LookupIP(ctx, "ip", name)
+}

--- a/internal/component/instance/resolve_ip_tinygo.go
+++ b/internal/component/instance/resolve_ip_tinygo.go
@@ -1,0 +1,12 @@
+//go:build tinygo
+
+package instance
+
+import (
+	"context"
+	"net"
+)
+
+func defaultResolveIP(_ context.Context, name string) ([]net.IP, error) {
+	return net.LookupIP(name)
+}

--- a/internal/component/instance/wasi.go
+++ b/internal/component/instance/wasi.go
@@ -338,9 +338,7 @@ func WithWASI(cfg WASIConfig) []Option {
 	}
 	resolveIP := cfg.ResolveIP
 	if resolveIP == nil {
-		resolveIP = func(ctx context.Context, name string) ([]net.IP, error) {
-			return net.DefaultResolver.LookupIP(ctx, "ip", name)
-		}
+		resolveIP = defaultResolveIP
 	}
 	sockets := newWasiSockets(dial, listenPacket, listen, resolveIP)
 

--- a/internal/engine/native/memmove.go
+++ b/internal/engine/native/memmove.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 package native
 
 import (

--- a/internal/engine/native/memmove_tinygo.go
+++ b/internal/engine/native/memmove_tinygo.go
@@ -1,0 +1,8 @@
+//go:build tinygo
+
+package native
+
+// TinyGo uses a different func-value representation and does not support
+// //go:linkname to runtime.memmove. The native engine is not usable under
+// TinyGo, so memmovPtr is set to zero; the interpreter is used instead.
+var memmovPtr uintptr

--- a/internal/platform/cpuid_amd64.go
+++ b/internal/platform/cpuid_amd64.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 package platform
 
 import "golang.org/x/sys/cpu"

--- a/internal/platform/cpuid_arm64.go
+++ b/internal/platform/cpuid_arm64.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 package platform
 
 import "golang.org/x/sys/cpu"

--- a/internal/platform/cpuid_unsupported.go
+++ b/internal/platform/cpuid_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !(amd64 || arm64)
+//go:build !(amd64 || arm64) || tinygo
 
 package platform
 

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -14,6 +14,9 @@ func CompilerSupported() bool {
 }
 
 func CompilerSupports(features api.CoreFeatures) bool {
+	if !nativeCompilerAvailable {
+		return false
+	}
 	if !compilerPlatformSupports(features) {
 		return false
 	}

--- a/internal/platform/platform_notinygo.go
+++ b/internal/platform/platform_notinygo.go
@@ -1,0 +1,5 @@
+//go:build !tinygo
+
+package platform
+
+const nativeCompilerAvailable = true

--- a/internal/platform/platform_tinygo.go
+++ b/internal/platform/platform_tinygo.go
@@ -1,0 +1,7 @@
+//go:build tinygo
+
+package platform
+
+// TinyGo does not support the native JIT engine: it lacks //go:linkname
+// compatibility with the standard runtime and uses a different func-value layout.
+const nativeCompilerAvailable = false

--- a/internal/sysfs/sock_supported.go
+++ b/internal/sysfs/sock_supported.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin || windows
+//go:build (linux || darwin || windows) && !tinygo
 
 package sysfs
 

--- a/internal/sysfs/sock_unix.go
+++ b/internal/sysfs/sock_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build (linux || darwin) && !tinygo
 
 package sysfs
 

--- a/internal/sysfs/sock_unsupported.go
+++ b/internal/sysfs/sock_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !(linux || darwin || windows)
+//go:build !(linux || darwin || windows) || tinygo
 
 package sysfs
 

--- a/internal/sysfs/sock_windows.go
+++ b/internal/sysfs/sock_windows.go
@@ -1,4 +1,4 @@
-//go:build windows
+//go:build windows && !tinygo
 
 package sysfs
 

--- a/runtime.go
+++ b/runtime.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/samyfodil/wazy/api"
 	"github.com/samyfodil/wazy/internal/engine/interpreter"
-	"github.com/samyfodil/wazy/internal/engine/native"
 	"github.com/samyfodil/wazy/internal/expctxkeys"
 	"github.com/samyfodil/wazy/internal/platform"
 	internalsock "github.com/samyfodil/wazy/internal/sock"
@@ -161,7 +160,7 @@ func NewRuntimeWithConfig(ctx context.Context, rConfig RuntimeConfig) Runtime {
 	}
 	if configEngine == nil {
 		if configKind == engineKindCompiler {
-			configEngine = native.NewEngine
+			configEngine = nativeEngine
 		} else {
 			configEngine = interpreter.NewEngine
 		}


### PR DESCRIPTION
TinyGo lacks syscall.Conn on net.TCPListener, x/sys/cpu assembly symbols (cpuid/xgetbv), //go:linkname compatibility with the standard runtime's memmove, and net.Resolver.LookupIP. Guard all affected code paths behind !tinygo build tags so TinyGo falls back to unsupported stubs, the interpreter engine, and a no-op IP resolver.

With this PR, Wazy compiled with TinyGo:
```
$ tinygo run ./examples/basic 7 9
7 + 9 = 16
```

Also Wazy running TinyGo in TinyGo:
```
$ tinygo run ./examples/allocation/tinygo/greet.go wazy
wasm >> Hello, wazy!
go >> Hello, wazy!
```

That's just wazy, don't you think? :smile_cat: 

A future PR will hopefully get more tests passing so `tinygo test ./...` can run, along with other desireable functionality.