### PR TITLE
fix(component): resolve core instances by identity, not consumer name

### DIFF
--- a/internal/component/binary/component.go
+++ b/internal/component/binary/component.go
@@ -34,6 +34,12 @@ type Component struct {
 	// componentfuncspace.go.
 	ComponentFuncSpace []ComponentFuncSpaceEntry
 
+	// ComponentInstanceSpace is the component's instance index space, one
+	// entry per instance-producing definition (instance import / instance
+	// definition / instance alias / instance export) in overall declaration
+	// order across sections. See componentinstancespace.go.
+	ComponentInstanceSpace []ComponentInstanceSpaceEntry
+
 	// CoreModules are embedded core wasm modules (section 1).
 	CoreModules []CoreModule
 

--- a/internal/component/binary/componentinstancespace.go
+++ b/internal/component/binary/componentinstancespace.go
@@ -1,0 +1,101 @@
+package binary
+
+// This file implements the COMPONENT-level instance index space, the
+// instance-sort counterpart of componentfuncspace.go's func index space.
+//
+// Per the component-model binary format, the component instance index space is
+// populated, in declaration order across sections, by every definition that
+// yields a component instance:
+//   - an instance import   (section 10, externdesc sort instance 0x05)
+//   - an instance definition (section 5) -- either `(instantiate <componentidx>
+//     <instantiatearg>*)` or the inline-export form
+//   - an instance alias    (section 6, Sort == 0x05)
+//   - an instance export   (section 11, externdesc sort instance 0x05) --
+//     Binary.md is explicit that "all exports (of all sorts) introduce a new
+//     index that aliases the exported definition and can be used by all
+//     subsequent definitions just like an alias", so exporting an instance
+//     shifts every LATER instance definition's index.
+//
+// That last producer is why the space has to exist. wit-component emits a
+// component's exported interfaces as an interleaved
+// `(instance ...) (export ...) (instance ...) (export ...)` run -- a real
+// componentize-py CPython component does exactly this -- so the flat
+// `exp.ExternIndex - numImportedInstances` arithmetic instance.go used lands
+// one slot short for every export after the first, either binding the wrong
+// nested instance or failing outright with an out-of-range error.
+//
+// Like TypeSpace / CoreFuncSpace / ComponentFuncSpace, this is built
+// incrementally by decodeComponent in file order, so it stays correct even
+// when sections interleave or repeat.
+
+// ComponentInstanceSpaceEntryKind distinguishes what produced a component
+// instance index-space entry.
+type ComponentInstanceSpaceEntryKind byte
+
+const (
+	// ComponentInstanceFromImport: an instance import (section 10, sort instance).
+	ComponentInstanceFromImport ComponentInstanceSpaceEntryKind = iota
+	// ComponentInstanceFromDefinition: an instance definition (section 5).
+	ComponentInstanceFromDefinition
+	// ComponentInstanceFromAlias: an instance alias (section 6, Sort == 0x05).
+	ComponentInstanceFromAlias
+	// ComponentInstanceFromExport: an instance export (section 11, sort
+	// instance) -- an alias of the exported instance into the next instance
+	// index.
+	ComponentInstanceFromExport
+)
+
+// ComponentInstanceSpaceEntry is one entry in the component's instance index
+// space. Exactly one of Import/Instance/Alias/Export is meaningful, selected by
+// Kind.
+type ComponentInstanceSpaceEntry struct {
+	Kind     ComponentInstanceSpaceEntryKind
+	Import   uint32 // index into Component.Imports   (Kind == ComponentInstanceFromImport)
+	Instance uint32 // index into Component.Instances (Kind == ComponentInstanceFromDefinition)
+	Alias    uint32 // index into Component.Aliases   (Kind == ComponentInstanceFromAlias)
+	Export   uint32 // index into Component.Exports   (Kind == ComponentInstanceFromExport)
+}
+
+// resolveInstanceMaxDepth bounds ResolveComponentInstance's export-alias chain
+// walk. A well-formed binary can only ever chain forward-declared exports, so
+// this is a defensive guard against a hand-built or corrupt structure, not a
+// real limit.
+const resolveInstanceMaxDepth = 64
+
+// ResolveComponentInstance resolves a component instance index to the index in
+// Component.Instances of the instance DEFINITION it ultimately names, following
+// export aliases (an `(export "x" (instance N))` both re-exports instance N and
+// introduces a new instance index aliasing it).
+//
+// ok is false when the index is out of range, names an imported instance, or
+// names an alias this decoder does not resolve structurally (an outer alias, or
+// an alias of another instance's instance-typed export). Callers that need to
+// distinguish those cases should inspect ComponentInstanceSpace directly.
+//
+// It returns (0, false) for a component that was not produced by Decode: a
+// hand-built Component has no instance index space at all, and the caller is
+// expected to fall back to its own arithmetic (see instance.go's
+// componentInstanceDef).
+func (c *Component) ResolveComponentInstance(idx uint32) (int, bool) {
+	for depth := 0; depth < resolveInstanceMaxDepth; depth++ {
+		if int(idx) >= len(c.ComponentInstanceSpace) {
+			return 0, false
+		}
+		e := c.ComponentInstanceSpace[idx]
+		switch e.Kind {
+		case ComponentInstanceFromDefinition:
+			if int(e.Instance) >= len(c.Instances) {
+				return 0, false
+			}
+			return int(e.Instance), true
+		case ComponentInstanceFromExport:
+			if int(e.Export) >= len(c.Exports) {
+				return 0, false
+			}
+			idx = c.Exports[e.Export].ExternIndex
+		default: // import or alias: not an instance definition of this component
+			return 0, false
+		}
+	}
+	return 0, false
+}

--- a/internal/component/binary/componentinstancespace_test.go
+++ b/internal/component/binary/componentinstancespace_test.go
@@ -1,0 +1,132 @@
+package binary
+
+import (
+	"bytes"
+	"testing"
+)
+
+// synthComponent assembles a component binary from already-encoded sections,
+// in the order given -- which is exactly what the index spaces are built from.
+func synthComponent(sections ...[]byte) []byte {
+	var b bytes.Buffer
+	b.Write([]byte{0x00, 0x61, 0x73, 0x6d}) // magic
+	b.Write([]byte{0x0d, 0x00})             // version 13
+	b.Write([]byte{0x01, 0x00})             // layer 1 (component)
+	for _, s := range sections {
+		b.Write(s)
+	}
+	return b.Bytes()
+}
+
+func synthSection(id byte, body []byte) []byte {
+	out := []byte{id}
+	out = append(out, byte(len(body))) // every body here is < 128 bytes
+	return append(out, body...)
+}
+
+func synthLabel(s string) []byte {
+	return append([]byte{byte(len(s))}, s...)
+}
+
+// synthInstanceImport encodes one `(import "n" (instance <typeidx>))`.
+func synthInstanceImport(name string) []byte {
+	body := []byte{0x00} // externname kind
+	body = append(body, synthLabel(name)...)
+	body = append(body, 0x05, 0x00) // externdesc: instance, type index 0
+	return body
+}
+
+// synthInlineInstance encodes one inline-export instance definition with no
+// members -- enough to occupy an index-space slot.
+func synthInlineInstance() []byte { return []byte{0x01, 0x00} }
+
+// synthInstanceExport encodes one `(export "n" (instance <idx>))`.
+func synthInstanceExport(name string, idx byte) []byte {
+	body := []byte{0x00}
+	body = append(body, synthLabel(name)...)
+	body = append(body, 0x05, idx, 0x00) // sortidx: instance <idx>; no ascribed type
+	return body
+}
+
+// The whole point of ComponentInstanceSpace: an instance export introduces an
+// aliasing index, so a definition declared AFTER it lands one slot later than
+// the flat [imports]++[definitions] model predicts. This is the exact shape
+// wit-component emits for a component with two exported interfaces.
+func TestComponentInstanceSpace_ExportsShiftLaterDefinitions(t *testing.T) {
+	// An instance type must exist for the import's externdesc to name.
+	typeSec := synthSection(7, []byte{0x01, 0x42, 0x00}) // one instancetype with no decls
+	raw := synthComponent(
+		typeSec,
+		synthSection(10, append([]byte{0x01}, synthInstanceImport("imported")...)),
+		synthSection(5, append([]byte{0x01}, synthInlineInstance()...)),
+		synthSection(11, append([]byte{0x01}, synthInstanceExport("first", 1)...)),
+		synthSection(5, append([]byte{0x01}, synthInlineInstance()...)),
+		synthSection(11, append([]byte{0x01}, synthInstanceExport("second", 3)...)),
+	)
+	c, err := Decode(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := []ComponentInstanceSpaceEntry{
+		{Kind: ComponentInstanceFromImport, Import: 0},
+		{Kind: ComponentInstanceFromDefinition, Instance: 0},
+		{Kind: ComponentInstanceFromExport, Export: 0},
+		{Kind: ComponentInstanceFromDefinition, Instance: 1},
+		{Kind: ComponentInstanceFromExport, Export: 1},
+	}
+	if len(c.ComponentInstanceSpace) != len(want) {
+		t.Fatalf("instance space: got %+v, want %+v", c.ComponentInstanceSpace, want)
+	}
+	for i := range want {
+		if c.ComponentInstanceSpace[i] != want[i] {
+			t.Errorf("instance space[%d]: got %+v, want %+v", i, c.ComponentInstanceSpace[i], want[i])
+		}
+	}
+
+	// The second export's sortidx (3) must resolve to the SECOND definition.
+	// The flat model would compute 3-1 == 2, past the end of Instances.
+	if def, ok := c.ResolveComponentInstance(3); !ok || def != 1 {
+		t.Errorf("ResolveComponentInstance(3): got (%d, %v), want (1, true)", def, ok)
+	}
+	if def, ok := c.ResolveComponentInstance(1); !ok || def != 0 {
+		t.Errorf("ResolveComponentInstance(1): got (%d, %v), want (0, true)", def, ok)
+	}
+	// An export index resolves THROUGH to the definition it aliases.
+	if def, ok := c.ResolveComponentInstance(2); !ok || def != 0 {
+		t.Errorf("ResolveComponentInstance(2): got (%d, %v), want (0, true)", def, ok)
+	}
+	// An imported instance is not a local definition.
+	if _, ok := c.ResolveComponentInstance(0); ok {
+		t.Error("ResolveComponentInstance(0) names an import; want ok=false")
+	}
+	// Out of range.
+	if _, ok := c.ResolveComponentInstance(99); ok {
+		t.Error("ResolveComponentInstance(99) is out of range; want ok=false")
+	}
+}
+
+func TestResolveComponentInstance_UnpopulatedAndDegenerate(t *testing.T) {
+	// A hand-built Component has no index space at all.
+	var c Component
+	if _, ok := c.ResolveComponentInstance(0); ok {
+		t.Error("empty index space: want ok=false")
+	}
+	// An entry pointing past Instances / Exports must fail loud rather than
+	// panic.
+	c.ComponentInstanceSpace = []ComponentInstanceSpaceEntry{
+		{Kind: ComponentInstanceFromDefinition, Instance: 5},
+		{Kind: ComponentInstanceFromExport, Export: 5},
+		{Kind: ComponentInstanceFromAlias, Alias: 0},
+	}
+	for i := range c.ComponentInstanceSpace {
+		if _, ok := c.ResolveComponentInstance(uint32(i)); ok {
+			t.Errorf("entry %d resolves; want ok=false", i)
+		}
+	}
+	// A self-referential export chain terminates instead of looping forever.
+	c.ComponentInstanceSpace = []ComponentInstanceSpaceEntry{{Kind: ComponentInstanceFromExport, Export: 0}}
+	c.Exports = []Export{{Name: "loop", ExternType: 0x05, ExternIndex: 0}}
+	if _, ok := c.ResolveComponentInstance(0); ok {
+		t.Error("self-referential export chain resolves; want ok=false")
+	}
+}

--- a/internal/component/binary/decoder.go
+++ b/internal/component/binary/decoder.go
@@ -146,7 +146,15 @@ func decodeComponent(buf []byte) (*Component, error) {
 				return nil, fmt.Errorf("instance section: %w", err)
 			}
 			offset = newOffset
+			instanceBase := uint32(len(c.Instances))
 			c.Instances = append(c.Instances, instances...)
+			// Every instance definition occupies the next index in the
+			// component's instance index space, interleaved with instance
+			// imports, instance aliases and (critically) instance exports --
+			// see componentinstancespace.go.
+			for j := range instances {
+				c.ComponentInstanceSpace = append(c.ComponentInstanceSpace, ComponentInstanceSpaceEntry{Kind: ComponentInstanceFromDefinition, Instance: instanceBase + uint32(j)})
+			}
 
 		case 6: // Alias section
 			aliases, newOffset, err := decodeAliasSection(buf, offset, sectionSize)
@@ -175,6 +183,12 @@ func decodeComponent(buf []byte) (*Component, error) {
 				// componentfuncspace.go.
 				if al.Sort == 0x01 {
 					c.ComponentFuncSpace = append(c.ComponentFuncSpace, ComponentFuncSpaceEntry{Kind: ComponentFuncFromAlias, Alias: aliasBase + uint32(j)})
+				}
+				// A component-level instance alias (sort 0x05) occupies the
+				// next index in the component instance index space -- see
+				// componentinstancespace.go.
+				if al.Sort == 0x05 {
+					c.ComponentInstanceSpace = append(c.ComponentInstanceSpace, ComponentInstanceSpaceEntry{Kind: ComponentInstanceFromAlias, Alias: aliasBase + uint32(j)})
 				}
 			}
 
@@ -246,6 +260,12 @@ func decodeComponent(buf []byte) (*Component, error) {
 				if im.ExternType == 0x01 {
 					c.ComponentFuncSpace = append(c.ComponentFuncSpace, ComponentFuncSpaceEntry{Kind: ComponentFuncFromImport, Import: importBase + uint32(j)})
 				}
+				// An instance import (sort instance 0x05) occupies the next
+				// index in the component instance index space -- see
+				// componentinstancespace.go.
+				if im.ExternType == 0x05 {
+					c.ComponentInstanceSpace = append(c.ComponentInstanceSpace, ComponentInstanceSpaceEntry{Kind: ComponentInstanceFromImport, Import: importBase + uint32(j)})
+				}
 			}
 
 		case 11: // Export section
@@ -265,6 +285,10 @@ func decodeComponent(buf []byte) (*Component, error) {
 				case 0x03: // type export: introduces a type index aliasing the
 					// exported type ("export introduces an alias").
 					c.TypeSpace = append(c.TypeSpace, TypeSpaceEntry{Kind: TypeSpaceExport, Export: exportBase + uint32(j)})
+				case 0x05: // instance export: introduces an instance index
+					// aliasing the exported instance, shifting every LATER
+					// instance definition -- see componentinstancespace.go.
+					c.ComponentInstanceSpace = append(c.ComponentInstanceSpace, ComponentInstanceSpaceEntry{Kind: ComponentInstanceFromExport, Export: exportBase + uint32(j)})
 				}
 			}
 

--- a/internal/component/instance/compilecache_test.go
+++ b/internal/component/instance/compilecache_test.go
@@ -266,6 +266,62 @@ func TestCompileCache_HelloPrintsHelloWorld(t *testing.T) {
 // in SEPARATE per-instance resolver maps (keyToInst). The host modules keep
 // per-instantiation-unique global names, so nothing collides in the store. Both
 // instances must independently print "hello world".
+// TestCompileCache_ShimBytesStableAcrossInstantiations pins the CM10 invariant
+// that core-instance identity keys (wazy:core-instance/<static index>, the
+// resolver key every passthrough shim names its alias sources by) must not
+// break: they are COMPONENT-CONSTANT, so a second Instantiate of the same
+// component produces byte-identical shim bytes and adds nothing to the compile
+// cache. A per-instantiation key (a global module name, say) would grow byKey
+// by one entry per shim on every Instantiate.
+func TestCompileCache_ShimBytesStableAcrossInstantiations(t *testing.T) {
+	ctx := context.Background()
+	r := wazy.NewRuntime(ctx)
+	defer r.Close(ctx)
+	cache := NewCompileCache()
+	defer cache.Close(ctx)
+
+	first, err := Instantiate(ctx, r, realHelloWasm, WithCompileCache(cache))
+	if err != nil {
+		t.Fatalf("first Instantiate: %v", err)
+	}
+	cache.mu.Lock()
+	n1 := len(cache.byKey)
+	cache.mu.Unlock()
+
+	second, err := Instantiate(ctx, r, realHelloWasm, WithCompileCache(cache))
+	if err != nil {
+		t.Fatalf("second Instantiate: %v", err)
+	}
+	cache.mu.Lock()
+	n2 := len(cache.byKey)
+	cache.mu.Unlock()
+
+	if n1 == 0 {
+		t.Fatal("cache is empty after the first Instantiate")
+	}
+	if n2 != n1 {
+		t.Errorf("compile cache grew from %d to %d entries on the second Instantiate; shim bytes are not component-constant", n1, n2)
+	}
+	// Every embedded core module AND every regrouping shim must be in there:
+	// real_hello has 4 core modules and a shim per inline-export core instance.
+	comp, err := binary.Decode(bytes.NewReader(realHelloWasm))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	shims := 0
+	for _, ci := range comp.CoreInstances {
+		if ci.Kind == 0x01 {
+			shims++
+		}
+	}
+	if want := len(comp.CoreModules) + shims; n1 != want {
+		t.Errorf("cache holds %d compiled modules, want %d (%d core modules + %d shims); a shim bypassed the cache", n1, want, len(comp.CoreModules), shims)
+	}
+
+	first.Close(ctx)
+	second.Close(ctx)
+}
+
 func TestCompileCache_TwoHelloLiveShareShims(t *testing.T) {
 	ctx := context.Background()
 	r := wazy.NewRuntime(ctx)

--- a/internal/component/instance/composition.go
+++ b/internal/component/instance/composition.go
@@ -201,7 +201,7 @@ func translateResourceFD(fd binary.FuncDesc, providerResolve abi.Resolver, trans
 // then delegated to precisely like a sibling's export -- the outer's own
 // core func is always ready here (instantiateNestedInstances, this func's
 // only caller, runs after the core-instance loop that builds it).
-func outerFuncArgImport(comp *binary.Component, cfg *config, in *Instance, byIdx map[int]*Instance, numImported int, funcIdx uint32, componentFunc func(uint32) (bool, int, aliasTarget, error), coreFuncTarget func(int) (api.Module, string, error), resolve abi.Resolver) (*hostImport, error) {
+func outerFuncArgImport(comp *binary.Component, cfg *config, in *Instance, byIdx map[int]*Instance, funcIdx uint32, componentFunc func(uint32) (bool, int, aliasTarget, error), coreFuncTarget func(int) (api.Module, string, error), resolve abi.Resolver) (*hostImport, error) {
 	if int(funcIdx) >= len(comp.ComponentFuncSpace) {
 		return nil, fmt.Errorf("func arg index %d out of range of the component func index space", funcIdx)
 	}
@@ -238,7 +238,12 @@ func outerFuncArgImport(comp *binary.Component, cfg *config, in *Instance, byIdx
 	if al.Sort != 0x01 || al.TargetKind != 0x00 {
 		return nil, fmt.Errorf("func arg index %d is a %#x/%#x alias, not a func export alias", funcIdx, al.Sort, al.TargetKind)
 	}
-	if int(al.InstanceIdx) >= numImported {
+	// A LOCAL instance definition names a sibling nested instantiation;
+	// anything else is an imported instance, resolved through
+	// importInterfaceName below. Resolved through the true component instance
+	// index space (see componentInstanceDef), not numImported arithmetic,
+	// since an interleaved instance export shifts every later definition.
+	if _, isLocal := componentInstanceDef(comp, al.InstanceIdx); isLocal {
 		sib, ok := byIdx[int(al.InstanceIdx)]
 		if !ok {
 			return nil, fmt.Errorf("func arg index %d aliases component instance %d, which is not a prior nested instantiation", funcIdx, al.InstanceIdx)

--- a/internal/component/instance/graph.go
+++ b/internal/component/instance/graph.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/samyfodil/wazy"
@@ -65,11 +66,13 @@ const graphEmptyImportKey = "wazy:component/empty-import"
 //    core instance index space:
 //      - Kind 0x00 (instantiate): instantiate the named embedded core
 //        module for real via Runtime.InstantiateWithConfig, registered under
-//        the wazy name its "with" args reference it by (or a synthesized
-//        key if none do -- see moduleKeyForGraph). Its own imports resolve
-//        automatically, by that same by-name mechanism, against whichever
-//        earlier core instances (real or shim) were registered under the
-//        names it imports from.
+//        its own collision-free identity key (coreInstanceKey) plus, as a
+//        fallback, the wazy name its "with" args reference it by. Its own
+//        two-level imports resolve first against THIS instantiation's own
+//        "with" args (a `with` name is a binding local to one instantiate,
+//        per Binary.md -- the same name routinely designates different
+//        source instances elsewhere in the component), then through the
+//        graph-wide fallback map.
 //      - Kind 0x01 (inline exports): build a "passthrough shim" -- a tiny
 //        hand-encoded real core wasm module (see shim.go) that imports each
 //        entry from wherever it really originates and re-exports it under
@@ -79,12 +82,14 @@ const graphEmptyImportKey = "wazy:component/empty-import"
 //        canon that produces a brand-new core func (canon lower, or one of
 //        the three resource canons): the latter gets a fresh, uniquely
 //        named single-func Go host module built first (see
-//        resolveInlineExportFuncItem), and the shim imports *that*. A memory
-//        or table entry is always a pure alias -- no canon ever produces
-//        one -- resolved the same way, giving the shim's re-export the exact
-//        same underlying MemoryInstance/TableInstance identity as its
-//        source (see shim.go's doc for why this matters and how a real,
-//        import-then-export core module achieves it for free).
+//        resolveInlineExportFuncItem), and the shim imports *that*. A table,
+//        memory or global entry is always a pure alias -- no canon ever
+//        produces one -- resolved the same way, giving the shim's re-export
+//        the exact same underlying TableInstance/MemoryInstance/
+//        GlobalInstance identity as its source (see shim.go's doc for why
+//        this matters and how a real, import-then-export core module
+//        achieves it for free). Every alias source is named by
+//        coreInstanceKey, never by a consumer-declared name.
 // 7. Bind the component's own exports (func or instance-typed, the latter
 //    for a WIT world that exports an interface -- see host_import.go's
 //    bindInstanceExport, whose core-agnostic logic this package reuses
@@ -175,9 +180,10 @@ func instantiateGraph(ctx context.Context, r wazy.Runtime, comp *binary.Componen
 		}
 	}
 
-	// Core memory and table index spaces: no canon ever produces either, so
-	// filtering Aliases in the slice's own order is already correct.
-	var coreMemSpace, coreTableSpace []aliasTarget
+	// Core memory, table and global index spaces: no canon ever produces any
+	// of the three, so filtering Aliases in the slice's own order is already
+	// correct.
+	var coreMemSpace, coreTableSpace, coreGlobalSpace []aliasTarget
 	for _, al := range comp.Aliases {
 		if al.Sort != 0x00 || al.TargetKind != 0x01 {
 			continue
@@ -187,14 +193,39 @@ func instantiateGraph(ctx context.Context, r wazy.Runtime, comp *binary.Componen
 			coreMemSpace = append(coreMemSpace, aliasTarget{instIdx: al.InstanceIdx, name: al.Name})
 		case 0x01: // table
 			coreTableSpace = append(coreTableSpace, aliasTarget{instIdx: al.InstanceIdx, name: al.Name})
+		case 0x03: // global
+			coreGlobalSpace = append(coreGlobalSpace, aliasTarget{instIdx: al.InstanceIdx, name: al.Name})
 		}
 	}
 
+	// refNames records, per core instance, the DISTINCT consumer-declared
+	// "with" names other instantiations pass it under. A source instance may
+	// legally appear under several names (and, just as often in real
+	// wit-component/componentize-py output, several DIFFERENT source instances
+	// share one name -- "env" appears ten times in a componentize-py CPython
+	// component). Neither is a conflict: a `with` name is a binding local to
+	// the one instantiation that declares it (Binary.md: the first import name
+	// is looked up in THAT instantiation's named list of args), never a
+	// component-wide module name. These names are therefore used only for the
+	// neededTypes lookup below, which is genuinely keyed by the consumer-
+	// declared module name because that is how a real core module spells its
+	// import. Identity is carried by coreInstanceKey instead.
 	refNames := make(map[uint32][]string)
 	for _, ci := range comp.CoreInstances {
-		if ci.Kind == 0x00 {
-			for _, arg := range ci.Args {
-				refNames[arg.InstanceIdx] = append(refNames[arg.InstanceIdx], arg.Name)
+		if ci.Kind != 0x00 {
+			continue
+		}
+		for _, arg := range ci.Args {
+			names := refNames[arg.InstanceIdx]
+			dup := false
+			for _, n := range names {
+				if n == arg.Name {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				refNames[arg.InstanceIdx] = append(names, arg.Name)
 			}
 		}
 	}
@@ -209,10 +240,11 @@ func instantiateGraph(ctx context.Context, r wazy.Runtime, comp *binary.Componen
 	// hits (unlike a per-instance name, which would bypass it), and nothing is
 	// registered under it globally (the module is anonymous).
 	emptyNameTarget := ""
-	for k := range comp.CoreInstances {
-		if names := refNames[uint32(k)]; len(names) == 1 && names[0] == "" {
-			emptyNameTarget = graphEmptyImportKey
-			break
+	for _, names := range refNames {
+		for _, n := range names {
+			if n == "" {
+				emptyNameTarget = graphEmptyImportKey
+			}
 		}
 	}
 
@@ -333,7 +365,7 @@ func instantiateGraph(ctx context.Context, r wazy.Runtime, comp *binary.Componen
 				return nil, "", fmt.Errorf("core func index %d: canon index %d out of range", cfi, entry.Canon)
 			}
 			privName := nextPrivateName()
-			hostMod, name, params, results, _, err := buildCanonHostModule(ctx, r, comp, cfg, resources, in, comp.Canons[entry.Canon], neededTypes, "", privName, privName, coreMemTarget, coreFuncTarget, coreTableTarget)
+			hostMod, name, params, results, _, err := buildCanonHostModule(ctx, r, comp, cfg, resources, in, comp.Canons[entry.Canon], neededTypes, nil, privName, privName, coreMemTarget, coreFuncTarget, coreTableTarget)
 			if err != nil {
 				return nil, "", fmt.Errorf("core func index %d: %w", cfi, err)
 			}
@@ -393,22 +425,34 @@ func instantiateGraph(ctx context.Context, r wazy.Runtime, comp *binary.Componen
 	}
 
 	// keyToInst is this component instance's private import environment: a
-	// per-instantiation map from an internal wiring name (a raw "with" name
-	// like wasi:io/streams@0.2.12, the empty-import key, or a synthesized
-	// core%d) to the instance that provides it. Its embedded modules and shims
-	// are instantiated ANONYMOUSLY (WithName("")), so they never enter the
-	// Runtime's global registry and never collide across components; all of
-	// their internal imports resolve through this map via the ImportResolver
-	// instead. This is wasmtime's model: a component's internal wiring lives in
-	// its own instance graph, not a shared global namespace. keys[k] holds each
-	// instance's key so a later shim can name its sources.
-	keys := make([]string, len(comp.CoreInstances))
+	// per-instantiation map from an internal wiring name to the instance that
+	// provides it. Its embedded modules and shims are instantiated
+	// ANONYMOUSLY (WithName("")), so they never enter the Runtime's global
+	// registry and never collide across components; all of their internal
+	// imports resolve through this map via the ImportResolver instead. This is
+	// wasmtime's model: a component's internal wiring lives in its own
+	// instance graph, not a shared global namespace.
+	//
+	// Two kinds of name live here:
+	//
+	//   - coreInstanceKey(k), the collision-free IDENTITY of core instance k.
+	//     Every instantiated core instance is registered under it, and every
+	//     passthrough shim names its alias sources by it. This is the only
+	//     key a shim ever uses, so a shim can never be handed the wrong
+	//     source instance.
+	//   - the consumer-declared "with" name (or the empty-import key, or a
+	//     synthesized core%d), kept as the graph-wide FALLBACK for a core
+	//     module import that its own instantiate-args do not name. Names are
+	//     NOT unique across a real component (see refNames), so this map is
+	//     last-writer-wins for them by construction -- which is exactly why
+	//     an instantiation resolves its own args locally first (see the loop
+	//     below) rather than trusting this map.
 	keyToInst := map[string]api.Module{}
 	// Chain to a caller-supplied ImportResolver, if any: the graph owns only
 	// its own internal names, so a name it doesn't provide falls through to the
 	// caller's resolver (then the global registry), never shadowing it.
 	parentResolver, _ := ctx.Value(expctxkeys.ImportResolverKey{}).(api.ImportResolver)
-	instCtx := api.WithImportResolver(ctx, func(name string) api.Module {
+	graphResolver := func(name string) api.Module {
 		if m := keyToInst[name]; m != nil {
 			return m
 		}
@@ -416,7 +460,8 @@ func instantiateGraph(ctx context.Context, r wazy.Runtime, comp *binary.Componen
 			return parentResolver(name)
 		}
 		return nil
-	})
+	}
+	instCtx := api.WithImportResolver(ctx, graphResolver)
 
 	// Register each of this component's OWN resource destructors on its table
 	// BEFORE instantiating core modules -- a core module's `start` section runs
@@ -450,15 +495,14 @@ func instantiateGraph(ctx context.Context, r wazy.Runtime, comp *binary.Componen
 	sh.instantiating = true
 	defer func() { sh.instantiating = false }()
 	for k, ci := range comp.CoreInstances {
-		// key is BOTH this instance's resolver key and the name a consumer
-		// declares to import it: the raw "with" name, the empty-import key, or
-		// a synthesized core%d (see moduleKeyForGraph). It is also the groupName
-		// for neededTypes lookups (the consumer-declared name).
-		key, nerr := moduleKeyForGraph(k, refNames[uint32(k)], emptyNameTarget)
-		if nerr != nil {
-			return fail(nerr)
-		}
-		keys[k] = key
+		// groupNames are the consumer-declared "with" names this instance is
+		// passed under -- the module names a real core module spells its
+		// imports of this group with, hence the neededTypes lookup keys. key
+		// is the first of them (or a synthesized core%d when nothing
+		// references this instance), used for the legacy graph-wide resolver
+		// registration and for diagnostics; identity is coreInstanceKey(k).
+		groupNames := groupNamesForGraph(refNames[uint32(k)], emptyNameTarget)
+		key := moduleKeyForGraph(k, groupNames)
 
 		switch ci.Kind {
 		case 0x00: // instantiate a real embedded core module
@@ -471,18 +515,58 @@ func instantiateGraph(ctx context.Context, r wazy.Runtime, comp *binary.Componen
 			// the per-instantiation re-slice + re-rewrite. Stable bytes => the
 			// compile cache still hits.
 			coreBytes := rewrittenCore[ci.ModuleIdx]
+			// This instantiation's OWN import environment. Per Binary.md, a
+			// two-level core import is resolved by looking the first name up
+			// "in the named list of core:instantiatearg" of THIS
+			// instantiation -- the args are local bindings, not entries in a
+			// component-wide namespace. Resolving them through the graph-wide
+			// map instead is wrong whenever one name is reused for different
+			// source instances (componentize-py passes ten different
+			// instances as "env") or one instance is bound under several
+			// names. The graph resolver stays as the fallback for a name the
+			// args don't cover.
+			//
+			// Every arg is validated here regardless; a local resolver is
+			// only built when at least one arg actually disagrees with what
+			// the graph-wide map would hand back, so a component with no
+			// name reuse (every fixture in this package, and every
+			// single-library wit-component guest) keeps the pre-existing,
+			// allocation-free path.
+			argCtx := instCtx
+			needLocal := false
+			for _, arg := range ci.Args {
+				src, ok := instMods[int(arg.InstanceIdx)]
+				if !ok {
+					return fail(fmt.Errorf("component/instance: core module %d instantiate arg %q references core instance %d, which was not instantiated", ci.ModuleIdx, arg.Name, arg.InstanceIdx))
+				}
+				if graphResolver(argImportName(arg.Name, emptyNameTarget)) != src {
+					needLocal = true
+				}
+			}
+			if needLocal {
+				args := ci.Args
+				argCtx = api.WithImportResolver(ctx, func(name string) api.Module {
+					for _, arg := range args {
+						if argImportName(arg.Name, emptyNameTarget) == name {
+							return instMods[int(arg.InstanceIdx)]
+						}
+					}
+					return graphResolver(name)
+				})
+			}
 			// WithName("") makes the module anonymous (not registered in the
 			// global name map -- see store_module_list.go's registerModule); its
-			// imports resolve through instCtx's resolver, and other modules
+			// imports resolve through argCtx's resolver, and other modules
 			// import it by its key, not a global name. WithStartFunctions()
 			// clears wazy's default "run _start on instantiate": an embedded
 			// core module's own _start is invoked later by another module once
 			// the graph is wired (see shim.go), not eagerly here.
-			mod, err := instantiateCoreModule(instCtx, r, cfg, coreBytes, wazy.NewModuleConfig().WithName("").WithStartFunctions())
+			mod, err := instantiateCoreModule(argCtx, r, cfg, coreBytes, wazy.NewModuleConfig().WithName("").WithStartFunctions())
 			if err != nil {
 				return fail(fmt.Errorf("component/instance: instantiate core module %d (key %q): %w", ci.ModuleIdx, key, err))
 			}
 			instMods[k] = mod
+			keyToInst[coreInstanceKey(k)] = mod
 			keyToInst[key] = mod
 			closers = append(closers, mod)
 			coreModuleCount++
@@ -504,7 +588,7 @@ func instantiateGraph(ctx context.Context, r wazy.Runtime, comp *binary.Componen
 					if int(centry.Canon) >= len(comp.Canons) {
 						return fail(fmt.Errorf("component/instance: core instance %d: inline export %q references canon %d, out of range", k, e.Name, centry.Canon))
 					}
-					def, wasiCall, cerr := computeCanonHostFunc(ctx, r, comp, cfg, resources, in, comp.Canons[centry.Canon], neededTypes, key, e.Name, coreMemTarget, coreFuncTarget, coreTableTarget)
+					def, wasiCall, cerr := computeCanonHostFunc(ctx, r, comp, cfg, resources, in, comp.Canons[centry.Canon], neededTypes, groupNames, e.Name, coreMemTarget, coreFuncTarget, coreTableTarget)
 					if cerr != nil {
 						return fail(fmt.Errorf("component/instance: core instance %d: inline export %q: %w", k, e.Name, cerr))
 					}
@@ -517,9 +601,9 @@ func instantiateGraph(ctx context.Context, r wazy.Runtime, comp *binary.Componen
 					canonDefs = append(canonDefs, def)
 					continue
 				}
-				// key doubles as groupName (the consumer-declared name) for
-				// neededTypes lookups; keys names the shim's alias sources.
-				item, wasiCall, privMod, err := resolveInlineExportItem(ctx, r, comp, cfg, resources, in, e, coreMemSpace, coreTableSpace, instMods, keys, neededTypes, key, nextPrivateName, coreFuncTarget, coreMemTarget, coreTableTarget)
+				// groupNames are the consumer-declared names for neededTypes
+				// lookups; the shim names its alias sources by coreInstanceKey.
+				item, wasiCall, privMod, err := resolveInlineExportItem(ctx, r, comp, cfg, resources, in, e, coreMemSpace, coreTableSpace, coreGlobalSpace, instMods, neededTypes, groupNames, nextPrivateName, coreFuncTarget, coreMemTarget, coreTableTarget)
 				if err != nil {
 					return fail(fmt.Errorf("component/instance: core instance %d: %w", k, err))
 				}
@@ -568,16 +652,17 @@ func instantiateGraph(ctx context.Context, r wazy.Runtime, comp *binary.Componen
 			}
 			// Anonymous like the embedded modules above; consumers import it by
 			// its key via the resolver, not by a global name. Every FromModule is
-			// now component-constant (embedded-module keys + the stable canon-group
-			// key), so shimBytes are identical every instantiation -- route through
-			// the CompileCache (a warm cache then skips re-encoding + recompiling
-			// each shim). cacheableShim is false only in the defensive canon-key
-			// fallback above, where the bytes are not stable.
+			// component-constant (coreInstanceKey(<static index>) + the stable
+			// canon-group key), so shimBytes are identical every instantiation --
+			// route through the CompileCache (a warm cache then skips re-encoding
+			// + recompiling each shim). cacheableShim is false only in the
+			// defensive canon-key fallback above, where the bytes are not stable.
 			mod, err := instantiateCoreModuleCacheable(instCtx, r, cfg, shimBytes, wazy.NewModuleConfig().WithName("").WithStartFunctions(), cacheableShim)
 			if err != nil {
 				return fail(fmt.Errorf("component/instance: instantiate regrouping shim for core instance %d (key %q): %w", k, key, err))
 			}
 			instMods[k] = mod
+			keyToInst[coreInstanceKey(k)] = mod
 			keyToInst[key] = mod
 			closers = append(closers, mod)
 
@@ -681,21 +766,19 @@ func instantiateNestedInstances(ctx context.Context, r wazy.Runtime, comp *binar
 	if len(comp.Instances) == 0 {
 		return nil, nil, nil
 	}
-	numImported := 0
-	for _, im := range comp.Imports {
-		if im.ExternType == 0x05 { // instance
-			numImported++
-		}
-	}
+	// spaceIdx[i] is the component instance index space slot comp.Instances[i]
+	// occupies -- NOT numImported+i, since an instance export interleaved
+	// between two instance definitions introduces an aliasing index of its own
+	// and shifts every later definition (see componentInstanceSpaceIndices).
+	spaceIdx := componentInstanceSpaceIndices(comp)
 
 	// A component instance re-exported directly as an INSTANCE (the WIT-
 	// exports-an-interface shim shape, comp.Exports' ExternType==0x05) is
 	// bindInstanceExportGraph's exclusive responsibility -- it does its own
 	// instantiation/validation there (nested-component-index bounds,
 	// pure-shim shape) and must keep being the ONLY consumer for that shape;
-	// don't preempt it here. Per bindInstanceExportGraph's own arithmetic,
-	// such an export's ExternIndex IS the component-instance index directly
-	// (numImportedInstances + localIdx, matching this func's compInstIdx).
+	// don't preempt it here. Such an export's ExternIndex IS a component-
+	// instance index, matching this func's compInstIdx.
 	exportedAsInstance := make(map[int]bool)
 	for _, exp := range comp.Exports {
 		if exp.ExternType == 0x05 {
@@ -714,7 +797,7 @@ func instantiateNestedInstances(ctx context.Context, r wazy.Runtime, comp *binar
 	// bindInstanceExportGraph above.
 	needed := make(map[int]bool)
 	for i, inst := range comp.Instances {
-		compInstIdx := numImported + i
+		compInstIdx := spaceIdx[i]
 		if inst.Kind == 0x00 && !exportedAsInstance[compInstIdx] {
 			needed[compInstIdx] = true
 		}
@@ -725,7 +808,7 @@ func instantiateNestedInstances(ctx context.Context, r wazy.Runtime, comp *binar
 	// Pull in transitive dependencies: a needed instance's instance-args name
 	// earlier (forward-declared) siblings it links, which must exist first.
 	for i := len(comp.Instances) - 1; i >= 0; i-- {
-		if !needed[numImported+i] {
+		if !needed[spaceIdx[i]] {
 			continue
 		}
 		for _, arg := range comp.Instances[i].Args {
@@ -743,7 +826,7 @@ func instantiateNestedInstances(ctx context.Context, r wazy.Runtime, comp *binar
 		}
 	}
 	for i, inst := range comp.Instances {
-		compInstIdx := numImported + i
+		compInstIdx := spaceIdx[i]
 		if !needed[compInstIdx] || inst.Kind != 0x00 {
 			continue
 		}
@@ -863,7 +946,7 @@ func instantiateNestedInstances(ctx context.Context, r wazy.Runtime, comp *binar
 				// importInterfaceName) or, just as often in the async
 				// suites' multi-nested-component .wast shape, a single named
 				// export of an earlier sibling nested instance (byIdx).
-				hi, err := outerFuncArgImport(comp, cfg, in, byIdx, numImported, arg.SortIdx, componentFunc, coreFuncTarget, resolve)
+				hi, err := outerFuncArgImport(comp, cfg, in, byIdx, arg.SortIdx, componentFunc, coreFuncTarget, resolve)
 				if err != nil {
 					failClose()
 					return nil, nil, fmt.Errorf("component/instance: component instance %d arg %q: %w", compInstIdx, arg.Name, err)
@@ -1059,26 +1142,136 @@ func startDelegatedFromBlocker(ctx context.Context, blk taskBlocker, tgt *guestA
 	return out, nil
 }
 
-// moduleKeyForGraph is moduleNameFor's graph-engine counterpart: identical
-// except that a sole "" ref name (see importrewrite.go) maps to
-// emptyNameTarget instead of the literal empty string, since wazy's module
-// registry cannot resolve an empty-named module by import.
-func moduleKeyForGraph(coreInstanceIdx int, refNames []string, emptyNameTarget string) (string, error) {
-	switch len(refNames) {
-	case 0:
+// coreInstanceKey is the COMPONENT-CONSTANT, collision-free resolver key that
+// identifies core instance k inside one component's private import
+// environment (keyToInst -- see instantiateGraph). It is the identity a
+// passthrough shim names its alias sources by.
+//
+// A consumer-declared "with" name cannot serve as that identity: names are
+// local to the instantiation that declares them, so the same name routinely
+// designates DIFFERENT source instances within one component (a
+// componentize-py CPython component passes ten distinct instances as "env",
+// three as "wasi_snapshot_preview1", and five as "GOT.mem"), and one instance
+// may be bound under several names. Keying by index removes both hazards.
+//
+// The index is static per component, so this is component-constant exactly
+// like canonGroupKey and graphEmptyImportKey: the shim bytes that embed it
+// stay byte-identical across instantiations and keep hitting the CompileCache
+// (OPTIMIZATIONS.md CM10). The "wazy:" prefix cannot collide with a real
+// core:name from a component binary that wit-component or componentize-py
+// emits, and nothing is ever registered under it globally.
+//
+// The first coreInstanceKeyCacheSize keys are interned once per process
+// (a component-constant string for a static index), so registering every core
+// instance's identity costs no allocation on the instantiate path -- the
+// straightforward fmt.Sprintf here would add two allocations per core
+// instance to every Instantiate (OPTIMIZATIONS.md CM5/CM7/CM9's territory).
+func coreInstanceKey(k int) string {
+	if k >= 0 && k < len(coreInstanceKeyCache) {
+		return coreInstanceKeyCache[k]
+	}
+	return coreInstanceKeyPrefix + strconv.Itoa(k)
+}
+
+const (
+	coreInstanceKeyPrefix    = "wazy:core-instance/"
+	coreInstanceKeyCacheSize = 128 // > the 83 core instances of a componentize-py CPython component
+)
+
+var coreInstanceKeyCache = func() [coreInstanceKeyCacheSize]string {
+	var out [coreInstanceKeyCacheSize]string
+	for i := range out {
+		out[i] = coreInstanceKeyPrefix + strconv.Itoa(i)
+	}
+	return out
+}()
+
+// argImportName is the module name a core module actually spells an import
+// from the instance bound under the "with" name argName. It is argName
+// verbatim, except that "" maps to emptyNameTarget: wazy's decoder rejects an
+// empty core import module name outright, so such an import was rewritten to
+// that stable key before the module was ever decoded (see graphEmptyImportKey
+// and importrewrite.go).
+func argImportName(argName, emptyNameTarget string) string {
+	if argName == "" {
+		return emptyNameTarget
+	}
+	return argName
+}
+
+// groupNamesForGraph is the list of consumer-declared "with" names core
+// instance k is passed under, with a "" name mapped to emptyNameTarget (see
+// importrewrite.go: the decoder rejects an empty core import module name, so
+// the guest's bytes were rewritten to that stable key and neededTypes is
+// keyed by it). These are the module names a real core module spells its
+// imports of this group with, hence the neededTypes lookup keys -- see
+// lookupCoreFuncSig. Identity is coreInstanceKey, never one of these.
+func groupNamesForGraph(refNames []string, emptyNameTarget string) []string {
+	rewrite := false
+	for _, n := range refNames {
+		if n == "" {
+			rewrite = true
+			break
+		}
+	}
+	if !rewrite {
+		// The overwhelmingly common case: no copy, so the per-core-instance
+		// loop stays allocation-free.
+		return refNames
+	}
+	out := make([]string, 0, len(refNames))
+	for _, n := range refNames {
+		if n == "" {
+			n = emptyNameTarget
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+// moduleKeyForGraph is the name core instance k is registered under in the
+// graph-wide FALLBACK resolver (and the one used in diagnostics): its first
+// consumer-declared name, or a synthesized core%d when nothing references it
+// (e.g. the root). It is deliberately NOT an identity -- see coreInstanceKey.
+func moduleKeyForGraph(coreInstanceIdx int, groupNames []string) string {
+	if len(groupNames) == 0 {
 		// Unreferenced (e.g. the root): nothing imports it, so any distinct key
 		// works; core%d is unique within this component.
-		return fmt.Sprintf("core%d", coreInstanceIdx), nil
-	case 1:
-		if refNames[0] == "" {
-			return emptyNameTarget, nil
+		return fmt.Sprintf("core%d", coreInstanceIdx)
+	}
+	return groupNames[0]
+}
+
+// lookupCoreFuncSig finds the core-level signature a consumer declared for a
+// canon-produced func re-exported as entryName from a group regrouped under
+// groupNames. Every name the group is passed under is tried: a single source
+// instance may legally be bound under several "with" names, and only one of
+// those consumers need declare the import.
+func lookupCoreFuncSig(neededTypes map[string]map[string]coreFuncSig, groupNames []string, entryName string) (coreFuncSig, bool) {
+	for _, g := range groupNames {
+		if sig, ok := neededTypes[g][entryName]; ok {
+			return sig, true
 		}
-		// The raw "with" name is exactly what consumers import; the resolver
-		// maps it to this (anonymous) instance. No prefix: the key lives only
-		// in this component's private resolver map, never the global registry.
-		return refNames[0], nil
+	}
+	return coreFuncSig{}, false
+}
+
+// quoteNames renders a group's consumer-declared names for a diagnostic:
+// `"env"` for the usual single-name case, `"a" or "b"` when a source instance
+// really is bound under several names, and `(none)` for an unreferenced group
+// (which is exactly why no consumer declared the signature).
+func quoteNames(names []string) string {
+	switch len(names) {
+	case 0:
+		return "(none)"
+	case 1:
+		return fmt.Sprintf("%q", names[0])
 	default:
-		return "", fmt.Errorf("component/instance: core instance %d is referenced under %d names (%v); a core module can only be registered under one name", coreInstanceIdx, len(refNames), refNames)
+		quoted := make([]string, len(names))
+		for i, n := range names {
+			quoted[i] = fmt.Sprintf("%q", n)
+		}
+		return strings.Join(quoted, " or ")
 	}
 }
 
@@ -1147,11 +1340,11 @@ func discoverNeededFuncTypes(r wazy.Runtime, comp *binary.Component, componentBy
 	return out, rewritten, nil
 }
 
-// resolveInlineExportItem resolves one CoreInlineExport entry (func, memory,
-// or table sort) to the shimItem that re-exports it. groupName is the wazy
-// module name the enclosing shim will be registered under -- used to look up
-// this entry's required core-level type in neededTypes when it's a canon-
-// produced func with no caller-supplied implementation. It returns the
+// resolveInlineExportItem resolves one CoreInlineExport entry (func, table,
+// memory, or global sort) to the shimItem that re-exports it. groupNames are
+// the consumer-declared module names the enclosing group is passed under --
+// used to look up this entry's required core-level type in neededTypes when
+// it's a canon-produced func with no caller-supplied implementation. It returns the
 // "iface.func" WASI call name when this entry is a canon lower, for
 // Instance.WASICalls -- empty otherwise -- and, when this entry is a
 // canon-produced func, the private host module buildCanonHostModule
@@ -1161,14 +1354,15 @@ func discoverNeededFuncTypes(r wazy.Runtime, comp *binary.Component, componentBy
 // otherwise leak it (and, on Runtime reuse, permanently occupy its private
 // name -- see bench_test.go's BenchmarkInstantiateHello doc for the bug this
 // closes).
-// keys names each already-instantiated core instance under its resolver key
-// (see instantiateGraph): a shim imports an anonymous alias source (embedded
-// module or earlier shim) by that key, not by mod.Name() -- which is "" for an
-// anonymous module.
+// A shim imports an anonymous alias source (embedded module or earlier shim)
+// by coreInstanceKey -- the source instance's collision-free identity -- not
+// by mod.Name() (which is "" for an anonymous module) and not by whichever
+// consumer-declared name happens to be bound to it (which is ambiguous, see
+// coreInstanceKey's doc).
 func resolveInlineExportItem(
 	ctx context.Context, r wazy.Runtime, comp *binary.Component, cfg *config, resources *handleTable, in *Instance,
-	e binary.CoreInlineExport, coreMemSpace, coreTableSpace []aliasTarget, instMods map[int]api.Module, keys []string,
-	neededTypes map[string]map[string]coreFuncSig, groupName string, nextPrivateName func() string,
+	e binary.CoreInlineExport, coreMemSpace, coreTableSpace, coreGlobalSpace []aliasTarget, instMods map[int]api.Module,
+	neededTypes map[string]map[string]coreFuncSig, groupNames []string, nextPrivateName func() string,
 	coreFuncTarget func(int) (api.Module, string, error), coreMemTarget func(int) (api.Module, error),
 	coreTableTarget func(int) (api.Module, string, error),
 ) (shimItem, string, api.Module, error) {
@@ -1190,11 +1384,11 @@ func resolveInlineExportItem(
 				return shimItem{}, "", nil, fmt.Errorf("inline export %q: core instance %d (%q) has no exported function %q", e.Name, al.InstanceIdx, mod.Name(), al.Name)
 			}
 			def := fn.Definition()
-			return shimItem{Sort: shimSortFunc, FromModule: keys[int(al.InstanceIdx)], FromName: al.Name, ExportName: e.Name, Params: def.ParamTypes(), Results: def.ResultTypes()}, "", nil, nil
+			return shimItem{Sort: shimSortFunc, FromModule: coreInstanceKey(int(al.InstanceIdx)), FromName: al.Name, ExportName: e.Name, Params: def.ParamTypes(), Results: def.ResultTypes()}, "", nil, nil
 
 		case binary.CoreFuncFromCanon:
 			canon := comp.Canons[entry.Canon]
-			mod, exportName, params, results, wasiCall, err := buildCanonHostModule(ctx, r, comp, cfg, resources, in, canon, neededTypes, groupName, e.Name, nextPrivateName(), coreMemTarget, coreFuncTarget, coreTableTarget)
+			mod, exportName, params, results, wasiCall, err := buildCanonHostModule(ctx, r, comp, cfg, resources, in, canon, neededTypes, groupNames, e.Name, nextPrivateName(), coreMemTarget, coreFuncTarget, coreTableTarget)
 			if err != nil {
 				return shimItem{}, "", nil, fmt.Errorf("inline export %q: %w", e.Name, err)
 			}
@@ -1218,7 +1412,7 @@ func resolveInlineExportItem(
 		if !ok {
 			return shimItem{}, "", nil, fmt.Errorf("inline export %q: core memory %d targets core instance %d, which was not instantiated", e.Name, e.CoreSortIdx, at.instIdx)
 		}
-		return shimItem{Sort: shimSortMemory, FromModule: keys[int(at.instIdx)], FromName: at.name, ExportName: e.Name}, "", nil, nil
+		return shimItem{Sort: shimSortMemory, FromModule: coreInstanceKey(int(at.instIdx)), FromName: at.name, ExportName: e.Name}, "", nil, nil
 
 	case 0x01: // table
 		if int(e.CoreSortIdx) >= len(coreTableSpace) {
@@ -1229,10 +1423,38 @@ func resolveInlineExportItem(
 		if !ok {
 			return shimItem{}, "", nil, fmt.Errorf("inline export %q: core table %d targets core instance %d, which was not instantiated", e.Name, e.CoreSortIdx, at.instIdx)
 		}
-		return shimItem{Sort: shimSortTable, FromModule: keys[int(at.instIdx)], FromName: at.name, ExportName: e.Name}, "", nil, nil
+		return shimItem{Sort: shimSortTable, FromModule: coreInstanceKey(int(at.instIdx)), FromName: at.name, ExportName: e.Name}, "", nil, nil
+
+	case 0x03: // global
+		// A core global is always a pure alias -- no canon produces one --
+		// resolved exactly like a memory or table, except that a global
+		// import must declare the source's EXACT value type and mutability
+		// (store.go's resolveImports rejects any mismatch, unlike the
+		// min/max limits it merely bounds-checks), so both are read off the
+		// live source global here and carried on the shim item.
+		//
+		// componentize-py's shared-everything dynamic linking makes this
+		// mandatory rather than exotic: every `libfoo.so` core module imports
+		// `__stack_pointer`, `__memory_base`/`__table_base` and its whole
+		// GOT.func/GOT.mem relocation table as core globals regrouped through
+		// inline-export instances.
+		if int(e.CoreSortIdx) >= len(coreGlobalSpace) {
+			return shimItem{}, "", nil, fmt.Errorf("inline export %q references core global %d, out of range of the %d-entry core global index space", e.Name, e.CoreSortIdx, len(coreGlobalSpace))
+		}
+		at := coreGlobalSpace[e.CoreSortIdx]
+		mod, ok := instMods[int(at.instIdx)]
+		if !ok {
+			return shimItem{}, "", nil, fmt.Errorf("inline export %q: core global %d targets core instance %d, which was not instantiated", e.Name, e.CoreSortIdx, at.instIdx)
+		}
+		g := mod.ExportedGlobal(at.name)
+		if g == nil {
+			return shimItem{}, "", nil, fmt.Errorf("inline export %q: core instance %d has no exported global %q", e.Name, at.instIdx, at.name)
+		}
+		_, mutable := g.(api.MutableGlobal)
+		return shimItem{Sort: shimSortGlobal, FromModule: coreInstanceKey(int(at.instIdx)), FromName: at.name, ExportName: e.Name, GlobalType: g.Type(), GlobalMutable: mutable}, "", nil, nil
 
 	default:
-		return shimItem{}, "", nil, fmt.Errorf("inline export %q has unsupported core:sort %#x; only func (0x00), table (0x01), and memory (0x02) are supported by the graph engine", e.Name, e.Sort)
+		return shimItem{}, "", nil, fmt.Errorf("inline export %q has unsupported core:sort %#x; only func (0x00), table (0x01), memory (0x02), and global (0x03) are supported by the graph engine", e.Name, e.Sort)
 	}
 }
 
@@ -1242,7 +1464,7 @@ func resolveInlineExportItem(
 // func under. A lower canon with a caller-supplied WithImport uses it
 // (reusing buildHostWrapper's full WIT-level lift/lower machinery,
 // unchanged); otherwise it becomes a trap stub whose core-level signature
-// comes from neededTypes[groupName][entryName] -- the type the real core
+// comes from neededTypes[<one of groupNames>][entryName] -- the type the real core
 // module that will eventually consume this group's re-export already
 // commits to -- and which panics naming the WASI iface+func, returned as
 // wasiCall for Instance.WASICalls (empty for a resource canon or a
@@ -1256,7 +1478,7 @@ func resolveInlineExportItem(
 // lower/trap-stub/resource behaviors.
 func computeCanonHostFunc(
 	ctx context.Context, r wazy.Runtime, comp *binary.Component, cfg *config, resources *handleTable, in *Instance,
-	canon binary.Canon, neededTypes map[string]map[string]coreFuncSig, groupName, entryName string,
+	canon binary.Canon, neededTypes map[string]map[string]coreFuncSig, groupNames []string, entryName string,
 	coreMemTarget func(int) (api.Module, error), coreFuncTarget func(int) (api.Module, string, error),
 	coreTableTarget func(int) (api.Module, string, error),
 ) (def hostFuncDef, wasiCall string, err error) {
@@ -1306,13 +1528,13 @@ func computeCanonHostFunc(
 			if al.Sort != 0x01 || al.TargetKind != 0x00 {
 				return hostFuncDef{}, "", fmt.Errorf("lower func index %d: unsupported alias %#x/%#x", fi, al.Sort, al.TargetKind)
 			}
-			numImported := 0
-			for _, im := range comp.Imports {
-				if im.ExternType == 0x05 {
-					numImported++
-				}
-			}
-			if int(al.InstanceIdx) >= numImported {
+			// A local instance definition, resolved through the true
+			// component instance index space (an instance export interleaved
+			// between two definitions shifts the later one -- see
+			// componentInstanceDef); anything else is an imported instance,
+			// handled by importInterfaceName below.
+			localIdx, isLocal := componentInstanceDef(comp, al.InstanceIdx)
+			if isLocal {
 				// A canon lower wired directly into the outer component's
 				// own core-instance graph, referencing a LOCALLY nested
 				// component instantiate's export -- trap-on-reenter.wast's
@@ -1325,10 +1547,6 @@ func computeCanonHostFunc(
 				// regardless). See cfg.pendingDelegates' doc for how the
 				// live sibling is filled in once it exists, always before
 				// any guest call could reach this func.
-				localIdx := int(al.InstanceIdx) - numImported
-				if localIdx < 0 || localIdx >= len(comp.Instances) {
-					return hostFuncDef{}, "", fmt.Errorf("lower func index %d: component instance %d out of range of %d locally-instantiated instance(s)", fi, al.InstanceIdx, len(comp.Instances))
-				}
 				instRef := comp.Instances[localIdx]
 				if instRef.Kind != 0x00 || int(instRef.ComponentIdx) >= len(comp.NestedComponents) {
 					return hostFuncDef{}, "", fmt.Errorf("lower func index %d: component instance %d is not a real nested component instantiation", fi, al.InstanceIdx)
@@ -1418,9 +1636,9 @@ func computeCanonHostFunc(
 			def = hostFuncDef{fn: fn, params: hiParams, results: hiResults}
 			wasiCall = "" // caller-provided, not a trap stub
 		} else {
-			sig, ok := neededTypes[groupName][entryName]
+			sig, ok := lookupCoreFuncSig(neededTypes, groupNames, entryName)
 			if !ok {
-				return hostFuncDef{}, "", fmt.Errorf("cannot determine the core-level signature for lowered import %q %q: no consumer declares module %q field %q", iface, fname, groupName, entryName)
+				return hostFuncDef{}, "", fmt.Errorf("cannot determine the core-level signature for lowered import %q %q: no consumer declares module %s field %q", iface, fname, quoteNames(groupNames), entryName)
 			}
 			trapIface, trapName := iface, fname
 			fn := api.GoModuleFunc(func(context.Context, api.Module, []uint64) {
@@ -1454,7 +1672,7 @@ func computeCanonHostFunc(
 
 	case binary.CanonKindThreadNewIndirect:
 		var terr error
-		def, terr = threadNewIndirectHostFunc(in, canon, neededTypes, groupName, entryName, coreTableTarget)
+		def, terr = threadNewIndirectHostFunc(in, canon, neededTypes, groupNames, entryName, coreTableTarget)
 		if terr != nil {
 			return hostFuncDef{}, "", terr
 		}
@@ -1588,11 +1806,11 @@ func buildMergedCanonHostModule(ctx context.Context, r wazy.Runtime, privateName
 // buildMergedCanonHostModule to pack a whole group's canon funcs into one module.
 func buildCanonHostModule(
 	ctx context.Context, r wazy.Runtime, comp *binary.Component, cfg *config, resources *handleTable, in *Instance,
-	canon binary.Canon, neededTypes map[string]map[string]coreFuncSig, groupName, entryName, privateName string,
+	canon binary.Canon, neededTypes map[string]map[string]coreFuncSig, groupNames []string, entryName, privateName string,
 	coreMemTarget func(int) (api.Module, error), coreFuncTarget func(int) (api.Module, string, error),
 	coreTableTarget func(int) (api.Module, string, error),
 ) (mod api.Module, exportName string, params, results []api.ValueType, wasiCall string, err error) {
-	def, wasiCall, err := computeCanonHostFunc(ctx, r, comp, cfg, resources, in, canon, neededTypes, groupName, entryName, coreMemTarget, coreFuncTarget, coreTableTarget)
+	def, wasiCall, err := computeCanonHostFunc(ctx, r, comp, cfg, resources, in, canon, neededTypes, groupNames, entryName, coreMemTarget, coreFuncTarget, coreTableTarget)
 	if err != nil {
 		return nil, "", nil, nil, "", err
 	}
@@ -1967,28 +2185,94 @@ func resolveCallbackFuncGraph(canon binary.Canon, coreFuncTarget func(int) (api.
 	return "", nil
 }
 
+// numImportedInstances counts the component's instance imports (extern sort
+// 0x05) -- the entries that lead the component instance index space in every
+// binary wit-component or componentize-py emits.
+func numImportedInstances(comp *binary.Component) int {
+	n := 0
+	for _, im := range comp.Imports {
+		if im.ExternType == 0x05 {
+			n++
+		}
+	}
+	return n
+}
+
+// componentInstanceDef resolves a component-level instance index to the index
+// in comp.Instances of the instance DEFINITION it names, following the alias
+// an `(export "x" (instance N))` introduces.
+//
+// It prefers the decoder's ComponentInstanceSpace, which records the real
+// cross-section declaration order (imports, definitions, aliases AND exports
+// -- see componentinstancespace.go). A hand-built Component has no such space,
+// so it falls back to the flat [imports] ++ [definitions] arithmetic that was
+// this package's only model before the space existed; that shape is exactly
+// what a hand-built fixture has.
+//
+// ok is false when the index names an imported instance, an alias this
+// decoder does not resolve structurally, or nothing at all.
+func componentInstanceDef(comp *binary.Component, idx uint32) (int, bool) {
+	if len(comp.ComponentInstanceSpace) > 0 {
+		return comp.ResolveComponentInstance(idx)
+	}
+	localIdx := int(idx) - numImportedInstances(comp)
+	if localIdx < 0 || localIdx >= len(comp.Instances) {
+		return 0, false
+	}
+	return localIdx, true
+}
+
+// componentInstanceSpaceIndices is componentInstanceDef's inverse: entry i is
+// the component instance index space slot comp.Instances[i] occupies. That is
+// the index other definitions (an instance-sort instantiate-arg, an
+// export/alias target) name it by, so it is the key instantiateNestedInstances
+// tracks sub-Instances under.
+func componentInstanceSpaceIndices(comp *binary.Component) []int {
+	out := make([]int, len(comp.Instances))
+	if len(comp.ComponentInstanceSpace) > 0 {
+		for i := range out {
+			out[i] = -1
+		}
+		for spaceIdx, e := range comp.ComponentInstanceSpace {
+			if e.Kind == binary.ComponentInstanceFromDefinition && int(e.Instance) < len(out) {
+				out[e.Instance] = spaceIdx
+			}
+		}
+		return out
+	}
+	base := numImportedInstances(comp)
+	for i := range out {
+		out[i] = base + i
+	}
+	return out
+}
+
 // bindInstanceExportGraph is bindInstanceExport's graph-engine counterpart --
 // identical resolution of the re-export-shim shape (see host_import.go's
 // doc), but calling bindFuncExportGraph for each member.
 func bindInstanceExportGraph(comp *binary.Component, exp binary.Export, componentFunc func(uint32) (bool, int, aliasTarget, error), coreFuncTarget func(int) (api.Module, string, error), resolve abi.Resolver, exports map[string]*boundExport, abiCache *CompileCache) error {
-	// The component-level "instance" sort index space is every imported
-	// instance (comp.Imports with ExternType == 0x05), in import order,
-	// followed by every locally-instantiated one (comp.Instances) -- unlike
-	// bindInstanceExport's fixtures (which never mix the two), a component
-	// like real_hello that both imports instances and instantiates its own
-	// nested re-export shim needs this offset to land on the right entry.
-	numImportedInstances := 0
-	for _, im := range comp.Imports {
-		if im.ExternType == 0x05 {
-			numImportedInstances++
+	// The component-level "instance" sort index space is NOT simply
+	// [imported instances] ++ [comp.Instances]: per Binary.md, "all exports
+	// (of all sorts) introduce a new index that aliases the exported
+	// definition", so every instance export the binary declares shifts the
+	// index of every LATER instance definition. wit-component emits exactly
+	// that interleaving -- `(instance ...) (export ...) (instance ...)
+	// (export ...)` -- for a component with more than one exported
+	// interface, which a real componentize-py CPython component has. The
+	// decoder's ComponentInstanceSpace records the true declaration order
+	// (see componentinstancespace.go); componentInstanceDef reads it, falling
+	// back to the flat arithmetic only for a hand-built Component that has no
+	// index space at all.
+	localIdx, ok := componentInstanceDef(comp, exp.ExternIndex)
+	if !ok {
+		if int(exp.ExternIndex) < len(comp.ComponentInstanceSpace) &&
+			comp.ComponentInstanceSpace[exp.ExternIndex].Kind == binary.ComponentInstanceFromImport {
+			return fmt.Errorf("component/instance: export %q references instance %d, which is an imported instance re-exported directly; unsupported", exp.Name, exp.ExternIndex)
 		}
-	}
-	localIdx := int(exp.ExternIndex) - numImportedInstances
-	if localIdx < 0 {
-		return fmt.Errorf("component/instance: export %q references instance %d, which is an imported instance re-exported directly; unsupported", exp.Name, exp.ExternIndex)
-	}
-	if localIdx >= len(comp.Instances) {
-		return fmt.Errorf("component/instance: export %q references instance %d, out of range of %d imported + %d locally-instantiated instance(s)", exp.Name, exp.ExternIndex, numImportedInstances, len(comp.Instances))
+		if len(comp.ComponentInstanceSpace) == 0 && int(exp.ExternIndex) < numImportedInstances(comp) {
+			return fmt.Errorf("component/instance: export %q references instance %d, which is an imported instance re-exported directly; unsupported", exp.Name, exp.ExternIndex)
+		}
+		return fmt.Errorf("component/instance: export %q references instance %d, out of range of %d imported + %d locally-instantiated instance(s)", exp.Name, exp.ExternIndex, numImportedInstances(comp), len(comp.Instances))
 	}
 	inst := comp.Instances[localIdx]
 	if inst.Kind == 0x01 { // inline exports: no nested component/shim at all

--- a/internal/component/instance/graph_synth_test.go
+++ b/internal/component/instance/graph_synth_test.go
@@ -1,0 +1,706 @@
+package instance
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/samyfodil/wazy"
+	"github.com/samyfodil/wazy/api"
+	"github.com/samyfodil/wazy/internal/component/binary"
+	"github.com/samyfodil/wazy/internal/leb128"
+	"github.com/samyfodil/wazy/internal/testing/binaryencoding"
+	"github.com/samyfodil/wazy/internal/wasm"
+)
+
+// This file builds SYNTHETIC component binaries in Go, in place of vendoring
+// giant real-world fixtures, to pin the four instantiation-graph behaviors a
+// real componentize-py CPython component depends on and which no decoded
+// fixture in this package exercises:
+//
+//  1. one source core instance regrouped under several consumer-declared
+//     "with" names,
+//  2. several DIFFERENT source core instances sharing one such name,
+//  3. passthrough of an immutable AND a mutable core global, with object
+//     identity preserved (the shared-everything dynamic-linking shape:
+//     `__stack_pointer` and the GOT tables),
+//  4. several exported component instances, where each export interleaved
+//     between two instance definitions shifts the later definition's index.
+//
+// Cases 1-3 are SELF-CHECKING without any component export: each consuming
+// core module carries a wasm `start` function that reads what it was wired to
+// and executes `unreachable` when the value is wrong. The graph runs a core
+// module's start section during instantiation, so a mis-wired graph fails
+// instantiateGraph outright rather than needing a lifted export to observe.
+//
+// Everything is generated in code -- no testdata file, hence nothing for the
+// scratch/BSD CI jobs (which run prebuilt test binaries from the repo root) to
+// fail to find.
+
+// ---------------------------------------------------------------------------
+// component binary assembly
+// ---------------------------------------------------------------------------
+
+// compBuilder assembles a component binary section by section. Sections are
+// emitted in append order, which is exactly what the decoder's index spaces
+// (TypeSpace / CoreFuncSpace / ComponentFuncSpace / ComponentInstanceSpace)
+// are built from -- so a test can reproduce a real binary's cross-section
+// interleaving by calling the section methods in the order it wants.
+type compBuilder struct {
+	buf bytes.Buffer
+}
+
+func newCompBuilder() *compBuilder {
+	b := &compBuilder{}
+	b.buf.Write([]byte{0x00, 0x61, 0x73, 0x6d}) // magic
+	b.buf.Write([]byte{0x0d, 0x00})             // version 13
+	b.buf.Write([]byte{0x01, 0x00})             // layer 1 (component)
+	return b
+}
+
+func (b *compBuilder) section(id byte, body []byte) {
+	b.buf.WriteByte(id)
+	b.buf.Write(leb128.EncodeUint32(uint32(len(body))))
+	b.buf.Write(body)
+}
+
+func (b *compBuilder) bytes() []byte { return b.buf.Bytes() }
+
+// coreModule appends section 1, whose body is the core module binary itself.
+func (b *compBuilder) coreModule(mod []byte) { b.section(1, mod) }
+
+// label encodes a core:name / label: a length-prefixed UTF-8 string.
+func label(s string) []byte {
+	return append(leb128.EncodeUint32(uint32(len(s))), s...)
+}
+
+// externName encodes an import/export name: a 0x00 kind byte then a label.
+func externName(s string) []byte { return append([]byte{0x00}, label(s)...) }
+
+// vec prefixes an already-encoded element list with its count.
+func vec(count int, body []byte) []byte {
+	return append(leb128.EncodeUint32(uint32(count)), body...)
+}
+
+// synthArg is one core:instantiatearg: a "with" name bound to a core instance.
+type synthArg struct {
+	name string
+	inst uint32
+}
+
+// synthInline is one core:inlineexport: a name bound to a core:sortidx.
+type synthInline struct {
+	name string
+	sort byte // 0x00 func, 0x01 table, 0x02 memory, 0x03 global
+	idx  uint32
+}
+
+// synthCoreInstance is one core:instance: either an instantiate (args != nil,
+// or kind 0) or an inline-export group.
+type synthCoreInstance struct {
+	inline    []synthInline // non-nil => the inline-export form
+	moduleIdx uint32
+	args      []synthArg
+}
+
+// coreInstances appends section 2.
+func (b *compBuilder) coreInstances(insts []synthCoreInstance) {
+	var body bytes.Buffer
+	for _, ci := range insts {
+		if ci.inline != nil {
+			body.WriteByte(0x01)
+			body.Write(leb128.EncodeUint32(uint32(len(ci.inline))))
+			for _, e := range ci.inline {
+				body.Write(label(e.name))
+				body.WriteByte(e.sort)
+				body.Write(leb128.EncodeUint32(e.idx))
+			}
+			continue
+		}
+		body.WriteByte(0x00)
+		body.Write(leb128.EncodeUint32(ci.moduleIdx))
+		body.Write(leb128.EncodeUint32(uint32(len(ci.args))))
+		for _, a := range ci.args {
+			body.Write(label(a.name))
+			body.WriteByte(0x12) // instance sort prefix
+			body.Write(leb128.EncodeUint32(a.inst))
+		}
+	}
+	b.section(2, vec(len(insts), body.Bytes()))
+}
+
+// synthAlias is one core-export alias: `(alias core export <instance> "<name>")`
+// for the given core:sort.
+type synthAlias struct {
+	coreSort byte
+	inst     uint32
+	name     string
+}
+
+// coreAliases appends section 6 holding only core-export aliases.
+func (b *compBuilder) coreAliases(aliases []synthAlias) {
+	var body bytes.Buffer
+	for _, al := range aliases {
+		body.WriteByte(0x00)        // sort: core
+		body.WriteByte(al.coreSort) // core:sort
+		body.WriteByte(0x01)        // target: core export
+		body.Write(leb128.EncodeUint32(al.inst))
+		body.Write(label(al.name))
+	}
+	b.section(6, vec(len(aliases), body.Bytes()))
+}
+
+// funcTypeU32Result appends section 7 with a single `(func (result u32))`.
+func (b *compBuilder) funcTypeU32Result() {
+	// 0x40 functype, 0 params, 0x00 unnamed result, 0x79 u32.
+	b.section(7, vec(1, []byte{0x40, 0x00, 0x00, 0x79}))
+}
+
+// canonLift appends section 8 with a single `(canon lift <coreFuncIdx>
+// (type <typeIdx>))`.
+func (b *compBuilder) canonLift(coreFuncIdx, typeIdx uint32) {
+	var body bytes.Buffer
+	body.WriteByte(0x00) // canon kind: lift
+	body.WriteByte(0x00) // lift prefix
+	body.Write(leb128.EncodeUint32(coreFuncIdx))
+	body.WriteByte(0x00) // no opts
+	body.Write(leb128.EncodeUint32(typeIdx))
+	b.section(8, vec(1, body.Bytes()))
+}
+
+// inlineExportInstance appends section 5 with a single inline-export component
+// instance re-listing already-defined component funcs.
+func (b *compBuilder) inlineExportInstance(members map[string]uint32) {
+	var body bytes.Buffer
+	body.WriteByte(0x01) // inline exports
+	body.Write(leb128.EncodeUint32(uint32(len(members))))
+	for name, idx := range members {
+		body.Write(externName(name))
+		body.WriteByte(0x01) // sort: func
+		body.Write(leb128.EncodeUint32(idx))
+	}
+	b.section(5, vec(1, body.Bytes()))
+}
+
+// exportInstance appends section 11 exporting one component instance by index.
+func (b *compBuilder) exportInstance(name string, instIdx uint32) {
+	var body bytes.Buffer
+	body.Write(externName(name))
+	body.WriteByte(0x05) // sort: instance
+	body.Write(leb128.EncodeUint32(instIdx))
+	body.WriteByte(0x00) // no ascribed type
+	b.section(11, vec(1, body.Bytes()))
+}
+
+func decodeSynth(t *testing.T, b *compBuilder) ([]byte, *binary.Component) {
+	t.Helper()
+	raw := b.bytes()
+	comp, err := binary.Decode(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("decode synthetic component: %v", err)
+	}
+	return raw, comp
+}
+
+func runSynth(t *testing.T, raw []byte, comp *binary.Component) (*Instance, error) {
+	t.Helper()
+	ctx := context.Background()
+	r := wazy.NewRuntime(ctx)
+	t.Cleanup(func() { r.Close(ctx) })
+	return instantiateGraph(ctx, r, comp, raw, newConfig(nil))
+}
+
+// ---------------------------------------------------------------------------
+// core module assembly
+// ---------------------------------------------------------------------------
+
+func i32Const(v int32) []byte {
+	return append([]byte{wasm.OpcodeI32Const}, leb128.EncodeInt32(v)...)
+}
+
+// providerModule exports a func returning `ret`, an immutable i32 global
+// `const-g`, a mutable i32 global `mut-g` and a memory -- the four sorts a
+// shared-everything dynamic library regroups through inline-export instances.
+func providerModule(ret int32, constVal, mutVal int32) []byte {
+	body := append(i32Const(ret), wasm.OpcodeEnd)
+	return binaryencoding.EncodeModule(&wasm.Module{
+		TypeSection:     []wasm.FunctionType{{Results: []wasm.ValueType{wasm.ValueTypeI32}, ResultNumInUint64: 1}},
+		FunctionSection: []wasm.Index{0},
+		MemorySection:   &wasm.Memory{Min: 1, Cap: 1, Max: 1, IsMaxEncoded: true},
+		GlobalSection: []wasm.Global{
+			{Type: wasm.GlobalType{ValType: wasm.ValueTypeI32}, Init: wasm.NewConstantExpressionFromOpcode(wasm.OpcodeI32Const, leb128.EncodeInt32(constVal))},
+			{Type: wasm.GlobalType{ValType: wasm.ValueTypeI32, Mutable: true}, Init: wasm.NewConstantExpressionFromOpcode(wasm.OpcodeI32Const, leb128.EncodeInt32(mutVal))},
+		},
+		CodeSection: []wasm.Code{{Body: body}},
+		ExportSection: []wasm.Export{
+			{Name: "id", Type: wasm.ExternTypeFunc, Index: 0},
+			{Name: "const-g", Type: wasm.ExternTypeGlobal, Index: 0},
+			{Name: "mut-g", Type: wasm.ExternTypeGlobal, Index: 1},
+			{Name: "memory", Type: wasm.ExternTypeMemory, Index: 0},
+		},
+	})
+}
+
+// checkFuncModule imports (fromModule, "id") -> i32 and traps in its start
+// function unless it returns want. Any mis-resolution of `fromModule` is
+// therefore a hard instantiation failure.
+func checkFuncModule(fromModule string, want int32) []byte {
+	// start: if (call $id) != want { unreachable }
+	body := []byte{wasm.OpcodeCall, 0x00}
+	body = append(body, i32Const(want)...)
+	body = append(body, wasm.OpcodeI32Ne, wasm.OpcodeIf, 0x40, wasm.OpcodeUnreachable, wasm.OpcodeEnd, wasm.OpcodeEnd)
+	start := wasm.Index(1)
+	return binaryencoding.EncodeModule(&wasm.Module{
+		TypeSection: []wasm.FunctionType{
+			{Results: []wasm.ValueType{wasm.ValueTypeI32}, ResultNumInUint64: 1},
+			{},
+		},
+		ImportSection:       []wasm.Import{{Module: fromModule, Name: "id", Type: wasm.ExternTypeFunc, DescFunc: 0}},
+		ImportFunctionCount: 1,
+		FunctionSection:     []wasm.Index{1},
+		CodeSection:         []wasm.Code{{Body: body}},
+		StartSection:        &start,
+	})
+}
+
+// checkGlobalModule imports an immutable and a mutable i32 global plus a
+// memory, traps unless they hold wantConst/wantMut, then STORES setMut into
+// the mutable one -- so a later module reading it proves the shim shared the
+// one GlobalInstance rather than copying a value.
+func checkGlobalModule(fromModule string, wantConst, wantMut, setMut int32) []byte {
+	var body []byte
+	body = append(body, wasm.OpcodeGlobalGet, 0x00)
+	body = append(body, i32Const(wantConst)...)
+	body = append(body, wasm.OpcodeI32Ne, wasm.OpcodeIf, 0x40, wasm.OpcodeUnreachable, wasm.OpcodeEnd)
+	body = append(body, wasm.OpcodeGlobalGet, 0x01)
+	body = append(body, i32Const(wantMut)...)
+	body = append(body, wasm.OpcodeI32Ne, wasm.OpcodeIf, 0x40, wasm.OpcodeUnreachable, wasm.OpcodeEnd)
+	body = append(body, i32Const(setMut)...)
+	body = append(body, wasm.OpcodeGlobalSet, 0x01, wasm.OpcodeEnd)
+	start := wasm.Index(0)
+	return binaryencoding.EncodeModule(&wasm.Module{
+		TypeSection: []wasm.FunctionType{{}},
+		ImportSection: []wasm.Import{
+			{Module: fromModule, Name: "const-g", Type: wasm.ExternTypeGlobal, DescGlobal: wasm.GlobalType{ValType: wasm.ValueTypeI32}},
+			{Module: fromModule, Name: "mut-g", Type: wasm.ExternTypeGlobal, DescGlobal: wasm.GlobalType{ValType: wasm.ValueTypeI32, Mutable: true}},
+			{Module: fromModule, Name: "memory", Type: wasm.ExternTypeMemory, DescMem: &wasm.Memory{Min: 1, Cap: 1, Max: 1, IsMaxEncoded: true}},
+		},
+		FunctionSection: []wasm.Index{0},
+		CodeSection:     []wasm.Code{{Body: body}},
+		StartSection:    &start,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 1. one source instance regrouped under several consumer names
+// ---------------------------------------------------------------------------
+
+// A single provider core instance is passed to two different consumers under
+// two different "with" names. Before core-instance identity keys, the graph
+// refused this outright ("referenced under 2 names"). Both consumers' start
+// functions assert they reached the real provider.
+func TestSynthGraph_OneSourceRegroupedUnderTwoNames(t *testing.T) {
+	b := newCompBuilder()
+	b.coreModule(providerModule(11, 0, 0))     // core module 0
+	b.coreModule(checkFuncModule("alpha", 11)) // core module 1
+	b.coreModule(checkFuncModule("beta", 11))  // core module 2
+	b.coreInstances([]synthCoreInstance{
+		{moduleIdx: 0}, // 0: the provider
+		{inline: []synthInline{{name: "id", sort: 0x00, idx: 0}}}, // 1: regroup its func
+		{moduleIdx: 1, args: []synthArg{{"alpha", 1}}},            // 2: consumer A
+		{moduleIdx: 2, args: []synthArg{{"beta", 1}}},             // 3: consumer B
+	})
+	b.coreAliases([]synthAlias{{coreSort: 0x00, inst: 0, name: "id"}})
+
+	raw, comp := decodeSynth(t, b)
+	in, err := runSynth(t, raw, comp)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	in.Close(context.Background())
+}
+
+// ---------------------------------------------------------------------------
+// 2. two source instances colliding on one consumer name
+// ---------------------------------------------------------------------------
+
+// Two DIFFERENT regrouping shims are both named "env" -- componentize-py's
+// shape, where every dynamic library gets its own "env". The graph-wide
+// name->module map is last-writer-wins, so before instantiate-args were
+// resolved locally the FIRST consumer silently reached the SECOND provider
+// (or, when the later group didn't export the name at all, failed with
+// `"cabi_realloc" is not exported in module ""`). Each consumer's start
+// function asserts it reached its own provider.
+func TestSynthGraph_CollidingConsumerNamesResolveLocally(t *testing.T) {
+	b := newCompBuilder()
+	b.coreModule(providerModule(21, 0, 0))   // core module 0
+	b.coreModule(providerModule(22, 0, 0))   // core module 1
+	b.coreModule(checkFuncModule("env", 21)) // core module 2: must reach provider A
+	b.coreModule(checkFuncModule("env", 22)) // core module 3: must reach provider B
+	b.coreInstances([]synthCoreInstance{
+		{moduleIdx: 0}, // 0: provider A
+		{moduleIdx: 1}, // 1: provider B
+		{inline: []synthInline{{name: "id", sort: 0x00, idx: 0}}}, // 2: "env" -> A's id
+		{inline: []synthInline{{name: "id", sort: 0x00, idx: 1}}}, // 3: "env" -> B's id
+		{moduleIdx: 2, args: []synthArg{{"env", 2}}},              // 4: consumer of A
+		{moduleIdx: 3, args: []synthArg{{"env", 3}}},              // 5: consumer of B
+	})
+	b.coreAliases([]synthAlias{
+		{coreSort: 0x00, inst: 0, name: "id"},
+		{coreSort: 0x00, inst: 1, name: "id"},
+	})
+
+	raw, comp := decodeSynth(t, b)
+	in, err := runSynth(t, raw, comp)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	in.Close(context.Background())
+}
+
+// The consumer declared LAST is the one the old graph-wide map happened to
+// resolve correctly; this variant puts BOTH consumers after both groups, so a
+// name-keyed resolver sends the first consumer to the wrong provider.
+func TestSynthGraph_CollidingNamesWithBothGroupsFirst(t *testing.T) {
+	b := newCompBuilder()
+	b.coreModule(providerModule(31, 0, 0))
+	b.coreModule(providerModule(32, 0, 0))
+	b.coreModule(checkFuncModule("env", 31))
+	b.coreModule(checkFuncModule("env", 32))
+	b.coreInstances([]synthCoreInstance{
+		{moduleIdx: 0}, // 0
+		{moduleIdx: 1}, // 1
+		{inline: []synthInline{{name: "id", sort: 0x00, idx: 0}}}, // 2
+		{inline: []synthInline{{name: "id", sort: 0x00, idx: 1}}}, // 3
+		{moduleIdx: 2, args: []synthArg{{"env", 2}}},              // 4
+		{moduleIdx: 3, args: []synthArg{{"env", 3}}},              // 5
+	})
+	b.coreAliases([]synthAlias{
+		{coreSort: 0x00, inst: 0, name: "id"},
+		{coreSort: 0x00, inst: 1, name: "id"},
+	})
+	raw, comp := decodeSynth(t, b)
+	in, err := runSynth(t, raw, comp)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	in.Close(context.Background())
+}
+
+// The exact shape that broke a componentize-py CPython component: a
+// regrouping shim aliases core instance 0's "id", but core instance 0 and
+// core instance 1 are BOTH bound under the consumer name "env". Naming the
+// shim's source by that consumer name resolved it to core instance 1 (the
+// later writer), which exports only a memory -- reproducing
+// `"cabi_realloc" is not exported in module ""` with "id" in place of
+// cabi_realloc. Naming it by core-instance identity cannot go wrong.
+func TestSynthGraph_ShimSourceIsIdentityNotConsumerName(t *testing.T) {
+	b := newCompBuilder()
+	b.coreModule(providerModule(71, 3, 4))          // core module 0
+	b.coreModule(checkFuncModule("grp", 71))        // core module 1
+	b.coreModule(checkGlobalModule("env", 3, 4, 4)) // core module 2
+	b.coreInstances([]synthCoreInstance{
+		{moduleIdx: 0}, // 0: the provider, bound as "env" by core instance 3
+		{inline: []synthInline{ // 1: ALSO bound as "env", by core instance 4
+			{name: "memory", sort: 0x02, idx: 0},
+			{name: "const-g", sort: 0x03, idx: 0},
+			{name: "mut-g", sort: 0x03, idx: 1},
+		}},
+		{inline: []synthInline{{name: "id", sort: 0x00, idx: 0}}}, // 2: aliases instance 0's "id"
+		{moduleIdx: 1, args: []synthArg{{"grp", 2}, {"env", 0}}},  // 3
+		{moduleIdx: 2, args: []synthArg{{"env", 1}}},              // 4
+	})
+	b.coreAliases([]synthAlias{
+		{coreSort: 0x00, inst: 0, name: "id"},
+		{coreSort: 0x02, inst: 0, name: "memory"},
+		{coreSort: 0x03, inst: 0, name: "const-g"},
+		{coreSort: 0x03, inst: 0, name: "mut-g"},
+	})
+
+	raw, comp := decodeSynth(t, b)
+	if got := comp.CoreInstances[3].Args[1].Name; got != "env" {
+		t.Fatalf("fixture: core instance 3 arg[1] name = %q, want \"env\"", got)
+	}
+	in, err := runSynth(t, raw, comp)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	in.Close(context.Background())
+}
+
+// A provider core module has both a memory (core memory index 0) and globals,
+// but the provider itself is the source of a memory REGROUPED under a name
+// another instance also claims -- the memory/table sorts take the same
+// identity path as funcs and globals.
+func TestSynthGraph_MemoryPassthroughUsesIdentity(t *testing.T) {
+	b := newCompBuilder()
+	b.coreModule(providerModule(81, 5, 6))          // core module 0
+	b.coreModule(providerModule(82, 7, 8))          // core module 1
+	b.coreModule(checkGlobalModule("env", 5, 6, 6)) // core module 2: must see module 0's
+	b.coreInstances([]synthCoreInstance{
+		{moduleIdx: 0}, // 0
+		{moduleIdx: 1}, // 1
+		{inline: []synthInline{ // 2: regroups instance 0's items, named "env"
+			{name: "memory", sort: 0x02, idx: 0},
+			{name: "const-g", sort: 0x03, idx: 0},
+			{name: "mut-g", sort: 0x03, idx: 1},
+		}},
+		{inline: []synthInline{ // 3: regroups instance 1's items, ALSO named "env"
+			{name: "memory", sort: 0x02, idx: 1},
+			{name: "const-g", sort: 0x03, idx: 2},
+			{name: "mut-g", sort: 0x03, idx: 3},
+		}},
+		{moduleIdx: 2, args: []synthArg{{"env", 2}}}, // 4
+		{moduleIdx: 2, args: []synthArg{{"env", 2}}}, // 5
+	})
+	b.coreAliases([]synthAlias{
+		{coreSort: 0x02, inst: 0, name: "memory"},
+		{coreSort: 0x03, inst: 0, name: "const-g"},
+		{coreSort: 0x03, inst: 0, name: "mut-g"},
+		{coreSort: 0x02, inst: 1, name: "memory"},
+		{coreSort: 0x03, inst: 1, name: "const-g"},
+		{coreSort: 0x03, inst: 1, name: "mut-g"},
+	})
+	raw, comp := decodeSynth(t, b)
+	in, err := runSynth(t, raw, comp)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	in.Close(context.Background())
+}
+
+func TestSynthGraph_InstantiateArgNamesUninstantiatedInstance(t *testing.T) {
+	b := newCompBuilder()
+	b.coreModule(providerModule(41, 0, 0))
+	b.coreModule(checkFuncModule("env", 41))
+	b.coreInstances([]synthCoreInstance{
+		{moduleIdx: 0}, // 0
+		{inline: []synthInline{{name: "id", sort: 0x00, idx: 0}}}, // 1
+		{moduleIdx: 1, args: []synthArg{{"env", 9}}},              // 2: forward ref
+	})
+	b.coreAliases([]synthAlias{{coreSort: 0x00, inst: 0, name: "id"}})
+	raw, comp := decodeSynth(t, b)
+	_, err := runSynth(t, raw, comp)
+	requireErrContains(t, err, `core module 1 instantiate arg "env" references core instance 9, which was not instantiated`)
+}
+
+// ---------------------------------------------------------------------------
+// 3. immutable + mutable core global passthrough
+// ---------------------------------------------------------------------------
+
+// A regrouping shim carries an immutable and a mutable core global (plus a
+// memory, so the shape matches a real `env` group). The first consumer checks
+// both initial values and writes the mutable one; the second checks it sees
+// the write, which only holds if the shim re-exported the SAME GlobalInstance
+// rather than a copy.
+func TestSynthGraph_CoreGlobalPassthroughImmutableAndMutable(t *testing.T) {
+	b := newCompBuilder()
+	b.coreModule(providerModule(0, 7, 42))             // core module 0
+	b.coreModule(checkGlobalModule("env", 7, 42, 99))  // core module 1
+	b.coreModule(checkGlobalModule("env", 7, 99, 100)) // core module 2: sees the write
+	b.coreInstances([]synthCoreInstance{
+		{moduleIdx: 0}, // 0: provider
+		{inline: []synthInline{ // 1: regroup memory + both globals
+			{name: "memory", sort: 0x02, idx: 0},
+			{name: "const-g", sort: 0x03, idx: 0},
+			{name: "mut-g", sort: 0x03, idx: 1},
+		}},
+		{moduleIdx: 1, args: []synthArg{{"env", 1}}}, // 2
+		{moduleIdx: 2, args: []synthArg{{"env", 1}}}, // 3
+	})
+	b.coreAliases([]synthAlias{
+		{coreSort: 0x02, inst: 0, name: "memory"},
+		{coreSort: 0x03, inst: 0, name: "const-g"},
+		{coreSort: 0x03, inst: 0, name: "mut-g"},
+	})
+
+	raw, comp := decodeSynth(t, b)
+	in, err := runSynth(t, raw, comp)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	in.Close(context.Background())
+}
+
+// The shim must declare the source global's real mutability: a `const`
+// declaration against a `var` source is rejected by resolveImports, and the
+// two consumers above would not share state. Assert the encoder emits the
+// mutability byte the item carries.
+func TestBuildPassthroughShim_GlobalEncoding(t *testing.T) {
+	got, err := buildPassthroughShim([]shimItem{
+		{Sort: shimSortGlobal, FromModule: "m", FromName: "c", ExportName: "c2", GlobalType: api.ValueTypeI32},
+		{Sort: shimSortGlobal, FromModule: "m", FromName: "v", ExportName: "v2", GlobalType: api.ValueTypeI64, GlobalMutable: true},
+	})
+	if err != nil {
+		t.Fatalf("buildPassthroughShim: %v", err)
+	}
+	// importdesc global: 0x03 valtype mut
+	if !bytes.Contains(got, []byte{0x03, api.ValueTypeI32, 0x00}) {
+		t.Errorf("missing immutable i32 global import descriptor in %x", got)
+	}
+	if !bytes.Contains(got, []byte{0x03, api.ValueTypeI64, 0x01}) {
+		t.Errorf("missing mutable i64 global import descriptor in %x", got)
+	}
+	// Both must decode and validate as a real core module, with the exports
+	// at global indices 0 and 1.
+	ctx := context.Background()
+	r := wazy.NewRuntime(ctx)
+	defer r.Close(ctx)
+	dec, ok := r.(interface {
+		DecodeModuleNoCompile(bin []byte) (*wasm.Module, error)
+	})
+	if !ok {
+		t.Skip("runtime cannot decode core modules")
+	}
+	m, err := dec.DecodeModuleNoCompile(got)
+	if err != nil {
+		t.Fatalf("decode shim: %v", err)
+	}
+	if len(m.ImportSection) != 2 || m.ImportSection[0].DescGlobal.Mutable || !m.ImportSection[1].DescGlobal.Mutable {
+		t.Fatalf("unexpected import section: %+v", m.ImportSection)
+	}
+	for i, exp := range m.ExportSection {
+		if exp.Type != wasm.ExternTypeGlobal || exp.Index != uint32(i) {
+			t.Errorf("export[%d] = %+v, want global index %d", i, exp, i)
+		}
+	}
+}
+
+func TestBuildPassthroughShim_GlobalWithoutValueType(t *testing.T) {
+	_, err := buildPassthroughShim([]shimItem{{Sort: shimSortGlobal, FromModule: "m", FromName: "g", ExportName: "g"}})
+	requireErrContains(t, err, "has no value type")
+}
+
+func TestSynthGraph_InlineExportGlobalMissingOnSource(t *testing.T) {
+	b := newCompBuilder()
+	b.coreModule(providerModule(0, 7, 42))
+	b.coreInstances([]synthCoreInstance{
+		{moduleIdx: 0},
+		{inline: []synthInline{{name: "g", sort: 0x03, idx: 0}}},
+	})
+	b.coreAliases([]synthAlias{{coreSort: 0x03, inst: 0, name: "nope"}})
+	raw, comp := decodeSynth(t, b)
+	_, err := runSynth(t, raw, comp)
+	requireErrContains(t, err, `has no exported global "nope"`)
+}
+
+func TestSynthGraph_InlineExportGlobalUninstantiatedSource(t *testing.T) {
+	b := newCompBuilder()
+	b.coreModule(providerModule(0, 7, 42))
+	b.coreInstances([]synthCoreInstance{
+		{inline: []synthInline{{name: "g", sort: 0x03, idx: 0}}}, // 0: before its source
+		{moduleIdx: 0}, // 1
+	})
+	b.coreAliases([]synthAlias{{coreSort: 0x03, inst: 1, name: "const-g"}})
+	raw, comp := decodeSynth(t, b)
+	_, err := runSynth(t, raw, comp)
+	requireErrContains(t, err, "core global 0 targets core instance 1, which was not instantiated")
+}
+
+// ---------------------------------------------------------------------------
+// 4. several exported component instances, index space shifted by each export
+// ---------------------------------------------------------------------------
+
+// Section order is (instance)(export)(instance)(export) -- what wit-component
+// emits for a component with two exported interfaces, and what a
+// componentize-py CPython component has. Per Binary.md, "all exports (of all
+// sorts) introduce a new index that aliases the exported definition", so the
+// second definition lands at instance index 2, not 1: the old
+// `ExternIndex - numImportedInstances` arithmetic resolved the second export
+// out of range.
+func TestSynthGraph_TwoExportedInstancesWithInterleavedAliases(t *testing.T) {
+	b := newCompBuilder()
+	b.coreModule(providerModule(55, 0, 0))
+	b.coreInstances([]synthCoreInstance{{moduleIdx: 0}})
+	b.coreAliases([]synthAlias{{coreSort: 0x00, inst: 0, name: "id"}})
+	b.funcTypeU32Result()
+	b.canonLift(0, 0)                                      // component func 0
+	b.inlineExportInstance(map[string]uint32{"first": 0})  // instance def 0 -> instance index 0
+	b.exportInstance("iface-a", 0)                         // introduces instance index 1
+	b.inlineExportInstance(map[string]uint32{"second": 0}) // instance def 1 -> instance index 2
+	b.exportInstance("iface-b", 2)
+
+	raw, comp := decodeSynth(t, b)
+
+	// The decoded index space must show the export-introduced alias between
+	// the two definitions.
+	wantKinds := []binary.ComponentInstanceSpaceEntryKind{
+		binary.ComponentInstanceFromDefinition,
+		binary.ComponentInstanceFromExport,
+		binary.ComponentInstanceFromDefinition,
+		binary.ComponentInstanceFromExport,
+	}
+	if len(comp.ComponentInstanceSpace) != len(wantKinds) {
+		t.Fatalf("instance space: got %+v, want %d entries", comp.ComponentInstanceSpace, len(wantKinds))
+	}
+	for i, want := range wantKinds {
+		if got := comp.ComponentInstanceSpace[i].Kind; got != want {
+			t.Errorf("instance space[%d] kind: got %d, want %d", i, got, want)
+		}
+	}
+	if def, ok := comp.ResolveComponentInstance(2); !ok || def != 1 {
+		t.Fatalf("instance index 2: got (%d, %v), want (1, true)", def, ok)
+	}
+	// An export index resolves THROUGH the alias to the definition it names.
+	if def, ok := comp.ResolveComponentInstance(1); !ok || def != 0 {
+		t.Fatalf("instance index 1 (the export alias): got (%d, %v), want (0, true)", def, ok)
+	}
+
+	in, err := runSynth(t, raw, comp)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close(context.Background())
+
+	ctx := context.Background()
+	for _, tc := range []struct{ iface, member string }{
+		{"iface-a", "first"},
+		{"iface-b", "second"},
+	} {
+		res, err := in.CallExport(ctx, tc.iface, tc.member)
+		if err != nil {
+			t.Fatalf("call %s#%s: %v", tc.iface, tc.member, err)
+		}
+		if len(res) != 1 || res[0] != uint32(55) {
+			t.Errorf("call %s#%s: got %+v, want 55", tc.iface, tc.member, res)
+		}
+	}
+}
+
+func TestSynthGraph_ExportedInstanceIndexOutOfRange(t *testing.T) {
+	b := newCompBuilder()
+	b.coreModule(providerModule(55, 0, 0))
+	b.coreInstances([]synthCoreInstance{{moduleIdx: 0}})
+	b.coreAliases([]synthAlias{{coreSort: 0x00, inst: 0, name: "id"}})
+	b.funcTypeU32Result()
+	b.canonLift(0, 0)
+	b.inlineExportInstance(map[string]uint32{"first": 0})
+	b.exportInstance("iface-a", 7) // nothing at instance index 7
+	raw, comp := decodeSynth(t, b)
+	_, err := runSynth(t, raw, comp)
+	requireErrContains(t, err, "out of range of 0 imported + 1 locally-instantiated instance(s)")
+}
+
+// componentInstanceDef must keep working for a hand-built Component, which has
+// no decoded index space at all -- the pre-existing flat model.
+func TestComponentInstanceDef_HandBuiltFallback(t *testing.T) {
+	comp := &binary.Component{
+		Imports:   []binary.Import{{Name: "i", ExternType: 0x05}},
+		Instances: []binary.Instance{{Kind: 0x01}, {Kind: 0x01}},
+	}
+	if got, ok := componentInstanceDef(comp, 1); !ok || got != 0 {
+		t.Errorf("index 1: got (%d, %v), want (0, true)", got, ok)
+	}
+	if got, ok := componentInstanceDef(comp, 2); !ok || got != 1 {
+		t.Errorf("index 2: got (%d, %v), want (1, true)", got, ok)
+	}
+	if _, ok := componentInstanceDef(comp, 0); ok {
+		t.Error("index 0 names an imported instance; want ok=false")
+	}
+	if _, ok := componentInstanceDef(comp, 3); ok {
+		t.Error("index 3 is out of range; want ok=false")
+	}
+	if got, want := componentInstanceSpaceIndices(comp), []int{1, 2}; got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("space indices: got %v, want %v", got, want)
+	}
+}

--- a/internal/component/instance/graph_test.go
+++ b/internal/component/instance/graph_test.go
@@ -48,16 +48,30 @@ func TestGraph_RequiresCoreFuncSpace(t *testing.T) {
 	requireErrContains(t, err, "requires a component decoded via binary.Decode")
 }
 
-func TestGraph_ModuleNameFor_MultipleNames(t *testing.T) {
+// A source core instance bound under a SECOND consumer-declared name is legal
+// (a `with` name is local to the instantiation that declares it, not a
+// component-wide module name), and used to be rejected outright.
+func TestGraph_MultipleRefNamesAreLegal(t *testing.T) {
 	comp := decodeRealHello(t)
-	// core instance 14 (module1) already references instance 1 (via a
-	// different core instance's arg? no -- reference core instance 1 which
-	// core instance 2 already names "wasi_snapshot_preview1") under a
-	// second name too.
+	// core instance 14 (module1) already references core instance 1, which
+	// core instance 2 names "wasi_snapshot_preview1"; bind it under a second
+	// name too.
 	comp.CoreInstances[14].Args = append(comp.CoreInstances[14].Args,
 		binary.CoreInstantiateArg{Name: "second-name", InstanceIdx: 1})
+	in, err := runGraph(t, comp)
+	if err != nil {
+		t.Fatalf("a second ref name must not fail instantiation: %v", err)
+	}
+	in.Close(context.Background())
+}
+
+func TestGraph_InstantiateArgTargetsUninstantiatedCoreInstance(t *testing.T) {
+	comp := decodeRealHello(t)
+	// Point core instance 14's first arg at a core instance defined LATER,
+	// which the forward-declaration rule forbids.
+	comp.CoreInstances[14].Args[0].InstanceIdx = uint32(len(comp.CoreInstances) - 1)
 	_, err := runGraph(t, comp)
-	requireErrContains(t, err, "referenced under 2 names")
+	requireErrContains(t, err, "which was not instantiated")
 }
 
 func TestGraph_CoreModuleIdxOutOfRange(t *testing.T) {
@@ -83,9 +97,18 @@ func TestGraph_UnknownCoreInstanceKind(t *testing.T) {
 
 func TestGraph_InlineExportUnsupportedSort(t *testing.T) {
 	comp := decodeRealHello(t)
-	comp.CoreInstances[3].Exports[0].Sort = 0x03 // global: unsupported
+	comp.CoreInstances[3].Exports[0].Sort = 0x04 // tag: unsupported
 	_, err := runGraph(t, comp)
 	requireErrContains(t, err, "unsupported core:sort")
+}
+
+func TestGraph_InlineExportGlobalIdxOutOfRange(t *testing.T) {
+	comp := decodeRealHello(t)
+	// real_hello regroups no core globals at all, so any global index is out
+	// of range of its empty core global index space.
+	comp.CoreInstances[3].Exports[0].Sort = 0x03 // global
+	_, err := runGraph(t, comp)
+	requireErrContains(t, err, "out of range of the 0-entry core global index space")
 }
 
 func TestGraph_InlineExportFuncIdxOutOfRange(t *testing.T) {
@@ -294,20 +317,71 @@ func TestGraph_BindInstanceExport_MemberNotFuncSkipped(t *testing.T) {
 
 func TestModuleKeyForGraph(t *testing.T) {
 	// Unreferenced -> synthesized core%d key.
-	if got, err := moduleKeyForGraph(3, nil, "anon"); err != nil || got != "core3" {
-		t.Fatalf("got (%q, %v), want (\"core3\", nil)", got, err)
+	if got := moduleKeyForGraph(3, groupNamesForGraph(nil, "anon")); got != "core3" {
+		t.Fatalf("got %q, want \"core3\"", got)
 	}
 	// A non-empty refName is the raw name consumers import -- no prefix (the key
 	// lives only in the component's private resolver map, never the registry).
-	if got, err := moduleKeyForGraph(3, []string{"foo"}, "anon"); err != nil || got != "foo" {
-		t.Fatalf("got (%q, %v), want (\"foo\", nil)", got, err)
+	if got := moduleKeyForGraph(3, groupNamesForGraph([]string{"foo"}, "anon")); got != "foo" {
+		t.Fatalf("got %q, want \"foo\"", got)
 	}
-	// The sole "" ref maps to the (stable) emptyNameTarget key.
-	if got, err := moduleKeyForGraph(3, []string{""}, "anon-import"); err != nil || got != "anon-import" {
-		t.Fatalf("got (%q, %v), want (\"anon-import\", nil)", got, err)
+	// A "" ref maps to the (stable) emptyNameTarget key.
+	if got := moduleKeyForGraph(3, groupNamesForGraph([]string{""}, "anon-import")); got != "anon-import" {
+		t.Fatalf("got %q, want \"anon-import\"", got)
 	}
-	if _, err := moduleKeyForGraph(3, []string{"a", "b"}, "anon"); err == nil {
-		t.Fatal("expected an error for 2 ref names")
+	// Several ref names are legal (a source instance may be bound under more
+	// than one "with" name): the first is the fallback-resolver key, and ALL
+	// of them are group names for the neededTypes lookup. Identity is
+	// coreInstanceKey, so no name has to be unique.
+	names := groupNamesForGraph([]string{"a", "", "b"}, "anon-import")
+	if got, want := len(names), 3; got != want {
+		t.Fatalf("group names: got %d, want %d (%v)", got, want, names)
+	}
+	if names[1] != "anon-import" {
+		t.Errorf("group names: got %v, want the \"\" entry mapped to the empty-import key", names)
+	}
+	if got := moduleKeyForGraph(3, names); got != "a" {
+		t.Fatalf("got %q, want \"a\"", got)
+	}
+}
+
+func TestCoreInstanceKeyIsDistinctAndComponentConstant(t *testing.T) {
+	if a, b := coreInstanceKey(2), coreInstanceKey(3); a == b {
+		t.Fatalf("core instance keys collide: %q", a)
+	}
+	// Component-CONSTANT (a function of the static index alone) is what keeps
+	// a shim's bytes identical across instantiations -- OPTIMIZATIONS.md CM10.
+	if a, b := coreInstanceKey(12), coreInstanceKey(12); a != b {
+		t.Fatalf("core instance key is not stable: %q != %q", a, b)
+	}
+	if got, want := coreInstanceKey(12), "wazy:core-instance/12"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestQuoteNames(t *testing.T) {
+	if got, want := quoteNames(nil), "(none)"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if got, want := quoteNames([]string{"env"}), `"env"`; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if got, want := quoteNames([]string{"a", "b"}), `"a" or "b"`; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestLookupCoreFuncSig_TriesEveryGroupName(t *testing.T) {
+	needed := map[string]map[string]coreFuncSig{
+		"second": {"f": {params: []api.ValueType{api.ValueTypeI64}}},
+	}
+	// The first name declares nothing; the second does.
+	sig, ok := lookupCoreFuncSig(needed, []string{"first", "second"}, "f")
+	if !ok || len(sig.params) != 1 || sig.params[0] != api.ValueTypeI64 {
+		t.Fatalf("got (%+v, %v), want the \"second\" group's signature", sig, ok)
+	}
+	if _, ok := lookupCoreFuncSig(needed, []string{"first"}, "f"); ok {
+		t.Fatal("expected no match when no group name declares the field")
 	}
 }
 
@@ -352,7 +426,7 @@ func TestBuildCanonHostModule_LowersLiftedFunc(t *testing.T) {
 	ctx := context.Background()
 	r := wazy.NewRuntime(ctx)
 	defer r.Close(ctx)
-	_, _, _, _, _, err := buildCanonHostModule(ctx, r, comp, newConfig(nil), newHandleTable(), nil, canon, nil, "g", "e", "p", nil, nil, nil)
+	_, _, _, _, _, err := buildCanonHostModule(ctx, r, comp, newConfig(nil), newHandleTable(), nil, canon, nil, []string{"g"}, "e", "p", nil, nil, nil)
 	requireErrContains(t, err, "lowers a lifted")
 }
 
@@ -377,7 +451,7 @@ func TestBuildCanonHostModule_ImportInterfaceNameError(t *testing.T) {
 	ctx := context.Background()
 	r := wazy.NewRuntime(ctx)
 	defer r.Close(ctx)
-	_, _, _, _, _, err := buildCanonHostModule(ctx, r, comp, newConfig(nil), newHandleTable(), nil, canon, nil, "g", "e", "p", nil, nil, nil)
+	_, _, _, _, _, err := buildCanonHostModule(ctx, r, comp, newConfig(nil), newHandleTable(), nil, canon, nil, []string{"g"}, "e", "p", nil, nil, nil)
 	requireErrContains(t, err, "out of range")
 }
 
@@ -392,7 +466,7 @@ func TestBuildCanonHostModule_WithImportOverride(t *testing.T) {
 	hostFn := func(context.Context, []abi.Value) ([]abi.Value, error) { return nil, nil }
 	cfg := newConfig([]Option{WithImport("wasi:cli/stderr@0.2.3", "get-stderr", hostFn, nil, nil)})
 
-	mod, exportName, _, _, wasiCall, err := buildCanonHostModule(ctx, r, comp, cfg, newHandleTable(), nil, canon, nil, "g", "e", "wazy:component/testpriv1", nil, nil, nil)
+	mod, exportName, _, _, wasiCall, err := buildCanonHostModule(ctx, r, comp, cfg, newHandleTable(), nil, canon, nil, []string{"g"}, "e", "wazy:component/testpriv1", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildCanonHostModule: %v", err)
 	}
@@ -412,7 +486,7 @@ func TestBuildCanonHostModule_UnsupportedCanonKind(t *testing.T) {
 	ctx := context.Background()
 	r := wazy.NewRuntime(ctx)
 	defer r.Close(ctx)
-	_, _, _, _, _, err := buildCanonHostModule(ctx, r, comp, newConfig(nil), newHandleTable(), nil, binary.Canon{Kind: 0xff}, nil, "g", "e", "p", nil, nil, nil)
+	_, _, _, _, _, err := buildCanonHostModule(ctx, r, comp, newConfig(nil), newHandleTable(), nil, binary.Canon{Kind: 0xff}, nil, []string{"g"}, "e", "p", nil, nil, nil)
 	requireErrContains(t, err, "does not produce a core func")
 }
 

--- a/internal/component/instance/shim.go
+++ b/internal/component/instance/shim.go
@@ -9,9 +9,10 @@ import (
 )
 
 // This file hand-encodes minimal core WebAssembly binaries for "passthrough
-// shim" modules: a module whose only job is to import a func/memory/table
-// from an already-instantiated real module (by its wazy-registered name) and
-// immediately re-export it, verbatim, under a (possibly different) name.
+// shim" modules: a module whose only job is to import a func/table/memory/
+// global from an already-instantiated real module (by its wazy-registered
+// name) and immediately re-export it, verbatim, under a (possibly different)
+// name.
 //
 // # Why this exists
 //
@@ -22,19 +23,22 @@ import (
 // instance that a *different* core module then imports as "env"."memory".
 //
 // wazy's public API has no way to build a *host* module (r.NewHostModuleBuilder)
-// that exports a memory or table: HostModuleBuilder only supports Go-backed
-// funcs (see builder.go), and api.Module has no Table() accessor at all (see
-// the "TODO: Table" note on api.Module). But per the Component Model's
-// "shared-everything" semantics, a re-grouped memory or table MUST be the
-// exact same underlying object as its source -- e.g. module1's adapter code
-// reads/writes offsets that module0's _start already computed, through
-// module1's own load/store instructions against an *imported* memory, so a
-// copy would silently desync the two modules' views of memory.
+// that exports a memory, table or global: HostModuleBuilder only supports
+// Go-backed funcs (see builder.go), and api.Module has no Table() accessor at
+// all (see the "TODO: Table" note on api.Module). But per the Component
+// Model's "shared-everything" semantics, a re-grouped memory, table or global
+// MUST be the exact same underlying object as its source -- e.g. module1's
+// adapter code reads/writes offsets that module0's _start already computed,
+// through module1's own load/store instructions against an *imported* memory,
+// so a copy would silently desync the two modules' views of memory. The same
+// goes for a shared-everything dynamic library's mutable `__stack_pointer`
+// global, which every linked core module must see (and update) as one object.
 //
 // A real (non-host) core module that imports an item and exports it right
 // back, unmodified, achieves this for free: wazy's own module-linking
 // resolves such an import by sharing the underlying MemoryInstance/
-// TableInstance object (see internal/wasm/store.go's resolveImports), exactly
+// TableInstance/GlobalInstance object (see internal/wasm/store.go's
+// resolveImports), exactly
 // like any two real wasm modules linked together. So rather than extend
 // wazy's public surface (a much larger change), this package hand-encodes the
 // (tiny, purely mechanical -- no instructions, no code section at all, since
@@ -51,13 +55,14 @@ import (
 
 // shimSort is the core:sort of one passthrough item, matching the
 // core-wasm-binary importdesc/exportdesc discriminator (funcs 0x00, tables
-// 0x01, memories 0x02).
+// 0x01, memories 0x02, globals 0x03).
 type shimSort byte
 
 const (
 	shimSortFunc   shimSort = 0x00
 	shimSortTable  shimSort = 0x01
 	shimSortMemory shimSort = 0x02
+	shimSortGlobal shimSort = 0x03
 )
 
 // shimItem is one passthrough entry: import (fromModule, fromName) and
@@ -66,13 +71,22 @@ const (
 // with no bounds (min 0, no max -- always satisfiable against any real
 // table, see buildPassthroughShim), and memories are always declared with no
 // bounds either, for the same reason.
+//
+// GlobalType/GlobalMutable are meaningful (and required) when Sort ==
+// shimSortGlobal. Unlike a table or memory, a global import is NOT satisfied
+// by a permissive declaration: store.go's resolveImports requires the declared
+// value type and mutability to match the source global EXACTLY, so both are
+// read off the live source global by the caller (see resolveInlineExportItem)
+// and reproduced verbatim here.
 type shimItem struct {
-	Sort       shimSort
-	FromModule string
-	FromName   string
-	ExportName string
-	Params     []api.ValueType // Sort == shimSortFunc only
-	Results    []api.ValueType // Sort == shimSortFunc only
+	Sort          shimSort
+	FromModule    string
+	FromName      string
+	ExportName    string
+	Params        []api.ValueType // Sort == shimSortFunc only
+	Results       []api.ValueType // Sort == shimSortFunc only
+	GlobalType    api.ValueType   // Sort == shimSortGlobal only
+	GlobalMutable bool            // Sort == shimSortGlobal only
 }
 
 // buildPassthroughShim encodes a minimal core wasm binary that imports every
@@ -94,7 +108,7 @@ func buildPassthroughShim(items []shimItem) ([]byte, error) {
 
 	var typeSec, importSec, exportSec bytes.Buffer
 	var typeCount, importCount, exportCount uint32
-	var funcIdx, tableIdx, memIdx uint32
+	var funcIdx, tableIdx, memIdx, globalIdx uint32
 
 	for i, it := range items {
 		if it.FromModule == "" || it.FromName == "" {
@@ -148,6 +162,27 @@ func buildPassthroughShim(items []shimItem) ([]byte, error) {
 			exportSec.Write(leb128.EncodeUint32(memIdx))
 			exportCount++
 			memIdx++
+
+		case shimSortGlobal:
+			if it.GlobalType == 0 {
+				return nil, fmt.Errorf("component/instance: buildPassthroughShim: item[%d] (global %q) has no value type", i, it.FromName)
+			}
+			writeName(&importSec, it.FromModule)
+			writeName(&importSec, it.FromName)
+			importSec.WriteByte(0x03)          // importdesc: global
+			importSec.WriteByte(it.GlobalType) // globaltype: valtype
+			if it.GlobalMutable {
+				importSec.WriteByte(0x01) // mut: var
+			} else {
+				importSec.WriteByte(0x00) // mut: const
+			}
+			importCount++
+
+			writeName(&exportSec, it.ExportName)
+			exportSec.WriteByte(0x03) // exportdesc: global
+			exportSec.Write(leb128.EncodeUint32(globalIdx))
+			exportCount++
+			globalIdx++
 
 		default:
 			return nil, fmt.Errorf("component/instance: buildPassthroughShim: item[%d] has unsupported sort %#x", i, it.Sort)

--- a/internal/component/instance/thread.go
+++ b/internal/component/instance/thread.go
@@ -434,7 +434,7 @@ func threadSuspendHostFunc(in *Instance, canon binary.Canon) hostFuncDef {
 // something actually resumes this thread -- typically
 // thread.yield-then-resume, 0x2b).
 func threadNewIndirectHostFunc(
-	in *Instance, canon binary.Canon, neededTypes map[string]map[string]coreFuncSig, groupName, entryName string,
+	in *Instance, canon binary.Canon, neededTypes map[string]map[string]coreFuncSig, groupNames []string, entryName string,
 	coreTableTarget func(int) (api.Module, string, error),
 ) (hostFuncDef, error) {
 	in.syncTaskNeeded, in.mayBlockSync = true, true
@@ -461,9 +461,9 @@ func threadNewIndirectHostFunc(
 	// core type section. sig.params[0] is the func-table index (always i32);
 	// sig.params[1] is flatten(ft.param) -- the reference's ft is always
 	// exactly (i32)->() or (i64)->().
-	sig, sok := neededTypes[groupName][entryName]
+	sig, sok := lookupCoreFuncSig(neededTypes, groupNames, entryName)
 	if !sok {
-		return hostFuncDef{}, fmt.Errorf("thread.new-indirect: cannot determine the core-level signature: no consumer declares module %q field %q", groupName, entryName)
+		return hostFuncDef{}, fmt.Errorf("thread.new-indirect: cannot determine the core-level signature: no consumer declares module %s field %q", quoteNames(groupNames), entryName)
 	}
 	if len(sig.params) != 2 || sig.params[0] != api.ValueTypeI32 ||
 		(sig.params[1] != api.ValueTypeI32 && sig.params[1] != api.ValueTypeI64) ||

--- a/internal/component/instance/thread_test.go
+++ b/internal/component/instance/thread_test.go
@@ -363,7 +363,7 @@ func TestThreadNewIndirectHostFunc_BindThenNoActiveTaskPanics(t *testing.T) {
 		return mod, "t", nil
 	}
 
-	def, err := threadNewIndirectHostFunc(in, canon, neededTypes, "g", "e", coreTableTarget)
+	def, err := threadNewIndirectHostFunc(in, canon, neededTypes, []string{"g"}, "e", coreTableTarget)
 	if err != nil {
 		t.Fatalf("threadNewIndirectHostFunc bind: %v", err)
 	}
@@ -387,7 +387,7 @@ func TestThreadNewIndirectHostFunc_BadTableIndexFailsBind(t *testing.T) {
 	coreTableTarget := func(int) (api.Module, string, error) {
 		return nil, "", fmt.Errorf("test: table index out of range")
 	}
-	_, err := threadNewIndirectHostFunc(in, canon, nil, "g", "e", coreTableTarget)
+	_, err := threadNewIndirectHostFunc(in, canon, nil, []string{"g"}, "e", coreTableTarget)
 	if err == nil {
 		t.Fatal("expected a bind-time error for an unresolvable table index")
 	}
@@ -406,7 +406,7 @@ func TestThreadNewIndirectHostFunc_WrongSignatureFailsBind(t *testing.T) {
 		"g": {"e": {params: []api.ValueType{api.ValueTypeI32}, results: []api.ValueType{api.ValueTypeI32}}}, // wrong arity
 	}
 	coreTableTarget := func(int) (api.Module, string, error) { return mod, "t", nil }
-	_, err := threadNewIndirectHostFunc(in, canon, neededTypes, "g", "e", coreTableTarget)
+	_, err := threadNewIndirectHostFunc(in, canon, neededTypes, []string{"g"}, "e", coreTableTarget)
 	if err == nil {
 		t.Fatal("expected a bind-time error for a non-legal-shape consumer signature")
 	}
@@ -422,7 +422,7 @@ func TestThreadNewIndirectHostFunc_MissingSignatureFailsBind(t *testing.T) {
 	in := &Instance{sched: &sched{}, mayLeave: true}
 	canon := binary.Canon{Kind: binary.CanonKindThreadNewIndirect, TableIdx: 0}
 	coreTableTarget := func(int) (api.Module, string, error) { return mod, "t", nil }
-	_, err := threadNewIndirectHostFunc(in, canon, nil, "g", "e", coreTableTarget)
+	_, err := threadNewIndirectHostFunc(in, canon, nil, []string{"g"}, "e", coreTableTarget)
 	if err == nil {
 		t.Fatal("expected a bind-time error when neededTypes has no entry for this group/entry")
 	}
@@ -482,7 +482,7 @@ func bindThreadFuncTableNewIndirect(t *testing.T, in *Instance, mod api.Module) 
 		"g": {"e": {params: []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, results: []api.ValueType{api.ValueTypeI32}}},
 	}
 	coreTableTarget := func(int) (api.Module, string, error) { return mod, "t", nil }
-	def, err := threadNewIndirectHostFunc(in, canon, neededTypes, "g", "e", coreTableTarget)
+	def, err := threadNewIndirectHostFunc(in, canon, neededTypes, []string{"g"}, "e", coreTableTarget)
 	if err != nil {
 		t.Fatalf("threadNewIndirectHostFunc bind: %v", err)
 	}


### PR DESCRIPTION
A downstream embedder ([pycage](https://github.com/samyfodil/pycage)) could not instantiate a real `componentize-py` CPython component at all:

```
component/instance: instantiate regrouping shim for core instance 12
  (key "__main_module__"): "cabi_realloc" is not exported in module ""
```

That component is the first fixture in this repo to reach four separate graph-engine defects. With this PR it instantiates, boots CPython, and executes Python source; the next failure is unrelated (`wasi:filesystem/types.descriptor.get-flags`, handled separately).

## 1. Core-module imports were resolved through a graph-wide name map

`Binary.md` is explicit about how a two-level core import resolves:

> The first import name is looked up in the named list of `core:instantiatearg` to select a core module instance. The second import name is looked up in the named list of exports of the core module instance found by the first step.

A `with` name is therefore a binding local to **one** `core:instance` definition, not an entry in a component-wide namespace. `instantiateGraph` instead resolved every core import through a single shared `name -> module` map (`keyToInst`), which is last-writer-wins. A `componentize-py` component binds **ten** different core instances as `"env"`, three as `"wasi_snapshot_preview1"`, and five as `"GOT.mem"`.

Each instantiation now resolves its own `ci.Args` first and falls back to the graph resolver only for a name its args do not cover. A missing arg target fails loud, naming the module index, the arg name and the referenced core-instance index.

**Deviation from the proposal:** rather than always building a local `map[string]api.Module`, the loop validates every arg and only installs a local resolver when at least one arg actually disagrees with what the graph map would return. That keeps the pre-existing allocation-free path for every component with no name reuse (i.e. every fixture in this repo), and behaviour is identical because the local map would have returned the same module anyway.

## 2. Regrouping shims named their alias sources by a consumer-declared name

Same ambiguity on the shim side, and the direct cause of the reported error. Core instance 12 aliases core instance **2**'s `cabi_realloc`, but instances 2 and 3 are *both* bound as `"env"`, so `keys[al.InstanceIdx]` pointed the shim at instance 3 — a group that exports only a memory.

Every instantiated core instance is now also registered under a collision-free identity key, `wazy:core-instance/<index>`, and every passthrough shim item (func, table, memory, global) imports from that identity rather than a consumer alias. Multiple `with` names for one source instance are consequently legal — they used to be rejected outright with *"referenced under N names"* — and all of a group's names are tried when looking a lowered import's core-level signature up in `neededTypes`.

### CompileCache evidence (the CM10 constraint)

`wazy:core-instance/<index>` is component-constant (the index is static), exactly like `wazy:canon-group/<k>` and `wazy:component/empty-import`, so shim bytes stay byte-identical across instantiations.

* `TestCompileCache_TwoHelloLiveShareShims` and `TestCompileCache_HelloReinstantiateAfterCloseOnSameRuntime` still pass.
* New `TestCompileCache_ShimBytesStableAcrossInstantiations` asserts this directly: a second `Instantiate` of `real_hello` through the same cache adds **zero** entries to `byKey`, and `byKey` holds exactly `len(CoreModules) + <shim count>` compiled modules — so no shim bypassed the cache.
* Allocation counts (`-benchtime 300x`, `origin/main` → this branch):

  | benchmark | before | after |
  |---|---|---|
  | `InstantiateHelloCached` | 1679 allocs/op | 1688 allocs/op (+0.5%) |
  | `InstantiateCached` | 101 | 102 |
  | `InstantiateHello` | 12419 | 12434 |
  | `Instantiate` | 2122 | 2126 |

  The residual is map growth from the extra identity keys. The naive versions of this change cost +64 allocs/op; `coreInstanceKey` interns the first 128 keys once per process instead of `fmt.Sprintf`-ing per instantiation, and `groupNamesForGraph` returns the ref-name slice uncopied when no rewrite is needed.

## 3. Inline core-global passthrough was unimplemented (`core:sort 0x03`)

`componentize-py`'s shared-everything dynamic linking regroups `__stack_pointer`, `__memory_base`/`__table_base`, and the entire `GOT.func`/`GOT.mem` relocation table as **core globals** — 542 of them in this component. The graph rejected the sort outright.

* Graph side: a `coreGlobalSpace` is built from global-sort core aliases (in slice order, like memory/table — no canon produces a global), the target instance and exported global are resolved, and the value type + `api.MutableGlobal` detection are carried on the shim item.
* Shim side: `shimSortGlobal = 0x03`, `GlobalType`/`GlobalMutable` on `shimItem`, and the encoder emits import kind `0x03` + valtype + mutability byte, export kind `0x03` + global index.

Unlike a table or memory — where a permissive `min=0`/no-max declaration always validates — `store.go`'s `resolveImports` requires a global import to match the source's value type **and** mutability exactly, so both are read off the live source global rather than guessed. The shim shares the one `GlobalInstance`, which is what makes a mutable stack pointer observable across linked libraries.

## 4. Exported component-instance index calculation

`Binary.md`, on the export section:

> all exports (of all sorts) introduce a new index that aliases the exported definition and can be used by all subsequent definitions just like an alias

Confirmed against the real binary: the CPython component's top-level section order ends `… 4, 5, 11, … 4, 5, 11`, i.e. `(component)(instance)(export)` twice. With 27 instance imports, the first definition sits at instance index 27, the first export introduces index 28, and the **second definition** is at index 29 — which the second export names. `ExternIndex - numImportedInstances` computes `29 - 27 = 2`, past the end of the 2-entry `comp.Instances`.

**Deviation from the proposal:** rather than "also subtract earlier exported instances", the decoder now records a real `ComponentInstanceSpace` (imports / definitions / aliases / exports, in declaration order across sections) — the same construction already used for `TypeSpace`, `CoreFuncSpace` and `ComponentFuncSpace`. The subtraction heuristic is only correct while every instance definition precedes every instance export; it silently mis-resolves the layout `I0 I1 E0 E1` (E1 would resolve to definition 0). The index space is correct for any interleaving, and `ResolveComponentInstance` also follows an export's aliasing index through to the definition it names.

Consumers updated to use it: `bindInstanceExportGraph`, `instantiateNestedInstances` (a sub-instance is keyed by its true space index, not `numImported+i`), `computeCanonHostFunc`'s local-vs-imported instance discrimination, and `outerFuncArgImport`. A hand-built `binary.Component` has no index space, so `componentInstanceDef` falls back to the previous flat arithmetic — the shape those fixtures actually have.

## Tests

Synthetic component binaries assembled in Go (`internal/component/instance/graph_synth_test.go`), not vendored fixtures — the real component is 55 MB. Cases 1–3 are self-checking without any component export: each consuming core module carries a wasm `start` function that reads what it was wired to and executes `unreachable` on a mismatch, so a mis-wired graph fails `instantiateGraph` outright. Nothing is read from disk, so the scratch/BSD/illumos jobs (which run prebuilt test binaries from the repo root) are unaffected.

| test | pins |
|---|---|
| `TestSynthGraph_OneSourceRegroupedUnderTwoNames` | one source instance bound under two `with` names |
| `TestSynthGraph_CollidingConsumerNamesResolveLocally` / `…WithBothGroupsFirst` | two source instances sharing one name; each consumer reaches its own |
| `TestSynthGraph_ShimSourceIsIdentityNotConsumerName` | the exact pycage shape — reproduces `"id" is not exported in module ""` when reverted |
| `TestSynthGraph_MemoryPassthroughUsesIdentity` | memory/global items take the identity path too |
| `TestSynthGraph_CoreGlobalPassthroughImmutableAndMutable` | both mutabilities, plus `GlobalInstance` identity (a second module observes the first's write) |
| `TestSynthGraph_TwoExportedInstancesWithInterleavedAliases` | `(instance)(export)(instance)(export)`; both exports bind and call |
| `TestComponentInstanceSpace_ExportsShiftLaterDefinitions` | decoder-level index-space ordering |

Every one was confirmed to **fail** against the pre-fix behaviour (local-arg resolution disabled / consumer-name shim sources / old instance arithmetic) before being kept. New fail-loud branches are covered too: missing arg target, missing/uninstantiated global source, global item with no value type, out-of-range global index, out-of-range exported instance, and `ResolveComponentInstance`'s degenerate/cyclic cases.

## Verification

* `go build ./... && go test ./...` green; `go test -race ./internal/component/...` green.
* All 35 `conformance_test.go` fixtures pass, plus `TestAsyncWastConformance` and the stackful suites.
* `go test ./internal/component/instance/ -cover` → **90.3%** (at the gate).
* `make lint` → **102 issues**, byte-identical to `origin/main` in the same worktree; none in the touched files.
* Cross-compile clean: `GOOS=plan9|js|wasip1|aix|freebsd|windows|darwin`, `GOARCH=386|arm|s390x|ppc64le`.
