### PR TITLE
fix(component): name the resource in handle-table errors

### DIFF
--- a/internal/component/instance/graph.go
+++ b/internal/component/instance/graph.go
@@ -301,6 +301,9 @@ func instantiateGraph(ctx context.Context, r wazy.Runtime, comp *binary.Componen
 	for tag, fn := range cfg.hostResDtors {
 		resources.registerDtor(tag, fn)
 	}
+	// Give the table the WIT names behind the tags, so a handle error names
+	// the resource the guest asked for instead of an internal number.
+	resources.setResourceNames(cfg.resourceTags)
 	runResourceHooks(cfg, resources)
 	instMods := make(map[int]api.Module, len(comp.CoreInstances))
 	var closers []api.Module

--- a/internal/component/instance/host_import.go
+++ b/internal/component/instance/host_import.go
@@ -976,21 +976,21 @@ func resolveHandleArg(in *Instance, resources *handleTable, canon func(uint32) u
 	case binary.OwnDesc:
 		h, ok := v.(uint32)
 		if !ok {
-			return nil, fmt.Errorf("own<%d> arg: expected a uint32 handle, got %T", d.ResourceType, v)
+			return nil, fmt.Errorf("own<%s> arg: expected a uint32 handle, got %T", resources.shortTypeName(tag(d.ResourceType)), v)
 		}
 		rep, err := resources.TakeOwn(tag(d.ResourceType), h)
 		if err != nil {
-			return nil, fmt.Errorf("own<%d> arg: %w", d.ResourceType, err)
+			return nil, fmt.Errorf("own<%s> arg: %w", resources.shortTypeName(tag(d.ResourceType)), err)
 		}
 		return rep, nil
 	case binary.BorrowDesc:
 		h, ok := v.(uint32)
 		if !ok {
-			return nil, fmt.Errorf("borrow<%d> arg: expected a uint32 handle, got %T", d.ResourceType, v)
+			return nil, fmt.Errorf("borrow<%s> arg: expected a uint32 handle, got %T", resources.shortTypeName(tag(d.ResourceType)), v)
 		}
 		rep, err := resources.Rep(tag(d.ResourceType), h)
 		if err != nil {
-			return nil, fmt.Errorf("borrow<%d> arg: %w", d.ResourceType, err)
+			return nil, fmt.Errorf("borrow<%s> arg: %w", resources.shortTypeName(tag(d.ResourceType)), err)
 		}
 		return rep, nil
 

--- a/internal/component/instance/resource.go
+++ b/internal/component/instance/resource.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/samyfodil/wazy/api"
@@ -129,6 +130,75 @@ type handleTable struct {
 	// the first drop); a HOST-provided resource's dtor is a Go callback (drop
 	// accounting). nil callback means drop just removes the entry.
 	dtors map[uint32]func(ctx context.Context, rep uint32) error
+
+	// names maps a resource type tag to the WIT name it was registered under
+	// (withResourceTag), used only to make this table's errors legible: a
+	// tag is an internal number that means nothing to someone reading a trap,
+	// whereas "network (wasi:sockets/network)" names the thing the guest
+	// actually asked for. Populated once per instance by setResourceNames;
+	// nil (every tag unnamed) is valid and degrades to bare numbers.
+	names map[uint32]string
+}
+
+// setResourceNames records tag -> WIT name for this table's error messages,
+// inverting the config's (iface, name) -> tag registrations. A tag registered
+// under several interfaces keeps the first name seen; the point is a legible
+// label, not a canonical one.
+func (t *handleTable) setResourceNames(tags map[importKey]uint32) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.names == nil {
+		t.names = make(map[uint32]string, len(tags))
+	}
+	for key, tag := range tags {
+		if _, taken := t.names[tag]; !taken {
+			t.names[tag] = fmt.Sprintf("%s (%s)", key.name, key.iface)
+		}
+	}
+}
+
+// typeName renders a resource type tag for an error message: its registered
+// WIT name when there is one, else the bare tag. Callers must NOT hold t.mu.
+func (t *handleTable) typeName(typeIdx uint32) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.typeNameLocked(typeIdx)
+}
+
+// shortTypeName is typeName without the interface qualifier, for a caller
+// that wraps an error this table already fully named -- so "borrow<network>
+// arg: unknown handle index 15 for network (wasi:sockets/network): ..." reads
+// once rather than twice.
+func (t *handleTable) shortTypeName(typeIdx uint32) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if n, ok := t.names[typeIdx]; ok {
+		if i := strings.IndexByte(n, ' '); i > 0 {
+			return n[:i]
+		}
+		return n
+	}
+	return fmt.Sprintf("resource type %d", typeIdx)
+}
+
+// typeNameLocked is typeName's body for callers already holding t.mu.
+func (t *handleTable) typeNameLocked(typeIdx uint32) string {
+	if n, ok := t.names[typeIdx]; ok {
+		return n
+	}
+	return fmt.Sprintf("resource type %d", typeIdx)
+}
+
+// liveCountLocked reports how many live handles this table holds for typeIdx.
+// Only ever called on an error path, so the scan costs nothing in practice.
+func (t *handleTable) liveCountLocked(typeIdx uint32) int {
+	n := 0
+	for _, raw := range t.entries {
+		if e, ok := raw.(*resourceEntry); ok && e.typeIdx == typeIdx {
+			n++
+		}
+	}
+	return n
 }
 
 // registerDtor records the destructor callback for a resource type tag.
