### PR TITLE
feat(component): implement descriptor.get-flags, sync and sync-data

### DIFF
--- a/internal/component/instance/wasi_fs.go
+++ b/internal/component/instance/wasi_fs.go
@@ -151,6 +151,24 @@ import (
 // re-keying every entry beneath it by hand. Mkdir/Rmdir/Rename/Unlink/
 // Readdir on the mount do all of that correctly and for free.
 //
+// # Batch 5: descriptor flags and sync
+//
+// A real CPython (componentize-py) guest -- the first guest here that is not
+// a rustc binary -- reaches two descriptor methods no rustc fixture ever
+// did, both through the preview1-to-preview2 adapter rather than from
+// Python source directly:
+//
+//   - [method]descriptor.get-flags, the adapter's fd_fdstat_get: "was this
+//     descriptor opened for reading, for writing, or both?". Answered from
+//     what open-at recorded on the descriptor, never from the mount -- see
+//     getFlags.
+//   - [method]descriptor.sync, the adapter's fd_sync, which is os.fsync --
+//     pip calls it on every file it writes while installing a wheel. Its
+//     sibling [method]descriptor.sync-data (fd_datasync, os.fdatasync) is
+//     registered alongside it, sharing one implementation; see fsSyncFunc
+//     for both, and for what syncing means when a descriptor holds no
+//     cached fd.
+//
 // # Nested own<T> handles
 //
 // Every func below whose result nests an own<T> inside a result<>/list<>
@@ -266,14 +284,20 @@ const (
 	wasiOpenFlagTruncate  uint32 = 1 << 3
 )
 
-// wasi:filesystem/types' descriptor-flags bit this package inspects (bit 1,
-// per its WIT declaration order
+// wasi:filesystem/types' descriptor-flags bits this package handles (bits 0
+// and 1, per its WIT declaration order
 // read/write/file-integrity-sync/data-integrity-sync/requested-write-sync/
-// mutate-directory): a descriptor opened with the write bit set is the one
+// mutate-directory). A descriptor opened with the write bit set is the one
 // [method]descriptor.write-via-stream/append-via-stream may be called
-// against; every other descriptor (including the single preopened root
-// directory) is write-via-stream-ineligible, matching a real OS refusing to
-// write through a read-only fd.
+// against; every other descriptor (including the preopened root
+// directories) is write-via-stream-ineligible, matching a real OS refusing
+// to write through a read-only fd. Both bits are also remembered on the
+// descriptor node verbatim, since [method]descriptor.get-flags' whole job is
+// to report back how a descriptor was opened (see getFlags). The remaining
+// four bits are never set by this package: the three sync bits are
+// O_SYNC/O_DSYNC/O_RSYNC, which open-at does not request, and
+// mutate-directory is a promise only the mount could keep -- see
+// getDirectories.
 const (
 	wasiDescFlagRead  uint32 = 1 << 0
 	wasiDescFlagWrite uint32 = 1 << 1
@@ -294,8 +318,14 @@ type fsMount struct {
 // handle table (wasiFS.descs, keyed by rep) tracks: fs is the mount it lives
 // in and path is its location within that mount, relative to the mount root
 // ("." names the mount root itself, matching io/fs and sys.FS convention).
-// writable records whether open-at's descriptor-flags carried the write bit
-// (wasiDescFlagWrite), gating write-via-stream/append-via-stream.
+// readable/writable are the access mode the descriptor was opened with
+// (open-at's descriptor-flags, corrected where open-at overrode them -- see
+// its oflag switch): writable gates write-via-stream/append-via-stream and
+// picks the mode sync reopens with, and the pair is what
+// [method]descriptor.get-flags reports back. They are recorded at open time
+// rather than derived from the path's own mode on demand for the reason
+// fcntl(fd, F_GETFL) exists: a descriptor's flags say how it was opened, not
+// what its file happens to permit today.
 //
 // A descriptor holds no open sys.File: every operation opens the path, acts,
 // and closes again. ponytail: that is one extra open+close per stream chunk;
@@ -313,6 +343,7 @@ type fsDescNode struct {
 	mount    int
 	path     string
 	isDir    bool
+	readable bool
 	writable bool
 }
 
@@ -612,6 +643,84 @@ func fsSelfPathArgs(method string, fs *wasiFS, args []abi.Value) (node *fsDescNo
 	return node, path, nil, nil
 }
 
+// fsSyncFunc builds the HostFunc behind [method]descriptor.sync (syncFile =
+// sys.File.Sync, POSIX fsync) and its sibling [method]descriptor.sync-data
+// (sys.File.Datasync, POSIX fdatasync). The two differ in exactly that one
+// call, so method (the WIT name, for error text) and syncFile are the whole
+// difference between them.
+//
+// # Syncing without a cached fd
+//
+// A descriptor here holds no open sys.File (see fsDescNode), so this opens
+// the path, syncs, and closes -- fsyncing a handle opened moments ago, which
+// reads odd until you notice what fsync(2) actually names: the FILE, not the
+// descriptor. It flushes the inode's dirty pages and metadata, state shared
+// by every descriptor open on it, which is why fsync through a freshly
+// opened handle is indistinguishable from fsync through one held since the
+// guest's own open. Nothing is lost by not caching, either: this package
+// buffers no writes of its own (writeStreamWrite Pwrites straight to the
+// mount, see its doc), so a cached fd would have nothing extra to give the
+// kernel. That leaves caching purely a cost -- a host file handle per live
+// descriptor, leaked whenever a guest drops a handle without saying so or
+// aborts mid-call, which is the exact failure fsDescNode's no-open-file rule
+// exists to prevent. So: no cached fd, and no correctness debt from it.
+//
+// # What each kind of descriptor syncs
+//
+//   - A directory syncs for real, opened O_RDONLY|O_DIRECTORY. fsync on a
+//     directory fd is what makes a create/unlink/rename durable, so no-oping
+//     it would quietly break the one guest that does the right thing. (A
+//     read-only mount answers bad-descriptor here, since wazy's read-only
+//     layer has no sync surface at all -- the same answer wazy's own
+//     preview1 fd_sync gives for that mount, so the two runtimes agree.)
+//   - A file opened for writing syncs for real, in the access mode it was
+//     opened with (mirroring openAt's own O_RDWR/O_WRONLY choice) -- the
+//     case pip's os.fsync after writing a wheel's files actually hits.
+//   - A file NOT opened for writing answers Ok without touching the mount:
+//     types.wit says so outright ("This function succeeds with no effect if
+//     the file descriptor is not opened for writing"), and it is the only
+//     answer that is the same everywhere -- POSIX fsync(2) on a read-only fd
+//     is a successful no-op, but Windows' FlushFileBuffers refuses a handle
+//     without write access, so honoring the call literally would make one
+//     guest's os.fsync succeed on Linux and fail on Windows for no reason
+//     the guest could act on.
+func fsSyncFunc(fs *wasiFS, method string, syncFile func(sys.File) sys.Errno) HostFunc {
+	return func(_ context.Context, args []abi.Value) ([]abi.Value, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("[method]descriptor.%s: expected 1 arg (self), got %d", method, len(args))
+		}
+		selfRep, ok := args[0].(uint32)
+		if !ok {
+			return nil, fmt.Errorf("[method]descriptor.%s: self: expected uint32 rep, got %T", method, args[0])
+		}
+		node, err := fs.descNode(selfRep)
+		if err != nil {
+			return nil, fmt.Errorf("[method]descriptor.%s: %w", method, err)
+		}
+		var oflag sys.Oflag
+		switch {
+		case node.isDir:
+			oflag = sys.O_RDONLY | sys.O_DIRECTORY
+		case !node.writable:
+			return []abi.Value{abi.ResultValue{IsErr: false, Payload: nil}}, nil // nothing this descriptor could have dirtied
+		case node.readable:
+			oflag = sys.O_RDWR
+		default:
+			oflag = sys.O_WRONLY
+		}
+		f, errno := node.fs.OpenFile(node.path, oflag, 0)
+		if errno != 0 {
+			return fsErrResult(errno), nil
+		}
+		errno = syncFile(f)
+		f.Close()
+		if errno != 0 {
+			return fsErrResult(errno), nil
+		}
+		return []abi.Value{abi.ResultValue{IsErr: false, Payload: nil}}, nil
+	}
+}
+
 // setResources implements withResourcesHook's callback: it runs once, right
 // after the owning Instance's handleTable is created and before any host
 // func can be invoked (see host_import.go's withResourcesHook doc).
@@ -868,7 +977,22 @@ func wasiFilesystemOptions(fs *wasiFS, sockets *wasiSockets) []Option {
 		}
 		dirs := make([]abi.Value, 0, len(fs.mounts))
 		for i, m := range fs.mounts {
-			rep := fs.newDescRep(&fsDescNode{fs: m.fs, mount: i, path: ".", isDir: true})
+			// A preopen is readable and not writable, which is what
+			// [method]descriptor.get-flags reports for it. `read` is
+			// honest: the guest may list it, stat it, and open paths under
+			// it, which is every use a directory descriptor has here.
+			// `write` would not be: in descriptor-flags it means "this
+			// descriptor may be written through", i.e. write-via-stream/
+			// append-via-stream, and both answer is-directory against any
+			// directory descriptor -- the same thing a real open(2) does
+			// when asked for O_RDWR on a directory. The flag that would
+			// describe a *mutable* directory is mutate-directory, and this
+			// package deliberately claims that one for no descriptor: the
+			// mount alone decides whether a create/unlink/rename lands (a
+			// WithReadOnlyDirMount answers EROFS, a WithFSMount ENOSYS),
+			// and there is no race-free way to promise up front an answer
+			// only the mount can give.
+			rep := fs.newDescRep(&fsDescNode{fs: m.fs, mount: i, path: ".", isDir: true, readable: true})
 			handle := resources.NewOwn(wasiDescriptorResType, rep)
 			dirs = append(dirs, []abi.Value{handle, m.guestPath})
 		}
@@ -926,6 +1050,7 @@ func wasiFilesystemOptions(fs *wasiFS, sockets *wasiSockets) []Option {
 			return []abi.Value{abi.ResultValue{IsErr: true, Payload: wasiErrorCodeNotPermitted}}, nil
 		}
 		writable := descFlags&wasiDescFlagWrite != 0
+		readable := descFlags&wasiDescFlagRead != 0
 		// The open is real: it is what applies create/truncate/exclusive and
 		// what reports a missing path, a read-only mount, or a permission
 		// problem as the errno the guest gets back. The handle itself is
@@ -936,18 +1061,37 @@ func wasiFilesystemOptions(fs *wasiFS, sockets *wasiSockets) []Option {
 		// that asked for write-only (what std::fs::write does) gets O_WRONLY
 		// rather than an O_RDWR the mount might refuse on a file it is only
 		// allowed to write.
+		//
+		// readable/writable are then corrected to the mode the open
+		// actually used, which is what the descriptor records and what
+		// [method]descriptor.get-flags reports back (see getFlags): the two
+		// differ from the request only where this switch overrides it.
 		oflag := sys.O_RDONLY
 		switch {
-		case writable && descFlags&wasiDescFlagRead != 0:
+		case writable && readable:
 			oflag = sys.O_RDWR
 		case writable:
 			oflag = sys.O_WRONLY
+		default:
+			// Neither bit, or read alone: there is no mode below O_RDONLY to
+			// fall back to, so a descriptor opened with empty
+			// descriptor-flags is a readable one -- read-via-stream works
+			// through it, and saying otherwise would be a lie a guest could
+			// act on.
+			readable = true
 		}
 		if openFlags&wasiOpenFlagDirectory != 0 {
 			// A directory open (discovered via std::fs::read_dir("/"), whose
 			// first host call is exactly open-at(root, ".", DIRECTORY)) must
 			// stay read-only: a real open(2) refuses O_RDWR on a directory.
+			// The descriptor is therefore not a writable one whatever the
+			// guest asked for -- and a directory opened WITHOUT this flag but
+			// with the write bit never gets a descriptor at all, since the
+			// mount refuses a write-mode open of a directory outright
+			// (EISDIR on POSIX, whatever the platform says elsewhere), so no
+			// directory descriptor can ever report `write`.
 			oflag = sys.O_RDONLY | sys.O_DIRECTORY
+			readable, writable = true, false
 		} else {
 			if openFlags&wasiOpenFlagCreate != 0 {
 				oflag |= sys.O_CREAT
@@ -978,7 +1122,7 @@ func wasiFilesystemOptions(fs *wasiFS, sockets *wasiSockets) []Option {
 		if err != nil {
 			return nil, err
 		}
-		rep := fs.newDescRep(&fsDescNode{fs: node.fs, mount: node.mount, path: full, isDir: isDir, writable: writable})
+		rep := fs.newDescRep(&fsDescNode{fs: node.fs, mount: node.mount, path: full, isDir: isDir, readable: readable, writable: writable})
 		handle := resources.NewOwn(wasiDescriptorResType, rep)
 		return []abi.Value{abi.ResultValue{IsErr: false, Payload: handle}}, nil
 	}
@@ -1001,6 +1145,67 @@ func wasiFilesystemOptions(fs *wasiFS, sockets *wasiSockets) []Option {
 		}
 		return fsOkResult(fsDescriptorType(st.Mode)), nil
 	}
+
+	// getFlags implements [method]descriptor.get-flags(self:
+	// borrow<descriptor>) -> result<descriptor-flags, error-code>, which a
+	// real CPython (componentize-py) guest reaches through the
+	// preview1-to-preview2 adapter's fd_fdstat_get -- the host half of
+	// Python's os.fstat/io mode checks, and of every std that asks "was
+	// this opened for reading, for writing, or both?".
+	//
+	// The answer is read straight off the descriptor node, with no call to
+	// the mount: descriptor-flags describes how the descriptor was OPENED
+	// (the access mode open-at's `flags` argument resolved to), not what the
+	// underlying path would permit -- the same distinction fcntl(fd,
+	// F_GETFL) draws, and the reason a descriptor opened read-only on a
+	// writable file must still report only `read`. That also means this func
+	// has no error branch of its own: an unknown rep is the shared fail-loud
+	// descNode error, and everything else is Ok.
+	//
+	// Only read/write are ever reported. The three sync bits
+	// (file-integrity-sync, data-integrity-sync, requested-write-sync) are
+	// O_SYNC/O_DSYNC/O_RSYNC, which open-at never requests, and
+	// mutate-directory is deliberately claimed for no descriptor -- see
+	// getDirectories for why.
+	getFlags := func(_ context.Context, args []abi.Value) ([]abi.Value, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("[method]descriptor.get-flags: expected 1 arg (self), got %d", len(args))
+		}
+		selfRep, ok := args[0].(uint32)
+		if !ok {
+			return nil, fmt.Errorf("[method]descriptor.get-flags: self: expected uint32 rep, got %T", args[0])
+		}
+		node, err := fs.descNode(selfRep)
+		if err != nil {
+			return nil, fmt.Errorf("[method]descriptor.get-flags: %w", err)
+		}
+		var flags uint32
+		if node.readable {
+			flags |= wasiDescFlagRead
+		}
+		if node.writable {
+			flags |= wasiDescFlagWrite
+		}
+		return fsOkResult(flags), nil
+	}
+
+	// syncFn implements [method]descriptor.sync(self: borrow<descriptor>) ->
+	// result<_, error-code> -- Python's os.fsync, which a real CPython
+	// (componentize-py) guest reaches during a pip wheel install. (Named
+	// syncFn rather than sync only because this file imports the sync
+	// package.)
+	syncFn := fsSyncFunc(fs, "sync", sys.File.Sync)
+
+	// syncDataFn implements [method]descriptor.sync-data -- sync's sibling
+	// (POSIX fdatasync, Python's os.fdatasync), registered for the same
+	// reason append-via-stream is (see this file's package doc): no fixture
+	// calls it yet, but it is one Datasync call away from a func that is
+	// already here, and a guest that does call it would otherwise hit the
+	// graph engine's trap stub. sys.File's Datasync is a real fdatasync(2)
+	// on Linux and dispatches to a full fsync everywhere else
+	// (internal/sysfs) -- syncing more than asked is always a legal answer
+	// to "flush this file's data".
+	syncDataFn := fsSyncFunc(fs, "sync-data", sys.File.Datasync)
 
 	stat := func(_ context.Context, args []abi.Value) ([]abi.Value, error) {
 		if len(args) != 1 {
@@ -1553,6 +1758,9 @@ func wasiFilesystemOptions(fs *wasiFS, sockets *wasiSockets) []Option {
 	fsErrFD, fsErrResolve := wasiFilesystemErrorCodeSig()
 	openAtFD, openAtResolve := wasiOpenAtSig()
 	getTypeFD, getTypeResolve := wasiGetTypeSig()
+	getFlagsFD, getFlagsResolve := wasiGetFlagsSig()
+	syncFD, syncResolve := wasiSyncSig()
+	syncDataFD, syncDataResolve := wasiSyncSig()
 	statFD, statResolve := wasiStatSig()
 	statAtFD, statAtResolve := wasiStatAtSig()
 	readDirectoryFD, readDirectoryResolve := wasiReadDirectorySig()
@@ -1594,6 +1802,9 @@ func wasiFilesystemOptions(fs *wasiFS, sockets *wasiSockets) []Option {
 		withImportCustom(wasiIfaceFilesystemTypes, "filesystem-error-code", filesystemErrorCode, fsErrFD, fsErrResolve),
 		withImportCustom(wasiIfaceFilesystemTypes, "[method]descriptor.open-at", openAt, openAtFD, openAtResolve),
 		withImportCustom(wasiIfaceFilesystemTypes, "[method]descriptor.get-type", getType, getTypeFD, getTypeResolve),
+		withImportCustom(wasiIfaceFilesystemTypes, "[method]descriptor.get-flags", getFlags, getFlagsFD, getFlagsResolve),
+		withImportCustom(wasiIfaceFilesystemTypes, "[method]descriptor.sync", syncFn, syncFD, syncResolve),
+		withImportCustom(wasiIfaceFilesystemTypes, "[method]descriptor.sync-data", syncDataFn, syncDataFD, syncDataResolve),
 		withImportCustom(wasiIfaceFilesystemTypes, "[method]descriptor.stat", stat, statFD, statResolve),
 		withImportCustom(wasiIfaceFilesystemTypes, "[method]descriptor.stat-at", statAt, statAtFD, statAtResolve),
 		withImportCustom(wasiIfaceFilesystemTypes, "[method]descriptor.read-directory", readDirectory, readDirectoryFD, readDirectoryResolve),
@@ -1731,6 +1942,45 @@ func wasiGetTypeSig() (binary.FuncDesc, abi.Resolver) {
 	okRef := wasiDescriptorTypeType(tbl)
 	errRef := wasiErrorCodeType(tbl)
 	resultRef := tbl.add(binary.ResultDesc{Ok: &okRef, Err: &errRef})
+	fd := binary.FuncDesc{
+		Params:  []binary.FuncParam{{Name: "self", Type: selfRef}},
+		Results: binary.FuncResults{Unnamed: &resultRef},
+	}
+	return fd, tbl.resolver()
+}
+
+// wasiGetFlagsSig builds the FuncDesc/resolver for
+// [method]descriptor.get-flags(self: borrow<descriptor>) ->
+// result<descriptor-flags, error-code>. descriptor-flags' field list is in
+// exact WIT declaration order, and must stay identical to open-at's own
+// (wasiOpenAtSig) -- it is the same WIT type, and wasiDescFlagRead/
+// wasiDescFlagWrite are positions in this list.
+func wasiGetFlagsSig() (binary.FuncDesc, abi.Resolver) {
+	tbl := &typeTable{}
+	selfRef := tbl.add(binary.BorrowDesc{ResourceType: wasiDescriptorResType})
+	okRef := tbl.add(binary.FlagsDesc{Names: []string{
+		"read", "write", "file-integrity-sync", "data-integrity-sync",
+		"requested-write-sync", "mutate-directory",
+	}})
+	errRef := wasiErrorCodeType(tbl)
+	resultRef := tbl.add(binary.ResultDesc{Ok: &okRef, Err: &errRef})
+	fd := binary.FuncDesc{
+		Params:  []binary.FuncParam{{Name: "self", Type: selfRef}},
+		Results: binary.FuncResults{Unnamed: &resultRef},
+	}
+	return fd, tbl.resolver()
+}
+
+// wasiSyncSig builds the FuncDesc/resolver for
+// [method]descriptor.sync(self: borrow<descriptor>) -> result<_,
+// error-code> -- reused as-is for [method]descriptor.sync-data, which has
+// the identical WIT signature (see fsSyncFunc for why one Go builder
+// implements both).
+func wasiSyncSig() (binary.FuncDesc, abi.Resolver) {
+	tbl := &typeTable{}
+	selfRef := tbl.add(binary.BorrowDesc{ResourceType: wasiDescriptorResType})
+	errRef := wasiErrorCodeType(tbl)
+	resultRef := tbl.add(binary.ResultDesc{Err: &errRef})
 	fd := binary.FuncDesc{
 		Params:  []binary.FuncParam{{Name: "self", Type: selfRef}},
 		Results: binary.FuncResults{Unnamed: &resultRef},

--- a/internal/component/instance/wasi_fs.go
+++ b/internal/component/instance/wasi_fs.go
@@ -159,9 +159,11 @@ import (
 // Python source directly:
 //
 //   - [method]descriptor.get-flags, the adapter's fd_fdstat_get: "was this
-//     descriptor opened for reading, for writing, or both?". Answered from
-//     what open-at recorded on the descriptor, never from the mount -- see
-//     getFlags.
+//     descriptor opened for reading, for writing, or both, and may its
+//     contents be mutated?". The read/write answer comes from what open-at
+//     recorded on the descriptor, never from the mount; mutate-directory is
+//     advertised for every directory, mirroring the dirRightsBase posture
+//     wazy's own preview1 fd_fdstat_get already takes -- see getFlags.
 //   - [method]descriptor.sync, the adapter's fd_sync, which is os.fsync --
 //     pip calls it on every file it writes while installing a wheel. Its
 //     sibling [method]descriptor.sync-data (fd_datasync, os.fdatasync) is
@@ -284,23 +286,30 @@ const (
 	wasiOpenFlagTruncate  uint32 = 1 << 3
 )
 
-// wasi:filesystem/types' descriptor-flags bits this package handles (bits 0
-// and 1, per its WIT declaration order
+// wasi:filesystem/types' descriptor-flags bits this package handles (bits 0,
+// 1 and 5, per its WIT declaration order
 // read/write/file-integrity-sync/data-integrity-sync/requested-write-sync/
-// mutate-directory). A descriptor opened with the write bit set is the one
+// mutate-directory).
+//
+// A descriptor opened with the write bit set is the one
 // [method]descriptor.write-via-stream/append-via-stream may be called
 // against; every other descriptor (including the preopened root
 // directories) is write-via-stream-ineligible, matching a real OS refusing
-// to write through a read-only fd. Both bits are also remembered on the
+// to write through a read-only fd. Read and write are remembered on the
 // descriptor node verbatim, since [method]descriptor.get-flags' whole job is
-// to report back how a descriptor was opened (see getFlags). The remaining
-// four bits are never set by this package: the three sync bits are
-// O_SYNC/O_DSYNC/O_RSYNC, which open-at does not request, and
-// mutate-directory is a promise only the mount could keep -- see
-// getDirectories.
+// to report back how a descriptor was opened (see getFlags).
+//
+// mutate-directory is not stored: it is a property of being a directory, and
+// get-flags derives it from the node's isDir. It is reported for every
+// directory descriptor, whatever mount it came from -- see getFlags for the
+// advisory-capability reasoning and for its preview1 precedent.
+//
+// The three sync bits are never set: they are O_SYNC/O_DSYNC/O_RSYNC, which
+// open-at does not request.
 const (
-	wasiDescFlagRead  uint32 = 1 << 0
-	wasiDescFlagWrite uint32 = 1 << 1
+	wasiDescFlagRead            uint32 = 1 << 0
+	wasiDescFlagWrite           uint32 = 1 << 1
+	wasiDescFlagMutateDirectory uint32 = 1 << 5
 )
 
 // fsMount is one preopened directory: the sys.FS an FSConfig mount supplied,
@@ -977,21 +986,17 @@ func wasiFilesystemOptions(fs *wasiFS, sockets *wasiSockets) []Option {
 		}
 		dirs := make([]abi.Value, 0, len(fs.mounts))
 		for i, m := range fs.mounts {
-			// A preopen is readable and not writable, which is what
-			// [method]descriptor.get-flags reports for it. `read` is
-			// honest: the guest may list it, stat it, and open paths under
-			// it, which is every use a directory descriptor has here.
-			// `write` would not be: in descriptor-flags it means "this
-			// descriptor may be written through", i.e. write-via-stream/
-			// append-via-stream, and both answer is-directory against any
-			// directory descriptor -- the same thing a real open(2) does
-			// when asked for O_RDWR on a directory. The flag that would
-			// describe a *mutable* directory is mutate-directory, and this
-			// package deliberately claims that one for no descriptor: the
-			// mount alone decides whether a create/unlink/rename lands (a
-			// WithReadOnlyDirMount answers EROFS, a WithFSMount ENOSYS),
-			// and there is no race-free way to promise up front an answer
-			// only the mount can give.
+			// A preopen is readable and not writable. `read` is honest: the
+			// guest may list it, stat it, and open paths under it, which is
+			// every use a directory descriptor has here. `write` would not
+			// be: in descriptor-flags it means "this descriptor may be
+			// written through", i.e. write-via-stream/append-via-stream, and
+			// both answer is-directory against any directory descriptor --
+			// the same thing a real open(2) does when asked for O_RDWR on a
+			// directory. Mutating what is *inside* the directory
+			// (create-directory-at, unlink-file-at, rename-at) is the
+			// separate mutate-directory flag, which get-flags reports for
+			// every directory descriptor including this one -- see getFlags.
 			rep := fs.newDescRep(&fsDescNode{fs: m.fs, mount: i, path: ".", isDir: true, readable: true})
 			handle := resources.NewOwn(wasiDescriptorResType, rep)
 			dirs = append(dirs, []abi.Value{handle, m.guestPath})
@@ -1162,11 +1167,38 @@ func wasiFilesystemOptions(fs *wasiFS, sockets *wasiSockets) []Option {
 	// has no error branch of its own: an unknown rep is the shared fail-loud
 	// descNode error, and everything else is Ok.
 	//
-	// Only read/write are ever reported. The three sync bits
-	// (file-integrity-sync, data-integrity-sync, requested-write-sync) are
-	// O_SYNC/O_DSYNC/O_RSYNC, which open-at never requests, and
-	// mutate-directory is deliberately claimed for no descriptor -- see
-	// getDirectories for why.
+	// mutate-directory is reported for every directory descriptor, and for
+	// no other kind -- the flag is directory-scoped by definition (it
+	// governs create-directory-at/unlink-file-at/rename-at/link-at, all of
+	// which take a directory as self), so a regular-file descriptor
+	// carrying it would be meaningless.
+	//
+	// Crucially it is reported whatever mount the directory came from,
+	// including one that will refuse every mutation. A capability flag is
+	// advisory, not a guarantee of outcome: `write` on a file descriptor
+	// does not promise the next write beats ENOSPC either, and nobody reads
+	// it that way. wazy's own preview1 says exactly this already --
+	// fd_fdstat_get advertises dirRightsBase (RIGHT_PATH_CREATE_FILE,
+	// RIGHT_PATH_UNLINK_FILE, RIGHT_PATH_RENAME_SOURCE/TARGET, ...) for
+	// every directory descriptor unconditionally, WithReadOnlyDirMount or
+	// not, and lets the real operation return the real errno
+	// (imports/wasi_snapshot_preview1/fs.go's dirRightsBase). Since
+	// mutate-directory is WASI 0.2's successor to those rights, withholding
+	// it here would make wazy's two runtimes disagree about the same mount.
+	//
+	// The failure modes are not symmetric either. Reported on a read-only
+	// mount, a guest tries and gets error-code::read-only or ::unsupported
+	// from the operation itself: an errno it can print. Withheld, a guest
+	// that gates on the flag never calls at all, and the mount looks
+	// read-only with no errno anywhere to explain why -- and a guest gating
+	// on it is the concrete case here, since the preview1-to-preview2
+	// adapter synthesizes preview1 rights from this func's result, so a
+	// missing mutate-directory can become a missing RIGHT_PATH_CREATE_FILE
+	// and an ENOTCAPABLE raised inside the guest, before any host call.
+	//
+	// The three sync bits (file-integrity-sync, data-integrity-sync,
+	// requested-write-sync) are O_SYNC/O_DSYNC/O_RSYNC, which open-at never
+	// requests, so they are never reported.
 	getFlags := func(_ context.Context, args []abi.Value) ([]abi.Value, error) {
 		if len(args) != 1 {
 			return nil, fmt.Errorf("[method]descriptor.get-flags: expected 1 arg (self), got %d", len(args))
@@ -1185,6 +1217,9 @@ func wasiFilesystemOptions(fs *wasiFS, sockets *wasiSockets) []Option {
 		}
 		if node.writable {
 			flags |= wasiDescFlagWrite
+		}
+		if node.isDir {
+			flags |= wasiDescFlagMutateDirectory
 		}
 		return fsOkResult(flags), nil
 	}

--- a/internal/component/instance/wasi_fsops_test.go
+++ b/internal/component/instance/wasi_fsops_test.go
@@ -274,6 +274,13 @@ func listDir(t *testing.T, c *config, resources *handleTable, dirRep uint32) map
 	}
 }
 
+// wasiDirDescFlags is the descriptor-flags bitset get-flags reports for
+// every directory descriptor, on any mount: readable (a guest lists, stats
+// and opens through it), not writable (write means write-via-stream, which
+// every directory descriptor refuses with is-directory), and mutable as a
+// directory.
+const wasiDirDescFlags = wasiDescFlagRead | wasiDescFlagMutateDirectory
+
 // descFlagsOf drives [method]descriptor.get-flags against descRep and
 // returns the raw descriptor-flags bitset it reports.
 func descFlagsOf(t *testing.T, c *config, descRep uint32, what string) uint32 {
@@ -282,18 +289,16 @@ func descFlagsOf(t *testing.T, c *config, descRep uint32, what string) uint32 {
 }
 
 // TestWasiFS_GetFlags pins the exact descriptor-flags bitset get-flags
-// reports for every way a descriptor can come into existence: it must be the
-// access mode the open actually used, and nothing else -- never a guess from
-// the path's own permissions, and never one of the four bits this package
-// does not claim (the three sync bits and mutate-directory, see
-// wasiDescFlagRead's doc).
+// reports for every way a descriptor can come into existence: the access
+// mode the open actually used, plus mutate-directory for a directory --
+// never a guess from the path's own permissions, and never one of the three
+// sync bits this package does not claim (see wasiDescFlagRead's doc).
 func TestWasiFS_GetFlags(t *testing.T) {
 	c, resources, rootRep, _ := fsOpsFixture(t, map[string][]byte{"/f": []byte("f"), "/sub/x": []byte("x")})
 
-	// A preopened root is readable and not writable -- see getDirectories for
-	// why `write` on a directory would be a claim this package cannot keep.
-	if got := descFlagsOf(t, c, rootRep, "the preopened root"); got != wasiDescFlagRead {
-		t.Errorf("get-flags(the preopened root) = %#b, want read (%#b)", got, wasiDescFlagRead)
+	// A preopened root is readable, not writable, and mutable as a directory.
+	if got := descFlagsOf(t, c, rootRep, "the preopened root"); got != wasiDirDescFlags {
+		t.Errorf("get-flags(the preopened root) = %#b, want read|mutate-directory (%#b)", got, wasiDirDescFlags)
 	}
 
 	for _, tt := range []struct {
@@ -310,14 +315,21 @@ func TestWasiFS_GetFlags(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			rep := openRep(t, c, resources, rootRep, "f", 0, tt.descFlags)
-			if got := descFlagsOf(t, c, rep, tt.name); got != tt.want {
+			got := descFlagsOf(t, c, rep, tt.name)
+			if got != tt.want {
 				t.Fatalf("get-flags(a %s file descriptor) = %#b, want %#b", tt.name, got, tt.want)
+			}
+			// mutate-directory is directory-scoped by definition: a
+			// regular-file descriptor must never carry it.
+			if got&wasiDescFlagMutateDirectory != 0 {
+				t.Fatalf("get-flags(a %s file descriptor) = %#b, want no mutate-directory bit", tt.name, got)
 			}
 		})
 	}
 
-	// A directory descriptor reports read and never write, however it was
-	// asked for: the open is forced read-only either way.
+	// A subdirectory descriptor reports read|mutate-directory and never
+	// write, however it was asked for: the open is forced read-only either
+	// way, and what a guest may do *inside* it is mutate-directory's job.
 	for _, tt := range []struct {
 		name      string
 		descFlags uint32
@@ -327,8 +339,8 @@ func TestWasiFS_GetFlags(t *testing.T) {
 	} {
 		t.Run("directory "+tt.name, func(t *testing.T) {
 			rep := openRep(t, c, resources, rootRep, "sub", wasiOpenFlagDirectory, tt.descFlags)
-			if got := descFlagsOf(t, c, rep, "sub"); got != wasiDescFlagRead {
-				t.Fatalf("get-flags(a directory descriptor %s) = %#b, want read (%#b)", tt.name, got, wasiDescFlagRead)
+			if got := descFlagsOf(t, c, rep, "sub"); got != wasiDirDescFlags {
+				t.Fatalf("get-flags(a directory descriptor %s) = %#b, want read|mutate-directory (%#b)", tt.name, got, wasiDirDescFlags)
 			}
 		})
 	}
@@ -405,15 +417,23 @@ func TestWasiFS_Sync(t *testing.T) {
 }
 
 // TestWasiFS_Sync_ReadOnlyMount covers the two answers a mount with no write
-// surface gives. A file descriptor there can never have been opened for
+// surface gives sync. A file descriptor there can never have been opened for
 // writing (the mount refuses a write-mode open outright), so sync is the
 // spec's "succeeds with no effect". A directory descriptor does genuinely
 // ask the mount to sync, and wazy's read-only layer answers EBADF for that
 // -- the same thing wazy's own preview1 fd_sync reports for the same mount,
 // so the two runtimes cannot disagree about it.
+//
+// It also pins what get-flags says about that mount, which is the opposite
+// posture on purpose: a descriptor-flags bit is advisory, so the directories
+// still advertise mutate-directory and let the mutation itself carry the
+// refusal.
 func TestWasiFS_Sync_ReadOnlyMount(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "f"), []byte("f"), 0o644); err != nil {
+		t.Fatalf("seeding the mount: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
 		t.Fatalf("seeding the mount: %v", err)
 	}
 	c, resources := wasiFSConfig(t, WASIConfig{FS: wazy.NewFSConfig().WithReadOnlyDirMount(dir, "/")})
@@ -426,9 +446,25 @@ func TestWasiFS_Sync_ReadOnlyMount(t *testing.T) {
 			method+"(a read-only mount's directory)")
 	}
 
-	// get-flags agrees: nothing on such a mount is ever writable.
+	// get-flags agrees no file on such a mount is ever writable...
 	if got := descFlagsOf(t, c, fileRep, "a read-only mount's file"); got != wasiDescFlagRead {
 		t.Fatalf("get-flags(a read-only mount's file) = %#b, want read (%#b)", got, wasiDescFlagRead)
+	}
+	// ...but its directory descriptor still advertises mutate-directory. A
+	// capability flag is advisory: the guest is told it may try, and the
+	// mutation itself reports the mount's real refusal (below), exactly as
+	// wazy's preview1 hands out dirRightsBase for this same mount. Hiding
+	// the flag would make a guest that gates on it skip the call entirely
+	// and see a read-only filesystem with no errno to explain it.
+	if got := descFlagsOf(t, c, rootRep, "a read-only mount's root"); got != wasiDirDescFlags {
+		t.Fatalf("get-flags(a read-only mount's root) = %#b, want read|mutate-directory (%#b)", got, wasiDirDescFlags)
+	}
+	requireErrCode(t, callFS(t, c, "[method]descriptor.create-directory-at", rootRep, "d"),
+		wasiErrorCodeReadOnly, "create-directory-at on a read-only mount")
+
+	subRep := openRep(t, c, resources, rootRep, "sub", wasiOpenFlagDirectory, wasiDescFlagRead)
+	if got := descFlagsOf(t, c, subRep, "a read-only mount's subdirectory"); got != wasiDirDescFlags {
+		t.Fatalf("get-flags(a read-only mount's subdirectory) = %#b, want read|mutate-directory (%#b)", got, wasiDirDescFlags)
 	}
 }
 

--- a/internal/component/instance/wasi_fsops_test.go
+++ b/internal/component/instance/wasi_fsops_test.go
@@ -274,6 +274,183 @@ func listDir(t *testing.T, c *config, resources *handleTable, dirRep uint32) map
 	}
 }
 
+// descFlagsOf drives [method]descriptor.get-flags against descRep and
+// returns the raw descriptor-flags bitset it reports.
+func descFlagsOf(t *testing.T, c *config, descRep uint32, what string) uint32 {
+	t.Helper()
+	return requireOk(t, callFS(t, c, "[method]descriptor.get-flags", descRep), "get-flags("+what+")").(uint32)
+}
+
+// TestWasiFS_GetFlags pins the exact descriptor-flags bitset get-flags
+// reports for every way a descriptor can come into existence: it must be the
+// access mode the open actually used, and nothing else -- never a guess from
+// the path's own permissions, and never one of the four bits this package
+// does not claim (the three sync bits and mutate-directory, see
+// wasiDescFlagRead's doc).
+func TestWasiFS_GetFlags(t *testing.T) {
+	c, resources, rootRep, _ := fsOpsFixture(t, map[string][]byte{"/f": []byte("f"), "/sub/x": []byte("x")})
+
+	// A preopened root is readable and not writable -- see getDirectories for
+	// why `write` on a directory would be a claim this package cannot keep.
+	if got := descFlagsOf(t, c, rootRep, "the preopened root"); got != wasiDescFlagRead {
+		t.Errorf("get-flags(the preopened root) = %#b, want read (%#b)", got, wasiDescFlagRead)
+	}
+
+	for _, tt := range []struct {
+		name      string
+		descFlags uint32
+		want      uint32
+	}{
+		{"read-only", wasiDescFlagRead, wasiDescFlagRead},
+		{"write-only", wasiDescFlagWrite, wasiDescFlagWrite},
+		{"read-write", wasiDescFlagRead | wasiDescFlagWrite, wasiDescFlagRead | wasiDescFlagWrite},
+		// Empty descriptor-flags still open O_RDONLY, so the descriptor
+		// really is readable -- see openAt's switch.
+		{"neither bit requested", 0, wasiDescFlagRead},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rep := openRep(t, c, resources, rootRep, "f", 0, tt.descFlags)
+			if got := descFlagsOf(t, c, rep, tt.name); got != tt.want {
+				t.Fatalf("get-flags(a %s file descriptor) = %#b, want %#b", tt.name, got, tt.want)
+			}
+		})
+	}
+
+	// A directory descriptor reports read and never write, however it was
+	// asked for: the open is forced read-only either way.
+	for _, tt := range []struct {
+		name      string
+		descFlags uint32
+	}{
+		{"opened for reading", wasiDescFlagRead},
+		{"asking for write anyway", wasiDescFlagRead | wasiDescFlagWrite},
+	} {
+		t.Run("directory "+tt.name, func(t *testing.T) {
+			rep := openRep(t, c, resources, rootRep, "sub", wasiOpenFlagDirectory, tt.descFlags)
+			if got := descFlagsOf(t, c, rep, "sub"); got != wasiDescFlagRead {
+				t.Fatalf("get-flags(a directory descriptor %s) = %#b, want read (%#b)", tt.name, got, wasiDescFlagRead)
+			}
+		})
+	}
+
+	// get-flags never touches the mount: it answers for a descriptor whose
+	// path has since been removed exactly as it did before, which is what
+	// makes it a report about the descriptor and not about the file.
+	c2, resources2, rootRep2, dir2 := fsOpsFixture(t, map[string][]byte{"/gone": []byte("g")})
+	goneRep := openRep(t, c2, resources2, rootRep2, "gone", 0, wasiDescFlagRead|wasiDescFlagWrite)
+	if err := os.Remove(filepath.Join(dir2, "gone")); err != nil {
+		t.Fatalf("removing gone: %v", err)
+	}
+	if got := descFlagsOf(t, c2, goneRep, "a vanished path"); got != wasiDescFlagRead|wasiDescFlagWrite {
+		t.Fatalf("get-flags(a vanished path) = %#b, want read|write (%#b)", got, wasiDescFlagRead|wasiDescFlagWrite)
+	}
+}
+
+// TestWasiFS_Sync drives [method]descriptor.sync and its sibling
+// [method]descriptor.sync-data -- which share one implementation, so both
+// run the whole table -- across every descriptor shape fsSyncFunc
+// distinguishes: a directory (a real fsync of the directory), a file opened
+// for writing (a real fsync of the file, in the mode it was opened with),
+// and a file not opened for writing (Ok with no effect, per types.wit).
+func TestWasiFS_Sync(t *testing.T) {
+	for _, method := range []string{"[method]descriptor.sync", "[method]descriptor.sync-data"} {
+		t.Run(method, func(t *testing.T) {
+			c, resources, rootRep, dir := fsOpsFixture(t, map[string][]byte{"/f": []byte("payload"), "/d/x": []byte("x")})
+
+			rwRep := openRep(t, c, resources, rootRep, "f", 0, wasiDescFlagRead|wasiDescFlagWrite)
+			woRep := openRep(t, c, resources, rootRep, "f", 0, wasiDescFlagWrite)
+			roRep := openRep(t, c, resources, rootRep, "f", 0, wasiDescFlagRead)
+			dirRep := openRep(t, c, resources, rootRep, "d", wasiOpenFlagDirectory, wasiDescFlagRead)
+
+			for _, tt := range []struct {
+				name string
+				rep  uint32
+			}{
+				{"a read-write file descriptor", rwRep},
+				{"a write-only file descriptor", woRep},
+				{"a read-only file descriptor", roRep},
+				{"a directory descriptor", dirRep},
+				{"the preopened root", rootRep},
+			} {
+				requireOk(t, callFS(t, c, method, tt.rep), method+"("+tt.name+")")
+			}
+
+			// Bytes written through the descriptor are still there after the
+			// sync: syncing through a freshly opened handle is a flush, never
+			// a truncate or a reopen that could lose them (see fsSyncFunc).
+			writeVia(t, c, resources, rwRep, "synced!")
+			requireOk(t, callFS(t, c, method, rwRep), method+"(after a write)")
+			if got := hostRead(t, dir, "/f"); got != "synced!" {
+				t.Fatalf("/f after %s = %q, want %q", method, got, "synced!")
+			}
+
+			// The mount's own failure surfaces: with the file gone, the open
+			// this func has to do reports no-entry rather than claiming a
+			// successful sync of nothing.
+			if err := os.Remove(filepath.Join(dir, "f")); err != nil {
+				t.Fatalf("removing f: %v", err)
+			}
+			requireErrCode(t, callFS(t, c, method, rwRep), wasiErrorCodeNoEntry, method+"(a vanished file)")
+			// A descriptor not opened for writing never touches the mount, so
+			// it cannot report the mount's failure either -- it still answers
+			// Ok, which is the same "no effect" it always answered.
+			requireOk(t, callFS(t, c, method, roRep), method+"(a vanished file, read-only descriptor)")
+
+			if err := os.RemoveAll(filepath.Join(dir, "d")); err != nil {
+				t.Fatalf("removing d: %v", err)
+			}
+			requireErrCode(t, callFS(t, c, method, dirRep), wasiErrorCodeNoEntry, method+"(a vanished directory)")
+		})
+	}
+}
+
+// TestWasiFS_Sync_ReadOnlyMount covers the two answers a mount with no write
+// surface gives. A file descriptor there can never have been opened for
+// writing (the mount refuses a write-mode open outright), so sync is the
+// spec's "succeeds with no effect". A directory descriptor does genuinely
+// ask the mount to sync, and wazy's read-only layer answers EBADF for that
+// -- the same thing wazy's own preview1 fd_sync reports for the same mount,
+// so the two runtimes cannot disagree about it.
+func TestWasiFS_Sync_ReadOnlyMount(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f"), []byte("f"), 0o644); err != nil {
+		t.Fatalf("seeding the mount: %v", err)
+	}
+	c, resources := wasiFSConfig(t, WASIConfig{FS: wazy.NewFSConfig().WithReadOnlyDirMount(dir, "/")})
+	rootRep := rootHandleRep(t, resources, rootDescriptorHandle(t, c))
+	fileRep := openRep(t, c, resources, rootRep, "f", 0, wasiDescFlagRead)
+
+	for _, method := range []string{"[method]descriptor.sync", "[method]descriptor.sync-data"} {
+		requireOk(t, callFS(t, c, method, fileRep), method+"(a read-only mount's file)")
+		requireErrCode(t, callFS(t, c, method, rootRep), wasiErrorCodeBadDescriptor,
+			method+"(a read-only mount's directory)")
+	}
+
+	// get-flags agrees: nothing on such a mount is ever writable.
+	if got := descFlagsOf(t, c, fileRep, "a read-only mount's file"); got != wasiDescFlagRead {
+		t.Fatalf("get-flags(a read-only mount's file) = %#b, want read (%#b)", got, wasiDescFlagRead)
+	}
+}
+
+// writeVia writes s through fileRep's own write-via-stream, the way a guest
+// does, so a test can assert on what a following sync did not disturb.
+func writeVia(t *testing.T, c *config, resources *handleTable, fileRep uint32, s string) {
+	t.Helper()
+	streamHandle := requireOk(t, callFS(t, c, "[method]descriptor.write-via-stream", fileRep, uint64(0)), "write-via-stream").(uint32)
+	streamRep, err := resources.Rep(wasiOutputStreamResType, streamHandle)
+	if err != nil {
+		t.Fatalf("resolve output-stream handle: %v", err)
+	}
+	results, err := wasiFSFn(t, c, wasiIfaceStreams, "[method]output-stream.write")(
+		context.Background(), []abi.Value{streamRep, wasiListFromBytes([]byte(s))})
+	if err != nil {
+		t.Fatalf("output-stream.write: %v", err)
+	}
+	if rv := results[0].(abi.ResultValue); rv.IsErr {
+		t.Fatalf("output-stream.write: unexpected Err: %#v", rv.Payload)
+	}
+}
+
 // TestFSErrorCode pins the errno -> error-code mapping, including the
 // catch-all: an errno with no specific counterpart must report `io` rather
 // than silently claiming something more specific.
@@ -356,6 +533,14 @@ func TestWasiFS_ArgValidation_AtMethods(t *testing.T) {
 		{"read-directory count", "[method]descriptor.read-directory", nil, "expected 1 arg"},
 		{"read-directory self", "[method]descriptor.read-directory", []abi.Value{"bad"}, "self: expected uint32"},
 
+		{"get-flags count", "[method]descriptor.get-flags", []abi.Value{uint32(1), uint32(2)}, "expected 1 arg"},
+		{"get-flags self", "[method]descriptor.get-flags", []abi.Value{"bad"}, "self: expected uint32"},
+
+		{"sync count", "[method]descriptor.sync", nil, "expected 1 arg"},
+		{"sync self", "[method]descriptor.sync", []abi.Value{"bad"}, "self: expected uint32"},
+		{"sync-data count", "[method]descriptor.sync-data", []abi.Value{uint32(1), uint32(2)}, "expected 1 arg"},
+		{"sync-data self", "[method]descriptor.sync-data", []abi.Value{"bad"}, "self: expected uint32"},
+
 		{"read-directory-entry count", "[method]directory-entry-stream.read-directory-entry", nil, "expected 1 arg"},
 		{"read-directory-entry self", "[method]directory-entry-stream.read-directory-entry", []abi.Value{"bad"}, "self: expected uint32"},
 
@@ -406,6 +591,9 @@ func TestWasiFS_UnknownReps(t *testing.T) {
 	}{
 		{"open-at", "[method]descriptor.open-at", []abi.Value{dead, uint32(0), "p", uint32(0), uint32(0)}, "does not name a live descriptor"},
 		{"stat", "[method]descriptor.stat", []abi.Value{dead}, "does not name a live descriptor"},
+		{"get-flags", "[method]descriptor.get-flags", []abi.Value{dead}, "does not name a live descriptor"},
+		{"sync", "[method]descriptor.sync", []abi.Value{dead}, "does not name a live descriptor"},
+		{"sync-data", "[method]descriptor.sync-data", []abi.Value{dead}, "does not name a live descriptor"},
 		{"stat-at", "[method]descriptor.stat-at", []abi.Value{dead, uint32(0), "p"}, "does not name a live descriptor"},
 		{"read-directory", "[method]descriptor.read-directory", []abi.Value{dead}, "does not name a live descriptor"},
 		{"unlink-file-at", "[method]descriptor.unlink-file-at", []abi.Value{dead, "p"}, "does not name a live descriptor"},


### PR DESCRIPTION
Adds the two `wasi:filesystem/types@0.2.3` descriptor methods a real CPython
(componentize-py) guest calls and this package did not implement, plus their
sibling. All three were declared imports left to the graph engine's trap
stub.

- `[method]descriptor.get-flags(self) -> result<descriptor-flags, error-code>`
  — the preview1-to-preview2 adapter's `fd_fdstat_get`.
- `[method]descriptor.sync(self) -> result<_, error-code>` — the adapter's
  `fd_sync`, i.e. Python's `os.fsync`, which pip calls on every file it
  writes while installing a wheel.
- `[method]descriptor.sync-data` — `fdatasync`/`os.fdatasync`, sharing sync's
  implementation.

Everything is in `internal/component/instance/wasi_fs.go` and its tests;
`graph.go`/`shim.go` are untouched.

## get-flags

The answer comes off the descriptor node, never from the mount:
descriptor-flags reports how a descriptor was **opened**, not what its path
happens to permit today — the distinction `fcntl(fd, F_GETFL)` draws. So
`fsDescNode` gains a `readable` field next to `writable`, and `open-at` now
records the access mode its `oflag` switch actually resolved to rather than
the raw request:

- empty descriptor-flags still open `O_RDONLY`, so such a descriptor reports
  `read` (read-via-stream genuinely works through it; saying otherwise would
  be a lie a guest could act on);
- a directory open is forced read-only, so it reports `read` and never
  `write` — and a directory opened *without* the directory open-flag but
  *with* the write bit never yields a descriptor at all, since the mount
  refuses a write-mode open of a directory. No directory descriptor can
  report `write`.

**Preopen roots report `read | mutate-directory`.** `write` in
descriptor-flags means "this descriptor may be written through"
(write-via-stream / append-via-stream), and both already answer
`is-directory` for any directory descriptor, exactly as a real `open(2)`
refuses `O_RDWR` on a directory. Mutating what is *inside* the directory is
the separate `mutate-directory` bit.

**`mutate-directory` is advertised for every directory descriptor, on any
mount — including one that will refuse every mutation**, and for no
non-directory descriptor (the flag governs
create-directory-at/unlink-file-at/rename-at/link-at, all of which take a
directory as `self`, so it is directory-scoped by definition). Reasons:

- **wazy's own preview1 already takes this posture.** `fd_fdstat_get`
  advertises `dirRightsBase` — `RIGHT_PATH_CREATE_DIRECTORY`,
  `RIGHT_PATH_CREATE_FILE`, `RIGHT_PATH_UNLINK_FILE`,
  `RIGHT_PATH_RENAME_SOURCE/TARGET`, `RIGHT_PATH_SYMLINK`,
  `RIGHT_PATH_REMOVE_DIRECTORY` — for every directory descriptor
  unconditionally, `WithReadOnlyDirMount` or not, and lets the real
  operation return the real errno
  (`imports/wasi_snapshot_preview1/fs.go`'s `dirRightsBase`).
  `mutate-directory` is WASI 0.2's successor to those rights, so
  withholding it would make wazy's two runtimes disagree about the same
  mount — the property the `sync` design deliberately preserves.
- **Capability flags are advisory, not outcome guarantees.** `O_RDWR` does
  not promise the next write beats ENOSPC; reporting `write` on a full disk
  is not a broken promise, and neither is this.
- **The failure modes are asymmetric.** Advertised on a read-only mount, a
  guest tries and gets `read-only`/`unsupported` from the operation itself:
  correct and debuggable. Withheld, a guest that gates on the flag never
  calls, and the mount looks read-only with no errno anywhere. Gating is the
  concrete case here — the preview1-to-preview2 adapter synthesizes preview1
  rights from `get-flags`, so a missing `mutate-directory` can become a
  missing `RIGHT_PATH_CREATE_FILE` and an ENOTCAPABLE raised inside the
  guest before any host call. The consumer driving this work is CPython
  installing a pip wheel: create-directory + create-file + rename in a loop.

The bit is derived from the node's `isDir` at call time; nothing is stored
on `fsDescNode` for it. The three sync bits are `O_SYNC`/`O_DSYNC`/`O_RSYNC`,
which `open-at` never requests, so they are never reported.

get-flags has no error branch of its own — an unknown rep is the shared
fail-loud `descNode` error every other method uses, and everything else is
`Ok`.

## sync (and the no-cached-fd question)

A descriptor here holds no open `sys.File`, so sync opens the path, syncs,
and closes. That reads odd — fsyncing a handle opened moments ago — until
you notice what `fsync(2)` names: **the file, not the descriptor**. It
flushes the inode's dirty pages and metadata, state shared by every open
handle, so a sync through a fresh handle is indistinguishable from one
through a handle held since the guest's own open. Nothing is lost by not
caching either: this package buffers no writes of its own (writes `Pwrite`
straight to the mount), so a cached fd would have nothing extra to give the
kernel. Caching would only reintroduce the host-handle leak `fsDescNode`'s
no-open-file rule exists to prevent — a leak per descriptor a guest drops
without saying so, or abandons mid-call. Kept uncached, and the reasoning is
in `fsSyncFunc`'s doc rather than left implicit.

What each descriptor kind does:

| descriptor | behavior |
| --- | --- |
| directory | real sync, opened `O_RDONLY\|O_DIRECTORY` — fsync on a directory is what makes a create/unlink/rename durable, so no-oping it would quietly break the guest that does the right thing |
| file opened for writing | real sync, in the mode it was opened with (mirrors `open-at`'s own `O_RDWR`/`O_WRONLY` choice) |
| file not opened for writing | `Ok` with no effect |

The last row is `types.wit`'s own sentence ("This function succeeds with no
effect if the file descriptor is not opened for writing") and it is also the
only answer that is the same everywhere: POSIX `fsync(2)` on a read-only fd
is a successful no-op, but Windows' `FlushFileBuffers` refuses a handle
without write access, so honoring the call literally would make one guest's
`os.fsync` succeed on Linux and fail on Windows for no reason the guest could
act on.

A read-only mount therefore answers `Ok` for a file descriptor (never
writable there) and `bad-descriptor` for a directory one — wazy's read-only
layer has no sync surface at all, and that is the same answer wazy's own
preview1 `fd_sync` gives for that mount, so the two runtimes cannot disagree.

## sync-data

Added: it is one `sys.File.Datasync` call away from a func that is already
here, sharing `fsSyncFunc` and `wasiSyncSig` with sync, so a guest that calls
`os.fdatasync` does not hit a trap stub. Same precedent as append-via-stream,
which this package registered for exactly that reason. `Datasync` is a real
`fdatasync(2)` on Linux and dispatches to a full fsync elsewhere — syncing
more than asked is always a legal answer.

## Tests and evidence

New in `wasi_fsops_test.go`, driving the registered host funcs against real
`t.TempDir()` mounts (no fixtures, nothing to embed):

- `TestWasiFS_GetFlags` — exact bitsets for read-only, write-only,
  read-write and empty-flags file descriptors (each also asserted *not* to
  carry `mutate-directory`); the preopened root and a subdirectory opened
  with `open-flags::directory`, both ways (including one that asked for
  write), asserted as `read|mutate-directory`; and a descriptor whose path
  was removed out from under it (get-flags never touches the mount).
- `TestWasiFS_Sync` — runs the whole table for both sync and sync-data:
  every descriptor shape succeeds, a write-then-sync round trip leaves the
  bytes on the mount, a vanished file surfaces the mount's `no-entry`
  (while a read-only descriptor of the same vanished file still answers Ok,
  since it never opens), and a vanished directory surfaces it too.
- `TestWasiFS_Sync_ReadOnlyMount` — sync: Ok for the file, `bad-descriptor`
  for the directory. get-flags: no file there is writable, but the root and
  a subdirectory both still advertise `mutate-directory` — with a following
  `create-directory-at` asserted to fail `read-only`, which is exactly the
  advisory-flag contract.
- Rows added to the existing arg-shape and unknown-rep tables for all three
  methods.

All assertions are on errnos the platform layer normalizes or on pure-Go
paths (`readFile.Sync`'s EBADF), so nothing is Linux-specific.

- `go build ./... && go test ./...` green, `-race` green for the fs/conformance tests.
- The ~35 `conformance_test.go` fixtures still match their wasmtime goldens byte for byte.
- `internal/component/instance` coverage 90.2% (unchanged from `origin/main`); `fsSyncFunc` 100%, `getFlags` fully covered including both `isDir` branches.
- `make lint`: 102 issues, identical to the `origin/main` baseline.
- Cross-compiles clean for plan9/js/wasip1/aix/freebsd/windows/darwin and GOARCH=386/arm.

Note: a real CPython guest cannot reach these methods yet — it fails earlier,
during component graph instantiation, which is a separate parallel PR. This
change is independently verified at the host-func level and does not depend
on it.