@@ -263,14 +333,23 @@ func (t *handleTable) NewBorrowScoped(typeIdx, rep uint32, scope *task) uint32 {
 func (t *handleTable) lookup(typeIdx, h uint32) (*resourceEntry, error) {
 	raw, ok := t.entryAt(h)
 	if !ok {
-		return nil, fmt.Errorf("unknown handle index %d", h)
+		// Name the resource and say how many of them are live, because those
+		// two facts separate the three ways to get here and the reader cannot
+		// tell them apart from a bare index: none live at all means the guest
+		// passed a handle this component instance never issued; some live
+		// means it passed a stale or already-dropped one.
+		if live := t.liveCountLocked(typeIdx); live == 0 {
+			return nil, fmt.Errorf("unknown handle index %d for %s: this component instance holds no handles of that resource, so it was never returned by a host call here", h, t.typeNameLocked(typeIdx))
+		} else {
+			return nil, fmt.Errorf("unknown handle index %d for %s: %d handle(s) of that resource are live, so this one was already dropped or never existed", h, t.typeNameLocked(typeIdx), live)
+		}
 	}
 	e, ok := raw.(*resourceEntry)
 	if !ok {
-		return nil, fmt.Errorf("handle %d is not a resource handle", h)
+		return nil, fmt.Errorf("handle %d is not a resource handle (expected %s)", h, t.typeNameLocked(typeIdx))
 	}
 	if e.typeIdx != typeIdx {
-		return nil, fmt.Errorf("handle %d belongs to resource type %d, not %d", h, e.typeIdx, typeIdx)
+		return nil, fmt.Errorf("handle %d belongs to %s, not %s", h, t.typeNameLocked(e.typeIdx), t.typeNameLocked(typeIdx))
 	}
 	return e, nil
 }

--- a/internal/component/instance/resource_test.go
+++ b/internal/component/instance/resource_test.go
@@ -571,3 +571,82 @@ func TestResourceRoundtrip_UnknownHandle(t *testing.T) {
 		t.Fatal("expected resource.drop of an unknown handle to fail")
 	}
 }
+
+// TestHandleTable_ErrorsNameTheResource pins the diagnostics a handle failure
+// produces. The messages exist to answer a specific question a bare tag
+// number cannot: a real componentize-py guest once called
+// wasi:sockets/tcp.start-bind with a network handle this runtime had never
+// issued, and the error said only "borrow<8> arg: unknown handle index 15",
+// which reads like a lifetime bug in the socket rather than what it was --
+// no network had ever been created at all.
+func TestHandleTable_ErrorsNameTheResource(t *testing.T) {
+	const networkTag, socketTag, untaggedTag = uint32(8), uint32(9), uint32(77)
+
+	newNamedTable := func() *handleTable {
+		tbl := newHandleTable()
+		tbl.setResourceNames(map[importKey]uint32{
+			mkImportKey("wasi:sockets/network@0.2.3", "network"): networkTag,
+			mkImportKey("wasi:sockets/tcp@0.2.3", "tcp-socket"):  socketTag,
+		})
+		return tbl
+	}
+
+	t.Run("none of that resource exist", func(t *testing.T) {
+		tbl := newNamedTable()
+		tbl.NewOwn(socketTag, 1) // a live handle, but of a different resource
+		_, err := tbl.Rep(networkTag, 15)
+		requireErrContains(t, err, "unknown handle index 15")
+		requireErrContains(t, err, "network (wasi:sockets/network)")
+		requireErrContains(t, err, "holds no handles of that resource")
+	})
+
+	t.Run("some exist, this one does not", func(t *testing.T) {
+		tbl := newNamedTable()
+		tbl.NewOwn(networkTag, 1)
+		tbl.NewOwn(networkTag, 2)
+		_, err := tbl.Rep(networkTag, 15)
+		requireErrContains(t, err, "2 handle(s) of that resource are live")
+		requireErrContains(t, err, "already dropped or never existed")
+	})
+
+	t.Run("dropped handle counts as gone", func(t *testing.T) {
+		tbl := newNamedTable()
+		h := tbl.NewOwn(networkTag, 1)
+		if _, err := tbl.TakeOwn(networkTag, h); err != nil {
+			t.Fatalf("TakeOwn: %v", err)
+		}
+		_, err := tbl.Rep(networkTag, h)
+		requireErrContains(t, err, "holds no handles of that resource")
+	})
+
+	t.Run("wrong resource names both sides", func(t *testing.T) {
+		tbl := newNamedTable()
+		h := tbl.NewOwn(socketTag, 1)
+		_, err := tbl.Rep(networkTag, h)
+		requireErrContains(t, err, "belongs to tcp-socket (wasi:sockets/tcp)")
+		requireErrContains(t, err, "not network (wasi:sockets/network)")
+	})
+
+	t.Run("unregistered tag falls back to its number", func(t *testing.T) {
+		tbl := newNamedTable()
+		_, err := tbl.Rep(untaggedTag, 3)
+		requireErrContains(t, err, "resource type 77")
+	})
+
+	t.Run("names are optional", func(t *testing.T) {
+		// A table that never had setResourceNames called (every unit test
+		// that builds one directly) must still produce a usable message.
+		tbl := newHandleTable()
+		_, err := tbl.Rep(networkTag, 1)
+		requireErrContains(t, err, "unknown handle index 1 for resource type 8")
+	})
+
+	t.Run("first registration wins", func(t *testing.T) {
+		tbl := newHandleTable()
+		tbl.setResourceNames(map[importKey]uint32{mkImportKey("a:b/c@1.0.0", "thing"): networkTag})
+		tbl.setResourceNames(map[importKey]uint32{mkImportKey("d:e/f@1.0.0", "other"): networkTag})
+		if got := tbl.typeName(networkTag); got != "thing (a:b/c)" {
+			t.Fatalf("typeName = %q, want the first registration to win", got)
+		}
+	})
+}


### PR DESCRIPTION
## Why

A failed handle lookup reported only internal numbers:

```
host import "wasi:sockets/tcp@0.2.0" "[method]tcp-socket.start-bind":
param 1: borrow<8> arg: unknown handle index 15
```

A real componentize-py CPython guest hit exactly this, and the message sent the investigation after the **tcp-socket's** lifetime — handle identity, ownership, drop timing. All of that was fine: the socket's handle resolved correctly one argument earlier, in the same call. The failing argument was the **`network`** (tag 8), of which this runtime had never issued a single handle. The only clue separating those two readings was the bare `8`, and nothing in the codebase renders it.

## What

The table now knows the WIT names behind its tags — inverted from the `withResourceTag` registrations already threaded through `config` — and uses them everywhere it reports a handle problem, which covers the `resource.drop` and `own<T>`-transfer paths too, not just import arguments:

```
param 1: borrow<network> arg: unknown handle index 15 for network
(wasi:sockets/network): this component instance holds no handles of that
resource, so it was never returned by a host call here
```

The live-count clause is the other half of the diagnosis. Zero live handles of a resource means the guest passed one this instance **never issued**; a nonzero count means it passed a **stale or already-dropped** one. Those are different bugs, usually in different codebases, and the old message could not tell them apart.

Wrong-type lookups now name both sides (`handle 5 belongs to tcp-socket (wasi:sockets/tcp), not network (wasi:sockets/network)`) instead of `belongs to resource type 9, not 8`.

## Design notes

- **Names live on the table, not at the call site.** One registration point improves every message the table produces; decorating `resolveHandleArg` alone would have fixed one of them.
- **Optional by construction.** A table built without names — every unit test that constructs one directly — degrades to the bare tag. `setResourceNames` is additive and first-registration-wins, since the goal is a legible label, not a canonical one.
- **Error path only.** The live count scans entries, which costs nothing because nothing reaches it unless a lookup has already failed.
- Argument wrappers use the short name (`borrow<network>`) so the qualified form appears once per message rather than twice.

## Verification

- `go build ./... && go test ./...` green; conformance goldens unchanged.
- Coverage `internal/component/instance` **90.4%**.
- `make lint`: 115 issues with an identical per-linter breakdown to `origin/main` — zero net new findings.
- Cross-compiles: plan9/js/wasip1/freebsd/windows/darwin, GOARCH=386/arm.
- New `TestHandleTable_ErrorsNameTheResource` covers all six shapes: none-of-that-resource-live, some-live, dropped-handle, wrong-resource, unregistered tag, and a table with no names at all.
- Verified against the original failure by rebuilding the CPython guest that produced it — the message above is its real output, not a constructed example.