### PR TITLE
feat(component): implement incoming-response.headers and fields.entries

### DIFF
--- a/internal/component/abi/flat.go
+++ b/internal/component/abi/flat.go
@@ -254,12 +254,7 @@ func lowerFlatString(s string, realloc Realloc, mem []byte) ([]CoreValue, error)
 // store_list_into_range() -- the same allocate+store helper storeList uses
 // for the Store/Load path (see allocStoreList in memory.go).
 func lowerFlatList(v Value, elemType binary.TypeDesc, resolve Resolver, realloc Realloc, mem []byte) ([]CoreValue, error) {
-	list, ok := v.([]Value)
-	if !ok {
-		return nil, fmt.Errorf("lowerFlat list: expected []Value, got %T", v)
-	}
-
-	ptr, length, err := allocStoreList(mem, list, elemType, resolve, realloc)
+	ptr, length, err := allocStoreAnyList(mem, v, elemType, resolve, realloc)
 	if err != nil {
 		return nil, fmt.Errorf("lowerFlatList: %w", err)
 	}

--- a/internal/component/abi/memory.go
+++ b/internal/component/abi/memory.go
@@ -839,14 +839,9 @@ func allocStoreString(mem []byte, s string, realloc Realloc) (uint32, uint32, er
 }
 
 func storeList(mem []byte, ptr uint32, v Value, elemType bintype.TypeDesc, resolve Resolver, realloc Realloc) error {
-	list, ok := v.([]Value)
-	if !ok {
-		return fmt.Errorf("storeList: expected []Value, got %T", v)
-	}
-
 	ptrSize := uint32(4) // assuming 32-bit pointers
 
-	newPtr, length, err := allocStoreList(mem, list, elemType, resolve, realloc)
+	newPtr, length, err := allocStoreAnyList(mem, v, elemType, resolve, realloc)
 	if err != nil {
 		return fmt.Errorf("storeList: %w", err)
 	}
@@ -856,6 +851,51 @@ func storeList(mem []byte, ptr uint32, v Value, elemType bintype.TypeDesc, resol
 		return err
 	}
 	return storeInt(mem, ptr+ptrSize, length, ptrSize)
+}
+
+// allocStoreAnyList stores a list value that is EITHER the general
+// []Value shape or, for list<u8> only, a raw []byte -- see byteListValue.
+func allocStoreAnyList(mem []byte, v Value, elemType bintype.TypeDesc, resolve Resolver, realloc Realloc) (uint32, uint32, error) {
+	if b, ok := byteListValue(v, elemType); ok {
+		return allocStoreBytes(mem, b, realloc)
+	}
+	list, ok := v.([]Value)
+	if !ok {
+		return 0, 0, fmt.Errorf("expected []Value (or []byte for list<u8>), got %T", v)
+	}
+	return allocStoreList(mem, list, elemType, resolve, realloc)
+}
+
+// byteListValue reports whether v is a raw []byte being stored as a
+// `list<u8>`. Value's general shape for a list is []Value (one interface per
+// element), which for a byte list costs a machine word per BYTE -- ~16x the
+// data on 64-bit. Since a host func producing bytes (a file read, an HTTP
+// body, a header value) already holds a []byte, letting it hand that over
+// directly turns the whole lowering into one copy. []Value stays valid
+// everywhere; this is a fast path, not a replacement.
+func byteListValue(v Value, elemType bintype.TypeDesc) ([]byte, bool) {
+	b, ok := v.([]byte)
+	if !ok {
+		return nil, false
+	}
+	p, isPrim := elemType.(bintype.PrimitiveDesc)
+	return b, isPrim && p.Prim == "u8"
+}
+
+// allocStoreBytes is allocStoreList's list<u8> fast path: one realloc and one
+// copy, with no per-element dispatch. u8's size and alignment are both 1, so
+// the layout is identical to what the generic path would have produced.
+func allocStoreBytes(mem []byte, b []byte, realloc Realloc) (uint32, uint32, error) {
+	byteLen := uint32(len(b))
+	newPtr, err := realloc.Grow(0, 0, 1, byteLen)
+	if err != nil {
+		return 0, 0, fmt.Errorf("realloc failed: %w", err)
+	}
+	if uint32(len(mem)) < newPtr+byteLen {
+		return 0, 0, fmt.Errorf("allocated memory out of bounds: ptr=%d size=%d", newPtr, byteLen)
+	}
+	copy(mem[newPtr:newPtr+byteLen], b)
+	return newPtr, byteLen, nil
 }
 
 // allocStoreList allocates room for len(list) elements of elemType via

--- a/internal/component/instance/testdata/wasi-wit/README.md
+++ b/internal/component/instance/testdata/wasi-wit/README.md
@@ -1,0 +1,17 @@
+# Reference WASI 0.2 WIT
+
+Verbatim copies of the WASI Preview 2 interface definitions, taken from the
+`wasip2` crate (`wasip2-1.0.4+wasi-0.2.12/wit/deps/`), which vendors them
+from [WebAssembly/WASI](https://github.com/WebAssembly/WASI). They are the
+*reference* — nothing here is generated from, or derived by, wazy.
+
+`wasi_conformance_test.go` parses these and checks every WASI host import
+wazy registers against them, so a typo'd or drifted function name cannot
+sit unnoticed behind the graph engine's trap-stub fallback.
+
+Do not hand-edit. To update, re-copy from a newer `wasip2` crate and re-run
+the conformance test; a diff in the reported gaps is the point.
+
+Licensed Apache-2.0 WITH LLVM-exception / MIT, per the upstream WASI
+repository (see `LICENSE-Apache-2.0_WITH_LLVM-exception` and `LICENSE-MIT`
+in the `wasip2` crate).

--- a/internal/component/instance/testdata/wasi-wit/cli.wit
+++ b/internal/component/instance/testdata/wasi-wit/cli.wit
@@ -1,0 +1,233 @@
+package wasi:cli@0.2.12;
+
+@since(version = 0.2.0)
+interface environment {
+  /// Get the POSIX-style environment variables.
+  ///
+  /// Each environment variable is provided as a pair of string variable names
+  /// and string value.
+  ///
+  /// Morally, these are a value import, but until value imports are available
+  /// in the component model, this import function should return the same
+  /// values each time it is called.
+  @since(version = 0.2.0)
+  get-environment: func() -> list<tuple<string, string>>;
+
+  /// Get the POSIX-style arguments to the program.
+  @since(version = 0.2.0)
+  get-arguments: func() -> list<string>;
+
+  /// Return a path that programs should use as their initial current working
+  /// directory, interpreting `.` as shorthand for this.
+  @since(version = 0.2.0)
+  initial-cwd: func() -> option<string>;
+}
+
+@since(version = 0.2.0)
+interface exit {
+  /// Exit the current instance and any linked instances.
+  @since(version = 0.2.0)
+  exit: func(status: result);
+
+  /// Exit the current instance and any linked instances, reporting the
+  /// specified status code to the host.
+  ///
+  /// The meaning of the code depends on the context, with 0 usually meaning
+  /// "success", and other values indicating various types of failure.
+  ///
+  /// This function does not return; the effect is analogous to a trap, but
+  /// without the connotation that something bad has happened.
+  @since(version = 0.2.12)
+  exit-with-code: func(status-code: u8);
+}
+
+@since(version = 0.2.0)
+interface run {
+  /// Run the program.
+  @since(version = 0.2.0)
+  run: func() -> result;
+}
+
+@since(version = 0.2.0)
+interface stdin {
+  @since(version = 0.2.0)
+  use wasi:io/streams@0.2.12.{input-stream};
+
+  @since(version = 0.2.0)
+  get-stdin: func() -> input-stream;
+}
+
+@since(version = 0.2.0)
+interface stdout {
+  @since(version = 0.2.0)
+  use wasi:io/streams@0.2.12.{output-stream};
+
+  @since(version = 0.2.0)
+  get-stdout: func() -> output-stream;
+}
+
+@since(version = 0.2.0)
+interface stderr {
+  @since(version = 0.2.0)
+  use wasi:io/streams@0.2.12.{output-stream};
+
+  @since(version = 0.2.0)
+  get-stderr: func() -> output-stream;
+}
+
+/// Terminal input.
+///
+/// In the future, this may include functions for disabling echoing,
+/// disabling input buffering so that keyboard events are sent through
+/// immediately, querying supported features, and so on.
+@since(version = 0.2.0)
+interface terminal-input {
+  /// The input side of a terminal.
+  @since(version = 0.2.0)
+  resource terminal-input;
+}
+
+/// Terminal output.
+///
+/// In the future, this may include functions for querying the terminal
+/// size, being notified of terminal size changes, querying supported
+/// features, and so on.
+@since(version = 0.2.0)
+interface terminal-output {
+  /// The output side of a terminal.
+  @since(version = 0.2.0)
+  resource terminal-output;
+}
+
+/// An interface providing an optional `terminal-input` for stdin as a
+/// link-time authority.
+@since(version = 0.2.0)
+interface terminal-stdin {
+  @since(version = 0.2.0)
+  use terminal-input.{terminal-input};
+
+  /// If stdin is connected to a terminal, return a `terminal-input` handle
+  /// allowing further interaction with it.
+  @since(version = 0.2.0)
+  get-terminal-stdin: func() -> option<terminal-input>;
+}
+
+/// An interface providing an optional `terminal-output` for stdout as a
+/// link-time authority.
+@since(version = 0.2.0)
+interface terminal-stdout {
+  @since(version = 0.2.0)
+  use terminal-output.{terminal-output};
+
+  /// If stdout is connected to a terminal, return a `terminal-output` handle
+  /// allowing further interaction with it.
+  @since(version = 0.2.0)
+  get-terminal-stdout: func() -> option<terminal-output>;
+}
+
+/// An interface providing an optional `terminal-output` for stderr as a
+/// link-time authority.
+@since(version = 0.2.0)
+interface terminal-stderr {
+  @since(version = 0.2.0)
+  use terminal-output.{terminal-output};
+
+  /// If stderr is connected to a terminal, return a `terminal-output` handle
+  /// allowing further interaction with it.
+  @since(version = 0.2.0)
+  get-terminal-stderr: func() -> option<terminal-output>;
+}
+
+@since(version = 0.2.0)
+world imports {
+  @since(version = 0.2.0)
+  import environment;
+  @since(version = 0.2.0)
+  import exit;
+  @since(version = 0.2.0)
+  import wasi:io/error@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:io/poll@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:io/streams@0.2.12;
+  @since(version = 0.2.0)
+  import stdin;
+  @since(version = 0.2.0)
+  import stdout;
+  @since(version = 0.2.0)
+  import stderr;
+  @since(version = 0.2.0)
+  import terminal-input;
+  @since(version = 0.2.0)
+  import terminal-output;
+  @since(version = 0.2.0)
+  import terminal-stdin;
+  @since(version = 0.2.0)
+  import terminal-stdout;
+  @since(version = 0.2.0)
+  import terminal-stderr;
+  import wasi:clocks/monotonic-clock@0.2.12;
+  import wasi:clocks/wall-clock@0.2.12;
+  @unstable(feature = clocks-timezone)
+  import wasi:clocks/timezone@0.2.12;
+  import wasi:filesystem/types@0.2.12;
+  import wasi:filesystem/preopens@0.2.12;
+  import wasi:sockets/network@0.2.12;
+  import wasi:sockets/instance-network@0.2.12;
+  import wasi:sockets/udp@0.2.12;
+  import wasi:sockets/udp-create-socket@0.2.12;
+  import wasi:sockets/tcp@0.2.12;
+  import wasi:sockets/tcp-create-socket@0.2.12;
+  import wasi:sockets/ip-name-lookup@0.2.12;
+  import wasi:random/random@0.2.12;
+  import wasi:random/insecure@0.2.12;
+  import wasi:random/insecure-seed@0.2.12;
+}
+@since(version = 0.2.0)
+world command {
+  @since(version = 0.2.0)
+  import environment;
+  @since(version = 0.2.0)
+  import exit;
+  @since(version = 0.2.0)
+  import wasi:io/error@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:io/poll@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:io/streams@0.2.12;
+  @since(version = 0.2.0)
+  import stdin;
+  @since(version = 0.2.0)
+  import stdout;
+  @since(version = 0.2.0)
+  import stderr;
+  @since(version = 0.2.0)
+  import terminal-input;
+  @since(version = 0.2.0)
+  import terminal-output;
+  @since(version = 0.2.0)
+  import terminal-stdin;
+  @since(version = 0.2.0)
+  import terminal-stdout;
+  @since(version = 0.2.0)
+  import terminal-stderr;
+  import wasi:clocks/monotonic-clock@0.2.12;
+  import wasi:clocks/wall-clock@0.2.12;
+  @unstable(feature = clocks-timezone)
+  import wasi:clocks/timezone@0.2.12;
+  import wasi:filesystem/types@0.2.12;
+  import wasi:filesystem/preopens@0.2.12;
+  import wasi:sockets/network@0.2.12;
+  import wasi:sockets/instance-network@0.2.12;
+  import wasi:sockets/udp@0.2.12;
+  import wasi:sockets/udp-create-socket@0.2.12;
+  import wasi:sockets/tcp@0.2.12;
+  import wasi:sockets/tcp-create-socket@0.2.12;
+  import wasi:sockets/ip-name-lookup@0.2.12;
+  import wasi:random/random@0.2.12;
+  import wasi:random/insecure@0.2.12;
+  import wasi:random/insecure-seed@0.2.12;
+
+  @since(version = 0.2.0)
+  export run;
+}

--- a/internal/component/instance/testdata/wasi-wit/clocks.wit
+++ b/internal/component/instance/testdata/wasi-wit/clocks.wit
@@ -1,0 +1,162 @@
+package wasi:clocks@0.2.12;
+
+/// WASI Monotonic Clock is a clock API intended to let users measure elapsed
+/// time.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+///
+/// A monotonic clock is a clock which has an unspecified initial value, and
+/// successive reads of the clock will produce non-decreasing values.
+@since(version = 0.2.0)
+interface monotonic-clock {
+  @since(version = 0.2.0)
+  use wasi:io/poll@0.2.12.{pollable};
+
+  /// An instant in time, in nanoseconds. An instant is relative to an
+  /// unspecified initial value, and can only be compared to instances from
+  /// the same monotonic-clock.
+  @since(version = 0.2.0)
+  type instant = u64;
+
+  /// A duration of time, in nanoseconds.
+  @since(version = 0.2.0)
+  type duration = u64;
+
+  /// Read the current value of the clock.
+  ///
+  /// The clock is monotonic, therefore calling this function repeatedly will
+  /// produce a sequence of non-decreasing values.
+  ///
+  /// For completeness, this function traps if it's not possible to represent
+  /// the value of the clock in an `instant`. Consequently, implementations
+  /// should ensure that the starting time is low enough to avoid the
+  /// possibility of overflow in practice.
+  @since(version = 0.2.0)
+  now: func() -> instant;
+
+  /// Query the resolution of the clock. Returns the duration of time
+  /// corresponding to a clock tick.
+  @since(version = 0.2.0)
+  resolution: func() -> duration;
+
+  /// Create a `pollable` which will resolve once the specified instant
+  /// has occurred.
+  @since(version = 0.2.0)
+  subscribe-instant: func(when: instant) -> pollable;
+
+  /// Create a `pollable` that will resolve after the specified duration has
+  /// elapsed from the time this function is invoked.
+  @since(version = 0.2.0)
+  subscribe-duration: func(when: duration) -> pollable;
+}
+
+/// WASI Wall Clock is a clock API intended to let users query the current
+/// time. The name "wall" makes an analogy to a "clock on the wall", which
+/// is not necessarily monotonic as it may be reset.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+///
+/// A wall clock is a clock which measures the date and time according to
+/// some external reference.
+///
+/// External references may be reset, so this clock is not necessarily
+/// monotonic, making it unsuitable for measuring elapsed time.
+///
+/// It is intended for reporting the current date and time for humans.
+@since(version = 0.2.0)
+interface wall-clock {
+  /// A time and date in seconds plus nanoseconds.
+  @since(version = 0.2.0)
+  record datetime {
+    seconds: u64,
+    nanoseconds: u32,
+  }
+
+  /// Read the current value of the clock.
+  ///
+  /// This clock is not monotonic, therefore calling this function repeatedly
+  /// will not necessarily produce a sequence of non-decreasing values.
+  ///
+  /// The returned timestamps represent the number of seconds since
+  /// 1970-01-01T00:00:00Z, also known as [POSIX's Seconds Since the Epoch],
+  /// also known as [Unix Time].
+  ///
+  /// The nanoseconds field of the output is always less than 1000000000.
+  ///
+  /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
+  /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
+  @since(version = 0.2.0)
+  now: func() -> datetime;
+
+  /// Query the resolution of the clock.
+  ///
+  /// The nanoseconds field of the output is always less than 1000000000.
+  @since(version = 0.2.0)
+  resolution: func() -> datetime;
+}
+
+@unstable(feature = clocks-timezone)
+interface timezone {
+  @unstable(feature = clocks-timezone)
+  use wall-clock.{datetime};
+
+  /// Information useful for displaying the timezone of a specific `datetime`.
+  ///
+  /// This information may vary within a single `timezone` to reflect daylight
+  /// saving time adjustments.
+  @unstable(feature = clocks-timezone)
+  record timezone-display {
+    /// The number of seconds difference between UTC time and the local
+    /// time of the timezone.
+    ///
+    /// The returned value will always be less than 86400 which is the
+    /// number of seconds in a day (24*60*60).
+    ///
+    /// In implementations that do not expose an actual time zone, this
+    /// should return 0.
+    utc-offset: s32,
+    /// The abbreviated name of the timezone to display to a user. The name
+    /// `UTC` indicates Coordinated Universal Time. Otherwise, this should
+    /// reference local standards for the name of the time zone.
+    ///
+    /// In implementations that do not expose an actual time zone, this
+    /// should be the string `UTC`.
+    ///
+    /// In time zones that do not have an applicable name, a formatted
+    /// representation of the UTC offset may be returned, such as `-04:00`.
+    name: string,
+    /// Whether daylight saving time is active.
+    ///
+    /// In implementations that do not expose an actual time zone, this
+    /// should return false.
+    in-daylight-saving-time: bool,
+  }
+
+  /// Return information needed to display the given `datetime`. This includes
+  /// the UTC offset, the time zone name, and a flag indicating whether
+  /// daylight saving time is active.
+  ///
+  /// If the timezone cannot be determined for the given `datetime`, return a
+  /// `timezone-display` for `UTC` with a `utc-offset` of 0 and no daylight
+  /// saving time.
+  @unstable(feature = clocks-timezone)
+  display: func(when: datetime) -> timezone-display;
+
+  /// The same as `display`, but only return the UTC offset.
+  @unstable(feature = clocks-timezone)
+  utc-offset: func(when: datetime) -> s32;
+}
+
+@since(version = 0.2.0)
+world imports {
+  @since(version = 0.2.0)
+  import wasi:io/poll@0.2.12;
+  @since(version = 0.2.0)
+  import monotonic-clock;
+  @since(version = 0.2.0)
+  import wall-clock;
+  @unstable(feature = clocks-timezone)
+  import timezone;
+}

--- a/internal/component/instance/testdata/wasi-wit/filesystem.wit
+++ b/internal/component/instance/testdata/wasi-wit/filesystem.wit
@@ -1,0 +1,589 @@
+package wasi:filesystem@0.2.12;
+
+/// WASI filesystem is a filesystem API primarily intended to let users run WASI
+/// programs that access their files on their existing filesystems, without
+/// significant overhead.
+///
+/// It is intended to be roughly portable between Unix-family platforms and
+/// Windows, though it does not hide many of the major differences.
+///
+/// Paths are passed as interface-type `string`s, meaning they must consist of
+/// a sequence of Unicode Scalar Values (USVs). Some filesystems may contain
+/// paths which are not accessible by this API.
+///
+/// The directory separator in WASI is always the forward-slash (`/`).
+///
+/// All paths in WASI are relative paths, and are interpreted relative to a
+/// `descriptor` referring to a base directory. If a `path` argument to any WASI
+/// function starts with `/`, or if any step of resolving a `path`, including
+/// `..` and symbolic link steps, reaches a directory outside of the base
+/// directory, or reaches a symlink to an absolute or rooted path in the
+/// underlying filesystem, the function fails with `error-code::not-permitted`.
+///
+/// For more information about WASI path resolution and sandboxing, see
+/// [WASI filesystem path resolution].
+///
+/// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
+@since(version = 0.2.0)
+interface types {
+  @since(version = 0.2.0)
+  use wasi:io/streams@0.2.12.{input-stream, output-stream, error};
+  @since(version = 0.2.0)
+  use wasi:clocks/wall-clock@0.2.12.{datetime};
+
+  /// File size or length of a region within a file.
+  @since(version = 0.2.0)
+  type filesize = u64;
+
+  /// The type of a filesystem object referenced by a descriptor.
+  ///
+  /// Note: This was called `filetype` in earlier versions of WASI.
+  @since(version = 0.2.0)
+  enum descriptor-type {
+    /// The type of the descriptor or file is unknown or is different from
+    /// any of the other types specified.
+    unknown,
+    /// The descriptor refers to a block device inode.
+    block-device,
+    /// The descriptor refers to a character device inode.
+    character-device,
+    /// The descriptor refers to a directory inode.
+    directory,
+    /// The descriptor refers to a named pipe.
+    fifo,
+    /// The file refers to a symbolic link inode.
+    symbolic-link,
+    /// The descriptor refers to a regular file inode.
+    regular-file,
+    /// The descriptor refers to a socket.
+    socket,
+  }
+
+  /// Descriptor flags.
+  ///
+  /// Note: This was called `fdflags` in earlier versions of WASI.
+  @since(version = 0.2.0)
+  flags descriptor-flags {
+    /// Read mode: Data can be read.
+    read,
+    /// Write mode: Data can be written to.
+    write,
+    /// Request that writes be performed according to synchronized I/O file
+    /// integrity completion. The data stored in the file and the file's
+    /// metadata are synchronized. This is similar to `O_SYNC` in POSIX.
+    ///
+    /// The precise semantics of this operation have not yet been defined for
+    /// WASI. At this time, it should be interpreted as a request, and not a
+    /// requirement.
+    file-integrity-sync,
+    /// Request that writes be performed according to synchronized I/O data
+    /// integrity completion. Only the data stored in the file is
+    /// synchronized. This is similar to `O_DSYNC` in POSIX.
+    ///
+    /// The precise semantics of this operation have not yet been defined for
+    /// WASI. At this time, it should be interpreted as a request, and not a
+    /// requirement.
+    data-integrity-sync,
+    /// Requests that reads be performed at the same level of integrity
+    /// requested for writes. This is similar to `O_RSYNC` in POSIX.
+    ///
+    /// The precise semantics of this operation have not yet been defined for
+    /// WASI. At this time, it should be interpreted as a request, and not a
+    /// requirement.
+    requested-write-sync,
+    /// Mutating directories mode: Directory contents may be mutated.
+    ///
+    /// When this flag is unset on a descriptor, operations using the
+    /// descriptor which would create, rename, delete, modify the data or
+    /// metadata of filesystem objects, or obtain another handle which
+    /// would permit any of those, shall fail with `error-code::read-only` if
+    /// they would otherwise succeed.
+    ///
+    /// This may only be set on directories.
+    mutate-directory,
+  }
+
+  /// Flags determining the method of how paths are resolved.
+  @since(version = 0.2.0)
+  flags path-flags {
+    /// As long as the resolved path corresponds to a symbolic link, it is
+    /// expanded.
+    symlink-follow,
+  }
+
+  /// Open flags used by `open-at`.
+  @since(version = 0.2.0)
+  flags open-flags {
+    /// Create file if it does not exist, similar to `O_CREAT` in POSIX.
+    create,
+    /// Fail if not a directory, similar to `O_DIRECTORY` in POSIX.
+    directory,
+    /// Fail if file already exists, similar to `O_EXCL` in POSIX.
+    exclusive,
+    /// Truncate file to size 0, similar to `O_TRUNC` in POSIX.
+    truncate,
+  }
+
+  /// Number of hard links to an inode.
+  @since(version = 0.2.0)
+  type link-count = u64;
+
+  /// File attributes.
+  ///
+  /// Note: This was called `filestat` in earlier versions of WASI.
+  @since(version = 0.2.0)
+  record descriptor-stat {
+    /// File type.
+    %type: descriptor-type,
+    /// Number of hard links to the file.
+    link-count: link-count,
+    /// For regular files, the file size in bytes. For symbolic links, the
+    /// length in bytes of the pathname contained in the symbolic link.
+    size: filesize,
+    /// Last data access timestamp.
+    ///
+    /// If the `option` is none, the platform doesn't maintain an access
+    /// timestamp for this file.
+    data-access-timestamp: option<datetime>,
+    /// Last data modification timestamp.
+    ///
+    /// If the `option` is none, the platform doesn't maintain a
+    /// modification timestamp for this file.
+    data-modification-timestamp: option<datetime>,
+    /// Last file status-change timestamp.
+    ///
+    /// If the `option` is none, the platform doesn't maintain a
+    /// status-change timestamp for this file.
+    status-change-timestamp: option<datetime>,
+  }
+
+  /// When setting a timestamp, this gives the value to set it to.
+  @since(version = 0.2.0)
+  variant new-timestamp {
+    /// Leave the timestamp set to its previous value.
+    no-change,
+    /// Set the timestamp to the current time of the system clock associated
+    /// with the filesystem.
+    now,
+    /// Set the timestamp to the given value.
+    timestamp(datetime),
+  }
+
+  /// A directory entry.
+  @since(version = 0.2.0)
+  record directory-entry {
+    /// The type of the file referred to by this directory entry.
+    %type: descriptor-type,
+    /// The name of the object.
+    name: string,
+  }
+
+  /// Error codes returned by functions, similar to `errno` in POSIX.
+  /// Not all of these error codes are returned by the functions provided by this
+  /// API; some are used in higher-level library layers, and others are provided
+  /// merely for alignment with POSIX.
+  @since(version = 0.2.0)
+  enum error-code {
+    /// Permission denied, similar to `EACCES` in POSIX.
+    access,
+    /// Resource unavailable, or operation would block, similar to `EAGAIN` and `EWOULDBLOCK` in POSIX.
+    would-block,
+    /// Connection already in progress, similar to `EALREADY` in POSIX.
+    already,
+    /// Bad descriptor, similar to `EBADF` in POSIX.
+    bad-descriptor,
+    /// Device or resource busy, similar to `EBUSY` in POSIX.
+    busy,
+    /// Resource deadlock would occur, similar to `EDEADLK` in POSIX.
+    deadlock,
+    /// Storage quota exceeded, similar to `EDQUOT` in POSIX.
+    quota,
+    /// File exists, similar to `EEXIST` in POSIX.
+    exist,
+    /// File too large, similar to `EFBIG` in POSIX.
+    file-too-large,
+    /// Illegal byte sequence, similar to `EILSEQ` in POSIX.
+    illegal-byte-sequence,
+    /// Operation in progress, similar to `EINPROGRESS` in POSIX.
+    in-progress,
+    /// Interrupted function, similar to `EINTR` in POSIX.
+    interrupted,
+    /// Invalid argument, similar to `EINVAL` in POSIX.
+    invalid,
+    /// I/O error, similar to `EIO` in POSIX.
+    io,
+    /// Is a directory, similar to `EISDIR` in POSIX.
+    is-directory,
+    /// Too many levels of symbolic links, similar to `ELOOP` in POSIX.
+    loop,
+    /// Too many links, similar to `EMLINK` in POSIX.
+    too-many-links,
+    /// Message too large, similar to `EMSGSIZE` in POSIX.
+    message-size,
+    /// Filename too long, similar to `ENAMETOOLONG` in POSIX.
+    name-too-long,
+    /// No such device, similar to `ENODEV` in POSIX.
+    no-device,
+    /// No such file or directory, similar to `ENOENT` in POSIX.
+    no-entry,
+    /// No locks available, similar to `ENOLCK` in POSIX.
+    no-lock,
+    /// Not enough space, similar to `ENOMEM` in POSIX.
+    insufficient-memory,
+    /// No space left on device, similar to `ENOSPC` in POSIX.
+    insufficient-space,
+    /// Not a directory or a symbolic link to a directory, similar to `ENOTDIR` in POSIX.
+    not-directory,
+    /// Directory not empty, similar to `ENOTEMPTY` in POSIX.
+    not-empty,
+    /// State not recoverable, similar to `ENOTRECOVERABLE` in POSIX.
+    not-recoverable,
+    /// Not supported, similar to `ENOTSUP` and `ENOSYS` in POSIX.
+    unsupported,
+    /// Inappropriate I/O control operation, similar to `ENOTTY` in POSIX.
+    no-tty,
+    /// No such device or address, similar to `ENXIO` in POSIX.
+    no-such-device,
+    /// Value too large to be stored in data type, similar to `EOVERFLOW` in POSIX.
+    overflow,
+    /// Operation not permitted, similar to `EPERM` in POSIX.
+    not-permitted,
+    /// Broken pipe, similar to `EPIPE` in POSIX.
+    pipe,
+    /// Read-only file system, similar to `EROFS` in POSIX.
+    read-only,
+    /// Invalid seek, similar to `ESPIPE` in POSIX.
+    invalid-seek,
+    /// Text file busy, similar to `ETXTBSY` in POSIX.
+    text-file-busy,
+    /// Cross-device link, similar to `EXDEV` in POSIX.
+    cross-device,
+  }
+
+  /// File or memory access pattern advisory information.
+  @since(version = 0.2.0)
+  enum advice {
+    /// The application has no advice to give on its behavior with respect
+    /// to the specified data.
+    normal,
+    /// The application expects to access the specified data sequentially
+    /// from lower offsets to higher offsets.
+    sequential,
+    /// The application expects to access the specified data in a random
+    /// order.
+    random,
+    /// The application expects to access the specified data in the near
+    /// future.
+    will-need,
+    /// The application expects that it will not access the specified data
+    /// in the near future.
+    dont-need,
+    /// The application expects to access the specified data once and then
+    /// not reuse it thereafter.
+    no-reuse,
+  }
+
+  /// A 128-bit hash value, split into parts because wasm doesn't have a
+  /// 128-bit integer type.
+  @since(version = 0.2.0)
+  record metadata-hash-value {
+    /// 64 bits of a 128-bit hash value.
+    lower: u64,
+    /// Another 64 bits of a 128-bit hash value.
+    upper: u64,
+  }
+
+  /// A descriptor is a reference to a filesystem object, which may be a file,
+  /// directory, named pipe, special file, or other object on which filesystem
+  /// calls may be made.
+  @since(version = 0.2.0)
+  resource descriptor {
+    /// Return a stream for reading from a file, if available.
+    ///
+    /// May fail with an error-code describing why the file cannot be read.
+    ///
+    /// Multiple read, write, and append streams may be active on the same open
+    /// file and they do not interfere with each other.
+    ///
+    /// Note: This allows using `read-stream`, which is similar to `read` in POSIX.
+    @since(version = 0.2.0)
+    read-via-stream: func(offset: filesize) -> result<input-stream, error-code>;
+    /// Return a stream for writing to a file, if available.
+    ///
+    /// May fail with an error-code describing why the file cannot be written.
+    ///
+    /// Note: This allows using `write-stream`, which is similar to `write` in
+    /// POSIX.
+    @since(version = 0.2.0)
+    write-via-stream: func(offset: filesize) -> result<output-stream, error-code>;
+    /// Return a stream for appending to a file, if available.
+    ///
+    /// May fail with an error-code describing why the file cannot be appended.
+    ///
+    /// Note: This allows using `write-stream`, which is similar to `write` with
+    /// `O_APPEND` in POSIX.
+    @since(version = 0.2.0)
+    append-via-stream: func() -> result<output-stream, error-code>;
+    /// Provide file advisory information on a descriptor.
+    ///
+    /// This is similar to `posix_fadvise` in POSIX.
+    @since(version = 0.2.0)
+    advise: func(offset: filesize, length: filesize, advice: advice) -> result<_, error-code>;
+    /// Synchronize the data of a file to disk.
+    ///
+    /// This function succeeds with no effect if the file descriptor is not
+    /// opened for writing.
+    ///
+    /// Note: This is similar to `fdatasync` in POSIX.
+    @since(version = 0.2.0)
+    sync-data: func() -> result<_, error-code>;
+    /// Get flags associated with a descriptor.
+    ///
+    /// Note: This returns similar flags to `fcntl(fd, F_GETFL)` in POSIX.
+    ///
+    /// Note: This returns the value that was the `fs_flags` value returned
+    /// from `fdstat_get` in earlier versions of WASI.
+    @since(version = 0.2.0)
+    get-flags: func() -> result<descriptor-flags, error-code>;
+    /// Get the dynamic type of a descriptor.
+    ///
+    /// Note: This returns the same value as the `type` field of the `fd-stat`
+    /// returned by `stat`, `stat-at` and similar.
+    ///
+    /// Note: This returns similar flags to the `st_mode & S_IFMT` value provided
+    /// by `fstat` in POSIX.
+    ///
+    /// Note: This returns the value that was the `fs_filetype` value returned
+    /// from `fdstat_get` in earlier versions of WASI.
+    @since(version = 0.2.0)
+    get-type: func() -> result<descriptor-type, error-code>;
+    /// Adjust the size of an open file. If this increases the file's size, the
+    /// extra bytes are filled with zeros.
+    ///
+    /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
+    @since(version = 0.2.0)
+    set-size: func(size: filesize) -> result<_, error-code>;
+    /// Adjust the timestamps of an open file or directory.
+    ///
+    /// Note: This is similar to `futimens` in POSIX.
+    ///
+    /// Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
+    @since(version = 0.2.0)
+    set-times: func(data-access-timestamp: new-timestamp, data-modification-timestamp: new-timestamp) -> result<_, error-code>;
+    /// Read from a descriptor, without using and updating the descriptor's offset.
+    ///
+    /// This function returns a list of bytes containing the data that was
+    /// read, along with a bool which, when true, indicates that the end of the
+    /// file was reached. The returned list will contain up to `length` bytes; it
+    /// may return fewer than requested, if the end of the file is reached or
+    /// if the I/O operation is interrupted.
+    ///
+    /// In the future, this may change to return a `stream<u8, error-code>`.
+    ///
+    /// Note: This is similar to `pread` in POSIX.
+    @since(version = 0.2.0)
+    read: func(length: filesize, offset: filesize) -> result<tuple<list<u8>, bool>, error-code>;
+    /// Write to a descriptor, without using and updating the descriptor's offset.
+    ///
+    /// It is valid to write past the end of a file; the file is extended to the
+    /// extent of the write, with bytes between the previous end and the start of
+    /// the write set to zero.
+    ///
+    /// In the future, this may change to take a `stream<u8, error-code>`.
+    ///
+    /// Note: This is similar to `pwrite` in POSIX.
+    @since(version = 0.2.0)
+    write: func(buffer: list<u8>, offset: filesize) -> result<filesize, error-code>;
+    /// Read directory entries from a directory.
+    ///
+    /// On filesystems where directories contain entries referring to themselves
+    /// and their parents, often named `.` and `..` respectively, these entries
+    /// are omitted.
+    ///
+    /// This always returns a new stream which starts at the beginning of the
+    /// directory. Multiple streams may be active on the same directory, and they
+    /// do not interfere with each other.
+    @since(version = 0.2.0)
+    read-directory: func() -> result<directory-entry-stream, error-code>;
+    /// Synchronize the data and metadata of a file to disk.
+    ///
+    /// This function succeeds with no effect if the file descriptor is not
+    /// opened for writing.
+    ///
+    /// Note: This is similar to `fsync` in POSIX.
+    @since(version = 0.2.0)
+    sync: func() -> result<_, error-code>;
+    /// Create a directory.
+    ///
+    /// Note: This is similar to `mkdirat` in POSIX.
+    @since(version = 0.2.0)
+    create-directory-at: func(path: string) -> result<_, error-code>;
+    /// Return the attributes of an open file or directory.
+    ///
+    /// Note: This is similar to `fstat` in POSIX, except that it does not return
+    /// device and inode information. For testing whether two descriptors refer to
+    /// the same underlying filesystem object, use `is-same-object`. To obtain
+    /// additional data that can be used do determine whether a file has been
+    /// modified, use `metadata-hash`.
+    ///
+    /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
+    @since(version = 0.2.0)
+    stat: func() -> result<descriptor-stat, error-code>;
+    /// Return the attributes of a file or directory.
+    ///
+    /// Note: This is similar to `fstatat` in POSIX, except that it does not
+    /// return device and inode information. See the `stat` description for a
+    /// discussion of alternatives.
+    ///
+    /// Note: This was called `path_filestat_get` in earlier versions of WASI.
+    @since(version = 0.2.0)
+    stat-at: func(path-flags: path-flags, path: string) -> result<descriptor-stat, error-code>;
+    /// Adjust the timestamps of a file or directory.
+    ///
+    /// Note: This is similar to `utimensat` in POSIX.
+    ///
+    /// Note: This was called `path_filestat_set_times` in earlier versions of
+    /// WASI.
+    @since(version = 0.2.0)
+    set-times-at: func(path-flags: path-flags, path: string, data-access-timestamp: new-timestamp, data-modification-timestamp: new-timestamp) -> result<_, error-code>;
+    /// Create a hard link.
+    ///
+    /// Fails with `error-code::no-entry` if the old path does not exist,
+    /// with `error-code::exist` if the new path already exists, and
+    /// `error-code::not-permitted` if the old path is not a file.
+    ///
+    /// Note: This is similar to `linkat` in POSIX.
+    @since(version = 0.2.0)
+    link-at: func(old-path-flags: path-flags, old-path: string, new-descriptor: borrow<descriptor>, new-path: string) -> result<_, error-code>;
+    /// Open a file or directory.
+    ///
+    /// If `flags` contains `descriptor-flags::mutate-directory`, and the base
+    /// descriptor doesn't have `descriptor-flags::mutate-directory` set,
+    /// `open-at` fails with `error-code::read-only`.
+    ///
+    /// If `flags` contains `write` or `mutate-directory`, or `open-flags`
+    /// contains `truncate` or `create`, and the base descriptor doesn't have
+    /// `descriptor-flags::mutate-directory` set, `open-at` fails with
+    /// `error-code::read-only`.
+    ///
+    /// Note: This is similar to `openat` in POSIX.
+    @since(version = 0.2.0)
+    open-at: func(path-flags: path-flags, path: string, open-flags: open-flags, %flags: descriptor-flags) -> result<descriptor, error-code>;
+    /// Read the contents of a symbolic link.
+    ///
+    /// If the contents contain an absolute or rooted path in the underlying
+    /// filesystem, this function fails with `error-code::not-permitted`.
+    ///
+    /// Note: This is similar to `readlinkat` in POSIX.
+    @since(version = 0.2.0)
+    readlink-at: func(path: string) -> result<string, error-code>;
+    /// Remove a directory.
+    ///
+    /// Return `error-code::not-empty` if the directory is not empty.
+    ///
+    /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
+    @since(version = 0.2.0)
+    remove-directory-at: func(path: string) -> result<_, error-code>;
+    /// Rename a filesystem object.
+    ///
+    /// Note: This is similar to `renameat` in POSIX.
+    @since(version = 0.2.0)
+    rename-at: func(old-path: string, new-descriptor: borrow<descriptor>, new-path: string) -> result<_, error-code>;
+    /// Create a symbolic link (also known as a "symlink").
+    ///
+    /// If `old-path` starts with `/`, the function fails with
+    /// `error-code::not-permitted`.
+    ///
+    /// Note: This is similar to `symlinkat` in POSIX.
+    @since(version = 0.2.0)
+    symlink-at: func(old-path: string, new-path: string) -> result<_, error-code>;
+    /// Unlink a filesystem object that is not a directory.
+    ///
+    /// Return `error-code::is-directory` if the path refers to a directory.
+    /// Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
+    @since(version = 0.2.0)
+    unlink-file-at: func(path: string) -> result<_, error-code>;
+    /// Test whether two descriptors refer to the same filesystem object.
+    ///
+    /// In POSIX, this corresponds to testing whether the two descriptors have the
+    /// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
+    /// wasi-filesystem does not expose device and inode numbers, so this function
+    /// may be used instead.
+    @since(version = 0.2.0)
+    is-same-object: func(other: borrow<descriptor>) -> bool;
+    /// Return a hash of the metadata associated with a filesystem object referred
+    /// to by a descriptor.
+    ///
+    /// This returns a hash of the last-modification timestamp and file size, and
+    /// may also include the inode number, device number, birth timestamp, and
+    /// other metadata fields that may change when the file is modified or
+    /// replaced. It may also include a secret value chosen by the
+    /// implementation and not otherwise exposed.
+    ///
+    /// Implementations are encouraged to provide the following properties:
+    ///
+    ///  - If the file is not modified or replaced, the computed hash value should
+    ///    usually not change.
+    ///  - If the object is modified or replaced, the computed hash value should
+    ///    usually change.
+    ///  - The inputs to the hash should not be easily computable from the
+    ///    computed hash.
+    ///
+    /// However, none of these is required.
+    @since(version = 0.2.0)
+    metadata-hash: func() -> result<metadata-hash-value, error-code>;
+    /// Return a hash of the metadata associated with a filesystem object referred
+    /// to by a directory descriptor and a relative path.
+    ///
+    /// This performs the same hash computation as `metadata-hash`.
+    @since(version = 0.2.0)
+    metadata-hash-at: func(path-flags: path-flags, path: string) -> result<metadata-hash-value, error-code>;
+  }
+
+  /// A stream of directory entries.
+  @since(version = 0.2.0)
+  resource directory-entry-stream {
+    /// Read a single directory entry from a `directory-entry-stream`.
+    @since(version = 0.2.0)
+    read-directory-entry: func() -> result<option<directory-entry>, error-code>;
+  }
+
+  /// Attempts to extract a filesystem-related `error-code` from the stream
+  /// `error` provided.
+  ///
+  /// Stream operations which return `stream-error::last-operation-failed`
+  /// have a payload with more information about the operation that failed.
+  /// This payload can be passed through to this function to see if there's
+  /// filesystem-related information about the error to return.
+  ///
+  /// Note that this function is fallible because not all stream-related
+  /// errors are filesystem-related errors.
+  @since(version = 0.2.0)
+  filesystem-error-code: func(err: borrow<error>) -> option<error-code>;
+}
+
+@since(version = 0.2.0)
+interface preopens {
+  @since(version = 0.2.0)
+  use types.{descriptor};
+
+  /// Return the set of preopened directories, and their paths.
+  @since(version = 0.2.0)
+  get-directories: func() -> list<tuple<descriptor, string>>;
+}
+
+@since(version = 0.2.0)
+world imports {
+  @since(version = 0.2.0)
+  import wasi:io/error@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:io/poll@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:io/streams@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:clocks/wall-clock@0.2.12;
+  @since(version = 0.2.0)
+  import types;
+  @since(version = 0.2.0)
+  import preopens;
+}

--- a/internal/component/instance/testdata/wasi-wit/http.wit
+++ b/internal/component/instance/testdata/wasi-wit/http.wit
@@ -1,0 +1,733 @@
+package wasi:http@0.2.12;
+
+/// This interface defines all of the types and methods for implementing
+/// HTTP Requests and Responses, both incoming and outgoing, as well as
+/// their headers, trailers, and bodies.
+@since(version = 0.2.0)
+interface types {
+  @since(version = 0.2.0)
+  use wasi:clocks/monotonic-clock@0.2.12.{duration};
+  @since(version = 0.2.0)
+  use wasi:io/streams@0.2.12.{input-stream, output-stream};
+  @since(version = 0.2.0)
+  use wasi:io/error@0.2.12.{error as io-error};
+  @since(version = 0.2.0)
+  use wasi:io/poll@0.2.12.{pollable};
+
+  /// This type corresponds to HTTP standard Methods.
+  @since(version = 0.2.0)
+  variant method {
+    get,
+    head,
+    post,
+    put,
+    delete,
+    connect,
+    options,
+    trace,
+    patch,
+    other(string),
+  }
+
+  /// This type corresponds to HTTP standard Related Schemes.
+  @since(version = 0.2.0)
+  variant scheme {
+    HTTP,
+    HTTPS,
+    other(string),
+  }
+
+  /// Defines the case payload type for `DNS-error` above:
+  @since(version = 0.2.0)
+  record DNS-error-payload {
+    rcode: option<string>,
+    info-code: option<u16>,
+  }
+
+  /// Defines the case payload type for `TLS-alert-received` above:
+  @since(version = 0.2.0)
+  record TLS-alert-received-payload {
+    alert-id: option<u8>,
+    alert-message: option<string>,
+  }
+
+  /// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
+  @since(version = 0.2.0)
+  record field-size-payload {
+    field-name: option<string>,
+    field-size: option<u32>,
+  }
+
+  /// These cases are inspired by the IANA HTTP Proxy Error Types:
+  ///   <https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types>
+  @since(version = 0.2.0)
+  variant error-code {
+    DNS-timeout,
+    DNS-error(DNS-error-payload),
+    destination-not-found,
+    destination-unavailable,
+    destination-IP-prohibited,
+    destination-IP-unroutable,
+    connection-refused,
+    connection-terminated,
+    connection-timeout,
+    connection-read-timeout,
+    connection-write-timeout,
+    connection-limit-reached,
+    TLS-protocol-error,
+    TLS-certificate-error,
+    TLS-alert-received(TLS-alert-received-payload),
+    HTTP-request-denied,
+    HTTP-request-length-required,
+    HTTP-request-body-size(option<u64>),
+    HTTP-request-method-invalid,
+    HTTP-request-URI-invalid,
+    HTTP-request-URI-too-long,
+    HTTP-request-header-section-size(option<u32>),
+    HTTP-request-header-size(option<field-size-payload>),
+    HTTP-request-trailer-section-size(option<u32>),
+    HTTP-request-trailer-size(field-size-payload),
+    HTTP-response-incomplete,
+    HTTP-response-header-section-size(option<u32>),
+    HTTP-response-header-size(field-size-payload),
+    HTTP-response-body-size(option<u64>),
+    HTTP-response-trailer-section-size(option<u32>),
+    HTTP-response-trailer-size(field-size-payload),
+    HTTP-response-transfer-coding(option<string>),
+    HTTP-response-content-coding(option<string>),
+    HTTP-response-timeout,
+    HTTP-upgrade-failed,
+    HTTP-protocol-error,
+    loop-detected,
+    configuration-error,
+    /// This is a catch-all error for anything that doesn't fit cleanly into a
+    /// more specific case. It also includes an optional string for an
+    /// unstructured description of the error. Users should not depend on the
+    /// string for diagnosing errors, as it's not required to be consistent
+    /// between implementations.
+    internal-error(option<string>),
+  }
+
+  /// This type enumerates the different kinds of errors that may occur when
+  /// setting or appending to a `fields` resource.
+  @since(version = 0.2.0)
+  variant header-error {
+    /// This error indicates that a `field-name` or `field-value` was
+    /// syntactically invalid when used with an operation that sets headers in a
+    /// `fields`.
+    invalid-syntax,
+    /// This error indicates that a forbidden `field-name` was used when trying
+    /// to set a header in a `fields`.
+    forbidden,
+    /// This error indicates that the operation on the `fields` was not
+    /// permitted because the fields are immutable.
+    immutable,
+  }
+
+  /// Field keys are always strings.
+  ///
+  /// Field keys should always be treated as case insensitive by the `fields`
+  /// resource for the purposes of equality checking.
+  ///
+  /// # Deprecation
+  ///
+  /// This type has been deprecated in favor of the `field-name` type.
+  @since(version = 0.2.0)
+  @deprecated(version = 0.2.2)
+  type field-key = string;
+
+  /// Field names are always strings.
+  ///
+  /// Field names should always be treated as case insensitive by the `fields`
+  /// resource for the purposes of equality checking.
+  @since(version = 0.2.1)
+  type field-name = field-key;
+
+  /// Field values should always be ASCII strings. However, in
+  /// reality, HTTP implementations often have to interpret malformed values,
+  /// so they are provided as a list of bytes.
+  @since(version = 0.2.0)
+  type field-value = list<u8>;
+
+  /// This following block defines the `fields` resource which corresponds to
+  /// HTTP standard Fields. Fields are a common representation used for both
+  /// Headers and Trailers.
+  ///
+  /// A `fields` may be mutable or immutable. A `fields` created using the
+  /// constructor, `from-list`, or `clone` will be mutable, but a `fields`
+  /// resource given by other means (including, but not limited to,
+  /// `incoming-request.headers`, `outgoing-request.headers`) might be
+  /// immutable. In an immutable fields, the `set`, `append`, and `delete`
+  /// operations will fail with `header-error.immutable`.
+  @since(version = 0.2.0)
+  resource fields {
+    /// Construct an empty HTTP Fields.
+    ///
+    /// The resulting `fields` is mutable.
+    @since(version = 0.2.0)
+    constructor();
+    /// Construct an HTTP Fields.
+    ///
+    /// The resulting `fields` is mutable.
+    ///
+    /// The list represents each name-value pair in the Fields. Names
+    /// which have multiple values are represented by multiple entries in this
+    /// list with the same name.
+    ///
+    /// The tuple is a pair of the field name, represented as a string, and
+    /// Value, represented as a list of bytes.
+    ///
+    /// An error result will be returned if any `field-name` or `field-value` is
+    /// syntactically invalid, or if a field is forbidden.
+    @since(version = 0.2.0)
+    from-list: static func(entries: list<tuple<field-name, field-value>>) -> result<fields, header-error>;
+    /// Get all of the values corresponding to a name. If the name is not present
+    /// in this `fields` or is syntactically invalid, an empty list is returned.
+    /// However, if the name is present but empty, this is represented by a list
+    /// with one or more empty field-values present.
+    @since(version = 0.2.0)
+    get: func(name: field-name) -> list<field-value>;
+    /// Returns `true` when the name is present in this `fields`. If the name is
+    /// syntactically invalid, `false` is returned.
+    @since(version = 0.2.0)
+    has: func(name: field-name) -> bool;
+    /// Set all of the values for a name. Clears any existing values for that
+    /// name, if they have been set.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
+    ///
+    /// Fails with `header-error.invalid-syntax` if the `field-name` or any of
+    /// the `field-value`s are syntactically invalid.
+    @since(version = 0.2.0)
+    set: func(name: field-name, value: list<field-value>) -> result<_, header-error>;
+    /// Delete all values for a name. Does nothing if no values for the name
+    /// exist.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
+    ///
+    /// Fails with `header-error.invalid-syntax` if the `field-name` is
+    /// syntactically invalid.
+    @since(version = 0.2.0)
+    delete: func(name: field-name) -> result<_, header-error>;
+    /// Append a value for a name. Does not change or delete any existing
+    /// values for that name.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
+    ///
+    /// Fails with `header-error.invalid-syntax` if the `field-name` or
+    /// `field-value` are syntactically invalid.
+    @since(version = 0.2.0)
+    append: func(name: field-name, value: field-value) -> result<_, header-error>;
+    /// Retrieve the full set of names and values in the Fields. Like the
+    /// constructor, the list represents each name-value pair.
+    ///
+    /// The outer list represents each name-value pair in the Fields. Names
+    /// which have multiple values are represented by multiple entries in this
+    /// list with the same name.
+    ///
+    /// The names and values are always returned in the original casing and in
+    /// the order in which they will be serialized for transport.
+    @since(version = 0.2.0)
+    entries: func() -> list<tuple<field-name, field-value>>;
+    /// Make a deep copy of the Fields. Equivalent in behavior to calling the
+    /// `fields` constructor on the return value of `entries`. The resulting
+    /// `fields` is mutable.
+    @since(version = 0.2.0)
+    clone: func() -> fields;
+  }
+
+  /// Headers is an alias for Fields.
+  @since(version = 0.2.0)
+  type headers = fields;
+
+  /// Trailers is an alias for Fields.
+  @since(version = 0.2.0)
+  type trailers = fields;
+
+  /// Represents an incoming HTTP Request.
+  @since(version = 0.2.0)
+  resource incoming-request {
+    /// Returns the method of the incoming request.
+    @since(version = 0.2.0)
+    method: func() -> method;
+    /// Returns the path with query parameters from the request, as a string.
+    @since(version = 0.2.0)
+    path-with-query: func() -> option<string>;
+    /// Returns the protocol scheme from the request.
+    @since(version = 0.2.0)
+    scheme: func() -> option<scheme>;
+    /// Returns the authority of the Request's target URI, if present.
+    @since(version = 0.2.0)
+    authority: func() -> option<string>;
+    /// Get the `headers` associated with the request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// The `headers` returned are a child resource: it must be dropped before
+    /// the parent `incoming-request` is dropped. Dropping this
+    /// `incoming-request` before all children are dropped will trap.
+    @since(version = 0.2.0)
+    headers: func() -> headers;
+    /// Gives the `incoming-body` associated with this request. Will only
+    /// return success at most once, and subsequent calls will return error.
+    @since(version = 0.2.0)
+    consume: func() -> result<incoming-body>;
+  }
+
+  /// Represents an outgoing HTTP Request.
+  @since(version = 0.2.0)
+  resource outgoing-request {
+    /// Construct a new `outgoing-request` with a default `method` of `GET`, and
+    /// `none` values for `path-with-query`, `scheme`, and `authority`.
+    ///
+    /// * `headers` is the HTTP Headers for the Request.
+    ///
+    /// It is possible to construct, or manipulate with the accessor functions
+    /// below, an `outgoing-request` with an invalid combination of `scheme`
+    /// and `authority`, or `headers` which are not permitted to be sent.
+    /// It is the obligation of the `outgoing-handler.handle` implementation
+    /// to reject invalid constructions of `outgoing-request`.
+    @since(version = 0.2.0)
+    constructor(headers: headers);
+    /// Returns the resource corresponding to the outgoing Body for this
+    /// Request.
+    ///
+    /// Returns success on the first call: the `outgoing-body` resource for
+    /// this `outgoing-request` can be retrieved at most once. Subsequent
+    /// calls will return error.
+    @since(version = 0.2.0)
+    body: func() -> result<outgoing-body>;
+    /// Get the Method for the Request.
+    @since(version = 0.2.0)
+    method: func() -> method;
+    /// Set the Method for the Request. Fails if the string present in a
+    /// `method.other` argument is not a syntactically valid method.
+    @since(version = 0.2.0)
+    set-method: func(method: method) -> result;
+    /// Get the combination of the HTTP Path and Query for the Request.
+    /// When `none`, this represents an empty Path and empty Query.
+    @since(version = 0.2.0)
+    path-with-query: func() -> option<string>;
+    /// Set the combination of the HTTP Path and Query for the Request.
+    /// When `none`, this represents an empty Path and empty Query. Fails is the
+    /// string given is not a syntactically valid path and query uri component.
+    @since(version = 0.2.0)
+    set-path-with-query: func(path-with-query: option<string>) -> result;
+    /// Get the HTTP Related Scheme for the Request. When `none`, the
+    /// implementation may choose an appropriate default scheme.
+    @since(version = 0.2.0)
+    scheme: func() -> option<scheme>;
+    /// Set the HTTP Related Scheme for the Request. When `none`, the
+    /// implementation may choose an appropriate default scheme. Fails if the
+    /// string given is not a syntactically valid uri scheme.
+    @since(version = 0.2.0)
+    set-scheme: func(scheme: option<scheme>) -> result;
+    /// Get the authority of the Request's target URI. A value of `none` may be used
+    /// with Related Schemes which do not require an authority. The HTTP and
+    /// HTTPS schemes always require an authority.
+    @since(version = 0.2.0)
+    authority: func() -> option<string>;
+    /// Set the authority of the Request's target URI. A value of `none` may be used
+    /// with Related Schemes which do not require an authority. The HTTP and
+    /// HTTPS schemes always require an authority. Fails if the string given is
+    /// not a syntactically valid URI authority.
+    @since(version = 0.2.0)
+    set-authority: func(authority: option<string>) -> result;
+    /// Get the headers associated with the Request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `outgoing-request` is dropped, or its ownership is transferred to
+    /// another component by e.g. `outgoing-handler.handle`.
+    @since(version = 0.2.0)
+    headers: func() -> headers;
+  }
+
+  /// Parameters for making an HTTP Request. Each of these parameters is
+  /// currently an optional timeout applicable to the transport layer of the
+  /// HTTP protocol.
+  ///
+  /// These timeouts are separate from any the user may use to bound a
+  /// blocking call to `wasi:io/poll.poll`.
+  @since(version = 0.2.0)
+  resource request-options {
+    /// Construct a default `request-options` value.
+    @since(version = 0.2.0)
+    constructor();
+    /// The timeout for the initial connect to the HTTP Server.
+    @since(version = 0.2.0)
+    connect-timeout: func() -> option<duration>;
+    /// Set the timeout for the initial connect to the HTTP Server. An error
+    /// return value indicates that this timeout is not supported.
+    @since(version = 0.2.0)
+    set-connect-timeout: func(duration: option<duration>) -> result;
+    /// The timeout for receiving the first byte of the Response body.
+    @since(version = 0.2.0)
+    first-byte-timeout: func() -> option<duration>;
+    /// Set the timeout for receiving the first byte of the Response body. An
+    /// error return value indicates that this timeout is not supported.
+    @since(version = 0.2.0)
+    set-first-byte-timeout: func(duration: option<duration>) -> result;
+    /// The timeout for receiving subsequent chunks of bytes in the Response
+    /// body stream.
+    @since(version = 0.2.0)
+    between-bytes-timeout: func() -> option<duration>;
+    /// Set the timeout for receiving subsequent chunks of bytes in the Response
+    /// body stream. An error return value indicates that this timeout is not
+    /// supported.
+    @since(version = 0.2.0)
+    set-between-bytes-timeout: func(duration: option<duration>) -> result;
+  }
+
+  /// Represents the ability to send an HTTP Response.
+  ///
+  /// This resource is used by the `wasi:http/incoming-handler` interface to
+  /// allow a Response to be sent corresponding to the Request provided as the
+  /// other argument to `incoming-handler.handle`.
+  @since(version = 0.2.0)
+  resource response-outparam {
+    /// Send an HTTP 1xx response.
+    ///
+    /// Unlike `response-outparam.set`, this does not consume the
+    /// `response-outparam`, allowing the guest to send an arbitrary number of
+    /// informational responses before sending the final response using
+    /// `response-outparam.set`.
+    ///
+    /// This will return an `HTTP-protocol-error` if `status` is not in the
+    /// range [100-199], or an `internal-error` if the implementation does not
+    /// support informational responses.
+    @unstable(feature = informational-outbound-responses)
+    send-informational: func(status: u16, headers: headers) -> result<_, error-code>;
+    /// Set the value of the `response-outparam` to either send a response,
+    /// or indicate an error.
+    ///
+    /// This method consumes the `response-outparam` to ensure that it is
+    /// called at most once. If it is never called, the implementation
+    /// will respond with an error.
+    ///
+    /// The user may provide an `error` to `response` to allow the
+    /// implementation determine how to respond with an HTTP error response.
+    @since(version = 0.2.0)
+    set: static func(param: response-outparam, response: result<outgoing-response, error-code>);
+  }
+
+  /// This type corresponds to the HTTP standard Status Code.
+  @since(version = 0.2.0)
+  type status-code = u16;
+
+  /// Represents an incoming HTTP Response.
+  @since(version = 0.2.0)
+  resource incoming-response {
+    /// Returns the status code from the incoming response.
+    @since(version = 0.2.0)
+    status: func() -> status-code;
+    /// Returns the headers from the incoming response.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `incoming-response` is dropped.
+    @since(version = 0.2.0)
+    headers: func() -> headers;
+    /// Returns the incoming body. May be called at most once. Returns error
+    /// if called additional times.
+    @since(version = 0.2.0)
+    consume: func() -> result<incoming-body>;
+  }
+
+  /// Represents an incoming HTTP Request or Response's Body.
+  ///
+  /// A body has both its contents - a stream of bytes - and a (possibly
+  /// empty) set of trailers, indicating that the full contents of the
+  /// body have been received. This resource represents the contents as
+  /// an `input-stream` and the delivery of trailers as a `future-trailers`,
+  /// and ensures that the user of this interface may only be consuming either
+  /// the body contents or waiting on trailers at any given time.
+  @since(version = 0.2.0)
+  resource incoming-body {
+    /// Returns the contents of the body, as a stream of bytes.
+    ///
+    /// Returns success on first call: the stream representing the contents
+    /// can be retrieved at most once. Subsequent calls will return error.
+    ///
+    /// The returned `input-stream` resource is a child: it must be dropped
+    /// before the parent `incoming-body` is dropped, or consumed by
+    /// `incoming-body.finish`.
+    ///
+    /// This invariant ensures that the implementation can determine whether
+    /// the user is consuming the contents of the body, waiting on the
+    /// `future-trailers` to be ready, or neither. This allows for network
+    /// backpressure is to be applied when the user is consuming the body,
+    /// and for that backpressure to not inhibit delivery of the trailers if
+    /// the user does not read the entire body.
+    @since(version = 0.2.0)
+    %stream: func() -> result<input-stream>;
+    /// Takes ownership of `incoming-body`, and returns a `future-trailers`.
+    /// This function will trap if the `input-stream` child is still alive.
+    @since(version = 0.2.0)
+    finish: static func(this: incoming-body) -> future-trailers;
+  }
+
+  /// Represents a future which may eventually return trailers, or an error.
+  ///
+  /// In the case that the incoming HTTP Request or Response did not have any
+  /// trailers, this future will resolve to the empty set of trailers once the
+  /// complete Request or Response body has been received.
+  @since(version = 0.2.0)
+  resource future-trailers {
+    /// Returns a pollable which becomes ready when either the trailers have
+    /// been received, or an error has occurred. When this pollable is ready,
+    /// the `get` method will return `some`.
+    @since(version = 0.2.0)
+    subscribe: func() -> pollable;
+    /// Returns the contents of the trailers, or an error which occurred,
+    /// once the future is ready.
+    ///
+    /// The outer `option` represents future readiness. Users can wait on this
+    /// `option` to become `some` using the `subscribe` method.
+    ///
+    /// The outer `result` is used to retrieve the trailers or error at most
+    /// once. It will be success on the first call in which the outer option
+    /// is `some`, and error on subsequent calls.
+    ///
+    /// The inner `result` represents that either the HTTP Request or Response
+    /// body, as well as any trailers, were received successfully, or that an
+    /// error occurred receiving them. The optional `trailers` indicates whether
+    /// or not trailers were present in the body.
+    ///
+    /// When some `trailers` are returned by this method, the `trailers`
+    /// resource is immutable, and a child. Use of the `set`, `append`, or
+    /// `delete` methods will return an error, and the resource must be
+    /// dropped before the parent `future-trailers` is dropped.
+    @since(version = 0.2.0)
+    get: func() -> option<result<result<option<trailers>, error-code>>>;
+  }
+
+  /// Represents an outgoing HTTP Response.
+  @since(version = 0.2.0)
+  resource outgoing-response {
+    /// Construct an `outgoing-response`, with a default `status-code` of `200`.
+    /// If a different `status-code` is needed, it must be set via the
+    /// `set-status-code` method.
+    ///
+    /// * `headers` is the HTTP Headers for the Response.
+    @since(version = 0.2.0)
+    constructor(headers: headers);
+    /// Get the HTTP Status Code for the Response.
+    @since(version = 0.2.0)
+    status-code: func() -> status-code;
+    /// Set the HTTP Status Code for the Response. Fails if the status-code
+    /// given is not a valid http status code.
+    @since(version = 0.2.0)
+    set-status-code: func(status-code: status-code) -> result;
+    /// Get the headers associated with the Request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `outgoing-request` is dropped, or its ownership is transferred to
+    /// another component by e.g. `outgoing-handler.handle`.
+    @since(version = 0.2.0)
+    headers: func() -> headers;
+    /// Returns the resource corresponding to the outgoing Body for this Response.
+    ///
+    /// Returns success on the first call: the `outgoing-body` resource for
+    /// this `outgoing-response` can be retrieved at most once. Subsequent
+    /// calls will return error.
+    @since(version = 0.2.0)
+    body: func() -> result<outgoing-body>;
+  }
+
+  /// Represents an outgoing HTTP Request or Response's Body.
+  ///
+  /// A body has both its contents - a stream of bytes - and a (possibly
+  /// empty) set of trailers, inducating the full contents of the body
+  /// have been sent. This resource represents the contents as an
+  /// `output-stream` child resource, and the completion of the body (with
+  /// optional trailers) with a static function that consumes the
+  /// `outgoing-body` resource, and ensures that the user of this interface
+  /// may not write to the body contents after the body has been finished.
+  ///
+  /// If the user code drops this resource, as opposed to calling the static
+  /// method `finish`, the implementation should treat the body as incomplete,
+  /// and that an error has occurred. The implementation should propagate this
+  /// error to the HTTP protocol by whatever means it has available,
+  /// including: corrupting the body on the wire, aborting the associated
+  /// Request, or sending a late status code for the Response.
+  @since(version = 0.2.0)
+  resource outgoing-body {
+    /// Returns a stream for writing the body contents.
+    ///
+    /// The returned `output-stream` is a child resource: it must be dropped
+    /// before the parent `outgoing-body` resource is dropped (or finished),
+    /// otherwise the `outgoing-body` drop or `finish` will trap.
+    ///
+    /// Returns success on the first call: the `output-stream` resource for
+    /// this `outgoing-body` may be retrieved at most once. Subsequent calls
+    /// will return error.
+    @since(version = 0.2.0)
+    write: func() -> result<output-stream>;
+    /// Finalize an outgoing body, optionally providing trailers. This must be
+    /// called to signal that the response is complete. If the `outgoing-body`
+    /// is dropped without calling `outgoing-body.finalize`, the implementation
+    /// should treat the body as corrupted.
+    ///
+    /// Fails if the body's `outgoing-request` or `outgoing-response` was
+    /// constructed with a Content-Length header, and the contents written
+    /// to the body (via `write`) does not match the value given in the
+    /// Content-Length.
+    @since(version = 0.2.0)
+    finish: static func(this: outgoing-body, trailers: option<trailers>) -> result<_, error-code>;
+  }
+
+  /// Represents a future which may eventually return an incoming HTTP
+  /// Response, or an error.
+  ///
+  /// This resource is returned by the `wasi:http/outgoing-handler` interface to
+  /// provide the HTTP Response corresponding to the sent Request.
+  @since(version = 0.2.0)
+  resource future-incoming-response {
+    /// Returns a pollable which becomes ready when either the Response has
+    /// been received, or an error has occurred. When this pollable is ready,
+    /// the `get` method will return `some`.
+    @since(version = 0.2.0)
+    subscribe: func() -> pollable;
+    /// Returns the incoming HTTP Response, or an error, once one is ready.
+    ///
+    /// The outer `option` represents future readiness. Users can wait on this
+    /// `option` to become `some` using the `subscribe` method.
+    ///
+    /// The outer `result` is used to retrieve the response or error at most
+    /// once. It will be success on the first call in which the outer option
+    /// is `some`, and error on subsequent calls.
+    ///
+    /// The inner `result` represents that either the incoming HTTP Response
+    /// status and headers have received successfully, or that an error
+    /// occurred. Errors may also occur while consuming the response body,
+    /// but those will be reported by the `incoming-body` and its
+    /// `output-stream` child.
+    @since(version = 0.2.0)
+    get: func() -> option<result<result<incoming-response, error-code>>>;
+  }
+
+  /// Attempts to extract a http-related `error` from the wasi:io `error`
+  /// provided.
+  ///
+  /// Stream operations which return
+  /// `wasi:io/stream.stream-error.last-operation-failed` have a payload of
+  /// type `wasi:io/error.error` with more information about the operation
+  /// that failed. This payload can be passed through to this function to see
+  /// if there's http-related information about the error to return.
+  ///
+  /// Note that this function is fallible because not all io-errors are
+  /// http-related errors.
+  @since(version = 0.2.0)
+  http-error-code: func(err: borrow<io-error>) -> option<error-code>;
+}
+
+/// This interface defines a handler of incoming HTTP Requests. It should
+/// be exported by components which can respond to HTTP Requests.
+@since(version = 0.2.0)
+interface incoming-handler {
+  @since(version = 0.2.0)
+  use types.{incoming-request, response-outparam};
+
+  /// This function is invoked with an incoming HTTP Request, and a resource
+  /// `response-outparam` which provides the capability to reply with an HTTP
+  /// Response. The response is sent by calling the `response-outparam.set`
+  /// method, which allows execution to continue after the response has been
+  /// sent. This enables both streaming to the response body, and performing other
+  /// work.
+  ///
+  /// The implementor of this function must write a response to the
+  /// `response-outparam` before returning, or else the caller will respond
+  /// with an error on its behalf.
+  @since(version = 0.2.0)
+  handle: func(request: incoming-request, response-out: response-outparam);
+}
+
+/// This interface defines a handler of outgoing HTTP Requests. It should be
+/// imported by components which wish to make HTTP Requests.
+@since(version = 0.2.0)
+interface outgoing-handler {
+  @since(version = 0.2.0)
+  use types.{outgoing-request, request-options, future-incoming-response, error-code};
+
+  /// This function is invoked with an outgoing HTTP Request, and it returns
+  /// a resource `future-incoming-response` which represents an HTTP Response
+  /// which may arrive in the future.
+  ///
+  /// The `options` argument accepts optional parameters for the HTTP
+  /// protocol's transport layer.
+  ///
+  /// This function may return an error if the `outgoing-request` is invalid
+  /// or not allowed to be made. Otherwise, protocol errors are reported
+  /// through the `future-incoming-response`.
+  @since(version = 0.2.0)
+  handle: func(request: outgoing-request, options: option<request-options>) -> result<future-incoming-response, error-code>;
+}
+
+/// The `wasi:http/imports` world imports all the APIs for HTTP proxies.
+/// It is intended to be `include`d in other worlds.
+@since(version = 0.2.0)
+world imports {
+  @since(version = 0.2.0)
+  import wasi:io/poll@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:clocks/monotonic-clock@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:clocks/wall-clock@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:random/random@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:io/error@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:io/streams@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:cli/stdout@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:cli/stderr@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:cli/stdin@0.2.12;
+  @since(version = 0.2.0)
+  import types;
+  @since(version = 0.2.0)
+  import outgoing-handler;
+}
+/// The `wasi:http/proxy` world captures a widely-implementable intersection of
+/// hosts that includes HTTP forward and reverse proxies. Components targeting
+/// this world may concurrently stream in and out any number of incoming and
+/// outgoing HTTP requests.
+@since(version = 0.2.0)
+world proxy {
+  @since(version = 0.2.0)
+  import wasi:io/poll@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:clocks/monotonic-clock@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:clocks/wall-clock@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:random/random@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:io/error@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:io/streams@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:cli/stdout@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:cli/stderr@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:cli/stdin@0.2.12;
+  @since(version = 0.2.0)
+  import types;
+  @since(version = 0.2.0)
+  import outgoing-handler;
+
+  @since(version = 0.2.0)
+  export incoming-handler;
+}

--- a/internal/component/instance/testdata/wasi-wit/io.wit
+++ b/internal/component/instance/testdata/wasi-wit/io.wit
@@ -1,0 +1,299 @@
+package wasi:io@0.2.12;
+
+@since(version = 0.2.0)
+interface error {
+  /// A resource which represents some error information.
+  ///
+  /// The only method provided by this resource is `to-debug-string`,
+  /// which provides some human-readable information about the error.
+  ///
+  /// In the `wasi:io` package, this resource is returned through the
+  /// `wasi:io/streams.stream-error` type.
+  ///
+  /// To provide more specific error information, other interfaces may
+  /// offer functions to "downcast" this error into more specific types. For example,
+  /// errors returned from streams derived from filesystem types can be described using
+  /// the filesystem's own error-code type. This is done using the function
+  /// `wasi:filesystem/types.filesystem-error-code`, which takes a `borrow<error>`
+  /// parameter and returns an `option<wasi:filesystem/types.error-code>`.
+  ///
+  /// The set of functions which can "downcast" an `error` into a more
+  /// concrete type is open.
+  @since(version = 0.2.0)
+  resource error {
+    /// Returns a string that is suitable to assist humans in debugging
+    /// this error.
+    ///
+    /// WARNING: The returned string should not be consumed mechanically!
+    /// It may change across platforms, hosts, or other implementation
+    /// details. Parsing this string is a major platform-compatibility
+    /// hazard.
+    @since(version = 0.2.0)
+    to-debug-string: func() -> string;
+  }
+}
+
+/// A poll API intended to let users wait for I/O events on multiple handles
+/// at once.
+@since(version = 0.2.0)
+interface poll {
+  /// `pollable` represents a single I/O event which may be ready, or not.
+  @since(version = 0.2.0)
+  resource pollable {
+    /// Return the readiness of a pollable. This function never blocks.
+    ///
+    /// Returns `true` when the pollable is ready, and `false` otherwise.
+    @since(version = 0.2.0)
+    ready: func() -> bool;
+    /// `block` returns immediately if the pollable is ready, and otherwise
+    /// blocks until ready.
+    ///
+    /// This function is equivalent to calling `poll.poll` on a list
+    /// containing only this pollable.
+    @since(version = 0.2.0)
+    block: func();
+  }
+
+  /// Poll for completion on a set of pollables.
+  ///
+  /// This function takes a list of pollables, which identify I/O sources of
+  /// interest, and waits until one or more of the events is ready for I/O.
+  ///
+  /// The result `list<u32>` contains one or more indices of handles in the
+  /// argument list that is ready for I/O.
+  ///
+  /// This function traps if either:
+  /// - the list is empty, or:
+  /// - the list contains more elements than can be indexed with a `u32` value.
+  ///
+  /// A timeout can be implemented by adding a pollable from the
+  /// wasi-clocks API to the list.
+  ///
+  /// This function does not return a `result`; polling in itself does not
+  /// do any I/O so it doesn't fail. If any of the I/O sources identified by
+  /// the pollables has an error, it is indicated by marking the source as
+  /// being ready for I/O.
+  @since(version = 0.2.0)
+  poll: func(in: list<borrow<pollable>>) -> list<u32>;
+}
+
+/// WASI I/O is an I/O abstraction API which is currently focused on providing
+/// stream types.
+///
+/// In the future, the component model is expected to add built-in stream types;
+/// when it does, they are expected to subsume this API.
+@since(version = 0.2.0)
+interface streams {
+  @since(version = 0.2.0)
+  use error.{error};
+  @since(version = 0.2.0)
+  use poll.{pollable};
+
+  /// An error for input-stream and output-stream operations.
+  @since(version = 0.2.0)
+  variant stream-error {
+    /// The last operation (a write or flush) failed before completion.
+    ///
+    /// More information is available in the `error` payload.
+    ///
+    /// After this, the stream will be closed. All future operations return
+    /// `stream-error::closed`.
+    last-operation-failed(error),
+    /// The stream is closed: no more input will be accepted by the
+    /// stream. A closed output-stream will return this error on all
+    /// future operations.
+    closed,
+  }
+
+  /// An input bytestream.
+  ///
+  /// `input-stream`s are *non-blocking* to the extent practical on underlying
+  /// platforms. I/O operations always return promptly; if fewer bytes are
+  /// promptly available than requested, they return the number of bytes promptly
+  /// available, which could even be zero. To wait for data to be available,
+  /// use the `subscribe` function to obtain a `pollable` which can be polled
+  /// for using `wasi:io/poll`.
+  @since(version = 0.2.0)
+  resource input-stream {
+    /// Perform a non-blocking read from the stream.
+    ///
+    /// When the source of a `read` is binary data, the bytes from the source
+    /// are returned verbatim. When the source of a `read` is known to the
+    /// implementation to be text, bytes containing the UTF-8 encoding of the
+    /// text are returned.
+    ///
+    /// This function returns a list of bytes containing the read data,
+    /// when successful. The returned list will contain up to `len` bytes;
+    /// it may return fewer than requested, but not more. The list is
+    /// empty when no bytes are available for reading at this time. The
+    /// pollable given by `subscribe` will be ready when more bytes are
+    /// available.
+    ///
+    /// This function fails with a `stream-error` when the operation
+    /// encounters an error, giving `last-operation-failed`, or when the
+    /// stream is closed, giving `closed`.
+    ///
+    /// When the caller gives a `len` of 0, it represents a request to
+    /// read 0 bytes. If the stream is still open, this call should
+    /// succeed and return an empty list, or otherwise fail with `closed`.
+    ///
+    /// The `len` parameter is a `u64`, which could represent a list of u8 which
+    /// is not possible to allocate in wasm32, or not desirable to allocate as
+    /// as a return value by the callee. The callee may return a list of bytes
+    /// less than `len` in size while more bytes are available for reading.
+    @since(version = 0.2.0)
+    read: func(len: u64) -> result<list<u8>, stream-error>;
+    /// Read bytes from a stream, after blocking until at least one byte can
+    /// be read. Except for blocking, behavior is identical to `read`.
+    @since(version = 0.2.0)
+    blocking-read: func(len: u64) -> result<list<u8>, stream-error>;
+    /// Skip bytes from a stream. Returns number of bytes skipped.
+    ///
+    /// Behaves identical to `read`, except instead of returning a list
+    /// of bytes, returns the number of bytes consumed from the stream.
+    @since(version = 0.2.0)
+    skip: func(len: u64) -> result<u64, stream-error>;
+    /// Skip bytes from a stream, after blocking until at least one byte
+    /// can be skipped. Except for blocking behavior, identical to `skip`.
+    @since(version = 0.2.0)
+    blocking-skip: func(len: u64) -> result<u64, stream-error>;
+    /// Create a `pollable` which will resolve once either the specified stream
+    /// has bytes available to read or the other end of the stream has been
+    /// closed.
+    /// The created `pollable` is a child resource of the `input-stream`.
+    /// Implementations may trap if the `input-stream` is dropped before
+    /// all derived `pollable`s created with this function are dropped.
+    @since(version = 0.2.0)
+    subscribe: func() -> pollable;
+  }
+
+  /// An output bytestream.
+  ///
+  /// `output-stream`s are *non-blocking* to the extent practical on
+  /// underlying platforms. Except where specified otherwise, I/O operations also
+  /// always return promptly, after the number of bytes that can be written
+  /// promptly, which could even be zero. To wait for the stream to be ready to
+  /// accept data, the `subscribe` function to obtain a `pollable` which can be
+  /// polled for using `wasi:io/poll`.
+  ///
+  /// Dropping an `output-stream` while there's still an active write in
+  /// progress may result in the data being lost. Before dropping the stream,
+  /// be sure to fully flush your writes.
+  @since(version = 0.2.0)
+  resource output-stream {
+    /// Check readiness for writing. This function never blocks.
+    ///
+    /// Returns the number of bytes permitted for the next call to `write`,
+    /// or an error. Calling `write` with more bytes than this function has
+    /// permitted will trap.
+    ///
+    /// When this function returns 0 bytes, the `subscribe` pollable will
+    /// become ready when this function will report at least 1 byte, or an
+    /// error.
+    @since(version = 0.2.0)
+    check-write: func() -> result<u64, stream-error>;
+    /// Perform a write. This function never blocks.
+    ///
+    /// When the destination of a `write` is binary data, the bytes from
+    /// `contents` are written verbatim. When the destination of a `write` is
+    /// known to the implementation to be text, the bytes of `contents` are
+    /// transcoded from UTF-8 into the encoding of the destination and then
+    /// written.
+    ///
+    /// Precondition: check-write gave permit of Ok(n) and contents has a
+    /// length of less than or equal to n. Otherwise, this function will trap.
+    ///
+    /// returns Err(closed) without writing if the stream has closed since
+    /// the last call to check-write provided a permit.
+    @since(version = 0.2.0)
+    write: func(contents: list<u8>) -> result<_, stream-error>;
+    /// Perform a write of up to 4096 bytes, and then flush the stream. Block
+    /// until all of these operations are complete, or an error occurs.
+    ///
+    /// Returns success when all of the contents written are successfully
+    /// flushed to output. If an error occurs at any point before all
+    /// contents are successfully flushed, that error is returned as soon as
+    /// possible. If writing and flushing the complete contents causes the
+    /// stream to become closed, this call should return success, and
+    /// subsequent calls to check-write or other interfaces should return
+    /// stream-error::closed.
+    @since(version = 0.2.0)
+    blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
+    /// Request to flush buffered output. This function never blocks.
+    ///
+    /// This tells the output-stream that the caller intends any buffered
+    /// output to be flushed. the output which is expected to be flushed
+    /// is all that has been passed to `write` prior to this call.
+    ///
+    /// Upon calling this function, the `output-stream` will not accept any
+    /// writes (`check-write` will return `ok(0)`) until the flush has
+    /// completed. The `subscribe` pollable will become ready when the
+    /// flush has completed and the stream can accept more writes.
+    @since(version = 0.2.0)
+    flush: func() -> result<_, stream-error>;
+    /// Request to flush buffered output, and block until flush completes
+    /// and stream is ready for writing again.
+    @since(version = 0.2.0)
+    blocking-flush: func() -> result<_, stream-error>;
+    /// Create a `pollable` which will resolve once the output-stream
+    /// is ready for more writing, or an error has occurred. When this
+    /// pollable is ready, `check-write` will return `ok(n)` with n>0, or an
+    /// error.
+    ///
+    /// If the stream is closed, this pollable is always ready immediately.
+    ///
+    /// The created `pollable` is a child resource of the `output-stream`.
+    /// Implementations may trap if the `output-stream` is dropped before
+    /// all derived `pollable`s created with this function are dropped.
+    @since(version = 0.2.0)
+    subscribe: func() -> pollable;
+    /// Write zeroes to a stream.
+    ///
+    /// This should be used precisely like `write` with the exact same
+    /// preconditions (must use check-write first), but instead of
+    /// passing a list of bytes, you simply pass the number of zero-bytes
+    /// that should be written.
+    @since(version = 0.2.0)
+    write-zeroes: func(len: u64) -> result<_, stream-error>;
+    /// Perform a write of up to 4096 zeroes, and then flush the stream.
+    /// Block until all of these operations are complete, or an error
+    /// occurs.
+    ///
+    /// Functionality is equivelant to `blocking-write-and-flush` with
+    /// contents given as a list of len containing only zeroes.
+    @since(version = 0.2.0)
+    blocking-write-zeroes-and-flush: func(len: u64) -> result<_, stream-error>;
+    /// Read from one stream and write to another.
+    ///
+    /// The behavior of splice is equivalent to:
+    /// 1. calling `check-write` on the `output-stream`
+    /// 2. calling `read` on the `input-stream` with the smaller of the
+    /// `check-write` permitted length and the `len` provided to `splice`
+    /// 3. calling `write` on the `output-stream` with that read data.
+    ///
+    /// Any error reported by the call to `check-write`, `read`, or
+    /// `write` ends the splice and reports that error.
+    ///
+    /// This function returns the number of bytes transferred; it may be less
+    /// than `len`.
+    @since(version = 0.2.0)
+    splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;
+    /// Read from one stream and write to another, with blocking.
+    ///
+    /// This is similar to `splice`, except that it blocks until the
+    /// `output-stream` is ready for writing, and the `input-stream`
+    /// is ready for reading, before performing the `splice`.
+    @since(version = 0.2.0)
+    blocking-splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;
+  }
+}
+
+@since(version = 0.2.0)
+world imports {
+  @since(version = 0.2.0)
+  import error;
+  @since(version = 0.2.0)
+  import poll;
+  @since(version = 0.2.0)
+  import streams;
+}

--- a/internal/component/instance/testdata/wasi-wit/random.wit
+++ b/internal/component/instance/testdata/wasi-wit/random.wit
@@ -1,0 +1,92 @@
+package wasi:random@0.2.12;
+
+/// The insecure-seed interface for seeding hash-map DoS resistance.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+@since(version = 0.2.0)
+interface insecure-seed {
+  /// Return a 128-bit value that may contain a pseudo-random value.
+  ///
+  /// The returned value is not required to be computed from a CSPRNG, and may
+  /// even be entirely deterministic. Host implementations are encouraged to
+  /// provide pseudo-random values to any program exposed to
+  /// attacker-controlled content, to enable DoS protection built into many
+  /// languages' hash-map implementations.
+  ///
+  /// This function is intended to only be called once, by a source language
+  /// to initialize Denial Of Service (DoS) protection in its hash-map
+  /// implementation.
+  ///
+  /// # Expected future evolution
+  ///
+  /// This will likely be changed to a value import, to prevent it from being
+  /// called multiple times and potentially used for purposes other than DoS
+  /// protection.
+  @since(version = 0.2.0)
+  insecure-seed: func() -> tuple<u64, u64>;
+}
+
+/// The insecure interface for insecure pseudo-random numbers.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+@since(version = 0.2.0)
+interface insecure {
+  /// Return `len` insecure pseudo-random bytes.
+  ///
+  /// This function is not cryptographically secure. Do not use it for
+  /// anything related to security.
+  ///
+  /// There are no requirements on the values of the returned bytes, however
+  /// implementations are encouraged to return evenly distributed values with
+  /// a long period.
+  @since(version = 0.2.0)
+  get-insecure-random-bytes: func(len: u64) -> list<u8>;
+
+  /// Return an insecure pseudo-random `u64` value.
+  ///
+  /// This function returns the same type of pseudo-random data as
+  /// `get-insecure-random-bytes`, represented as a `u64`.
+  @since(version = 0.2.0)
+  get-insecure-random-u64: func() -> u64;
+}
+
+/// WASI Random is a random data API.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+@since(version = 0.2.0)
+interface random {
+  /// Return `len` cryptographically-secure random or pseudo-random bytes.
+  ///
+  /// This function must produce data at least as cryptographically secure and
+  /// fast as an adequately seeded cryptographically-secure pseudo-random
+  /// number generator (CSPRNG). It must not block, from the perspective of
+  /// the calling program, under any circumstances, including on the first
+  /// request and on requests for numbers of bytes. The returned data must
+  /// always be unpredictable.
+  ///
+  /// This function must always return fresh data. Deterministic environments
+  /// must omit this function, rather than implementing it with deterministic
+  /// data.
+  @since(version = 0.2.0)
+  get-random-bytes: func(len: u64) -> list<u8>;
+
+  /// Return a cryptographically-secure random or pseudo-random `u64` value.
+  ///
+  /// This function returns the same type of data as `get-random-bytes`,
+  /// represented as a `u64`.
+  @since(version = 0.2.0)
+  get-random-u64: func() -> u64;
+}
+
+@since(version = 0.2.0)
+world imports {
+  @since(version = 0.2.0)
+  import random;
+  @since(version = 0.2.0)
+  import insecure;
+  @since(version = 0.2.0)
+  import insecure-seed;
+}

--- a/internal/component/instance/testdata/wasi-wit/sockets.wit
+++ b/internal/component/instance/testdata/wasi-wit/sockets.wit
@@ -1,0 +1,949 @@
+package wasi:sockets@0.2.12;
+
+@since(version = 0.2.0)
+interface network {
+  @unstable(feature = network-error-code)
+  use wasi:io/error@0.2.12.{error};
+
+  /// An opaque resource that represents access to (a subset of) the network.
+  /// This enables context-based security for networking.
+  /// There is no need for this to map 1:1 to a physical network interface.
+  @since(version = 0.2.0)
+  resource network;
+
+  /// Error codes.
+  ///
+  /// In theory, every API can return any error code.
+  /// In practice, API's typically only return the errors documented per API
+  /// combined with a couple of errors that are always possible:
+  /// - `unknown`
+  /// - `access-denied`
+  /// - `not-supported`
+  /// - `out-of-memory`
+  /// - `concurrency-conflict`
+  ///
+  /// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
+  @since(version = 0.2.0)
+  enum error-code {
+    /// Unknown error
+    unknown,
+    /// Access denied.
+    ///
+    /// POSIX equivalent: EACCES, EPERM
+    access-denied,
+    /// The operation is not supported.
+    ///
+    /// POSIX equivalent: EOPNOTSUPP
+    not-supported,
+    /// One of the arguments is invalid.
+    ///
+    /// POSIX equivalent: EINVAL
+    invalid-argument,
+    /// Not enough memory to complete the operation.
+    ///
+    /// POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
+    out-of-memory,
+    /// The operation timed out before it could finish completely.
+    timeout,
+    /// This operation is incompatible with another asynchronous operation that is already in progress.
+    ///
+    /// POSIX equivalent: EALREADY
+    concurrency-conflict,
+    /// Trying to finish an asynchronous operation that:
+    /// - has not been started yet, or:
+    /// - was already finished by a previous `finish-*` call.
+    ///
+    /// Note: this is scheduled to be removed when `future`s are natively supported.
+    not-in-progress,
+    /// The operation has been aborted because it could not be completed immediately.
+    ///
+    /// Note: this is scheduled to be removed when `future`s are natively supported.
+    would-block,
+    /// The operation is not valid in the socket's current state.
+    invalid-state,
+    /// A new socket resource could not be created because of a system limit.
+    new-socket-limit,
+    /// A bind operation failed because the provided address is not an address that the `network` can bind to.
+    address-not-bindable,
+    /// A bind operation failed because the provided address is already in use or because there are no ephemeral ports available.
+    address-in-use,
+    /// The remote address is not reachable
+    remote-unreachable,
+    /// The TCP connection was forcefully rejected
+    connection-refused,
+    /// The TCP connection was reset.
+    connection-reset,
+    /// A TCP connection was aborted.
+    connection-aborted,
+    /// The size of a datagram sent to a UDP socket exceeded the maximum
+    /// supported size.
+    datagram-too-large,
+    /// Name does not exist or has no suitable associated IP addresses.
+    name-unresolvable,
+    /// A temporary failure in name resolution occurred.
+    temporary-resolver-failure,
+    /// A permanent failure in name resolution occurred.
+    permanent-resolver-failure,
+  }
+
+  @since(version = 0.2.0)
+  enum ip-address-family {
+    /// Similar to `AF_INET` in POSIX.
+    ipv4,
+    /// Similar to `AF_INET6` in POSIX.
+    ipv6,
+  }
+
+  @since(version = 0.2.0)
+  type ipv4-address = tuple<u8, u8, u8, u8>;
+
+  @since(version = 0.2.0)
+  type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
+
+  @since(version = 0.2.0)
+  variant ip-address {
+    ipv4(ipv4-address),
+    ipv6(ipv6-address),
+  }
+
+  @since(version = 0.2.0)
+  record ipv4-socket-address {
+    /// sin_port
+    port: u16,
+    /// sin_addr
+    address: ipv4-address,
+  }
+
+  @since(version = 0.2.0)
+  record ipv6-socket-address {
+    /// sin6_port
+    port: u16,
+    /// sin6_flowinfo
+    flow-info: u32,
+    /// sin6_addr
+    address: ipv6-address,
+    /// sin6_scope_id
+    scope-id: u32,
+  }
+
+  @since(version = 0.2.0)
+  variant ip-socket-address {
+    ipv4(ipv4-socket-address),
+    ipv6(ipv6-socket-address),
+  }
+
+  /// Attempts to extract a network-related `error-code` from the stream
+  /// `error` provided.
+  ///
+  /// Stream operations which return `stream-error::last-operation-failed`
+  /// have a payload with more information about the operation that failed.
+  /// This payload can be passed through to this function to see if there's
+  /// network-related information about the error to return.
+  ///
+  /// Note that this function is fallible because not all stream-related
+  /// errors are network-related errors.
+  @unstable(feature = network-error-code)
+  network-error-code: func(err: borrow<error>) -> option<error-code>;
+}
+
+/// This interface provides a value-export of the default network handle..
+@since(version = 0.2.0)
+interface instance-network {
+  @since(version = 0.2.0)
+  use network.{network};
+
+  /// Get a handle to the default network.
+  @since(version = 0.2.0)
+  instance-network: func() -> network;
+}
+
+@since(version = 0.2.0)
+interface ip-name-lookup {
+  @since(version = 0.2.0)
+  use wasi:io/poll@0.2.12.{pollable};
+  @since(version = 0.2.0)
+  use network.{network, error-code, ip-address};
+
+  @since(version = 0.2.0)
+  resource resolve-address-stream {
+    /// Returns the next address from the resolver.
+    ///
+    /// This function should be called multiple times. On each call, it will
+    /// return the next address in connection order preference. If all
+    /// addresses have been exhausted, this function returns `none`.
+    ///
+    /// This function never returns IPv4-mapped IPv6 addresses.
+    ///
+    /// # Typical errors
+    /// - `name-unresolvable`:          Name does not exist or has no suitable associated IP addresses. (EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY)
+    /// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
+    /// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
+    /// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
+    @since(version = 0.2.0)
+    resolve-next-address: func() -> result<option<ip-address>, error-code>;
+    /// Create a `pollable` which will resolve once the stream is ready for I/O.
+    ///
+    /// Note: this function is here for WASI 0.2 only.
+    /// It's planned to be removed when `future` is natively supported in Preview3.
+    @since(version = 0.2.0)
+    subscribe: func() -> pollable;
+  }
+
+  /// Resolve an internet host name to a list of IP addresses.
+  ///
+  /// Unicode domain names are automatically converted to ASCII using IDNA encoding.
+  /// If the input is an IP address string, the address is parsed and returned
+  /// as-is without making any external requests.
+  ///
+  /// See the wasi-socket proposal README.md for a comparison with getaddrinfo.
+  ///
+  /// This function never blocks. It either immediately fails or immediately
+  /// returns successfully with a `resolve-address-stream` that can be used
+  /// to (asynchronously) fetch the results.
+  ///
+  /// # Typical errors
+  /// - `invalid-argument`: `name` is a syntactically invalid domain name or IP address.
+  ///
+  /// # References:
+  /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>
+  /// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
+  /// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
+  /// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
+  @since(version = 0.2.0)
+  resolve-addresses: func(network: borrow<network>, name: string) -> result<resolve-address-stream, error-code>;
+}
+
+@since(version = 0.2.0)
+interface tcp {
+  @since(version = 0.2.0)
+  use wasi:io/streams@0.2.12.{input-stream, output-stream};
+  @since(version = 0.2.0)
+  use wasi:io/poll@0.2.12.{pollable};
+  @since(version = 0.2.0)
+  use wasi:clocks/monotonic-clock@0.2.12.{duration};
+  @since(version = 0.2.0)
+  use network.{network, error-code, ip-socket-address, ip-address-family};
+
+  @since(version = 0.2.0)
+  enum shutdown-type {
+    /// Similar to `SHUT_RD` in POSIX.
+    receive,
+    /// Similar to `SHUT_WR` in POSIX.
+    send,
+    /// Similar to `SHUT_RDWR` in POSIX.
+    both,
+  }
+
+  /// A TCP socket resource.
+  ///
+  /// The socket can be in one of the following states:
+  /// - `unbound`
+  /// - `bind-in-progress`
+  /// - `bound` (See note below)
+  /// - `listen-in-progress`
+  /// - `listening`
+  /// - `connect-in-progress`
+  /// - `connected`
+  /// - `closed`
+  /// See <https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/TcpSocketOperationalSemantics.md>
+  /// for more information.
+  ///
+  /// Note: Except where explicitly mentioned, whenever this documentation uses
+  /// the term "bound" without backticks it actually means: in the `bound` state *or higher*.
+  /// (i.e. `bound`, `listen-in-progress`, `listening`, `connect-in-progress` or `connected`)
+  ///
+  /// In addition to the general error codes documented on the
+  /// `network::error-code` type, TCP socket methods may always return
+  /// `error(invalid-state)` when in the `closed` state.
+  @since(version = 0.2.0)
+  resource tcp-socket {
+    /// Bind the socket to a specific network on the provided IP address and port.
+    ///
+    /// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+    /// network interface(s) to bind to.
+    /// If the TCP/UDP port is zero, the socket will be bound to a random free port.
+    ///
+    /// Bind can be attempted multiple times on the same socket, even with
+    /// different arguments on each iteration. But never concurrently and
+    /// only as long as the previous bind failed. Once a bind succeeds, the
+    /// binding can't be changed anymore.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
+    /// - `invalid-argument`:          `local-address` is not a unicast address. (EINVAL)
+    /// - `invalid-argument`:          `local-address` is an IPv4-mapped IPv6 address. (EINVAL)
+    /// - `invalid-state`:             The socket is already bound. (EINVAL)
+    /// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+    /// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+    /// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+    /// - `not-in-progress`:           A `bind` operation is not in progress.
+    /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+    ///
+    /// # Implementors note
+    /// When binding to a non-zero port, this bind operation shouldn't be affected by the TIME_WAIT
+    /// state of a recently closed socket on the same local address. In practice this means that the SO_REUSEADDR
+    /// socket option should be set implicitly on all platforms, except on Windows where this is the default behavior
+    /// and SO_REUSEADDR performs something different entirely.
+    ///
+    /// Unlike in POSIX, in WASI the bind operation is async. This enables
+    /// interactive WASI hosts to inject permission prompts. Runtimes that
+    /// don't want to make use of this ability can simply call the native
+    /// `bind` as part of either `start-bind` or `finish-bind`.
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+    /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+    @since(version = 0.2.0)
+    start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+    @since(version = 0.2.0)
+    finish-bind: func() -> result<_, error-code>;
+    /// Connect to a remote endpoint.
+    ///
+    /// On success:
+    /// - the socket is transitioned into the `connected` state.
+    /// - a pair of streams is returned that can be used to read & write to the connection
+    ///
+    /// After a failed connection attempt, the socket will be in the `closed`
+    /// state and the only valid action left is to `drop` the socket. A single
+    /// socket can not be used to connect more than once.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+    /// - `invalid-argument`:          `remote-address` is not a unicast address. (EINVAL, ENETUNREACH on Linux, EAFNOSUPPORT on MacOS)
+    /// - `invalid-argument`:          `remote-address` is an IPv4-mapped IPv6 address. (EINVAL, EADDRNOTAVAIL on Illumos)
+    /// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
+    /// - `invalid-argument`:          The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
+    /// - `invalid-argument`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+    /// - `invalid-state`:             The socket is already in the `connected` state. (EISCONN)
+    /// - `invalid-state`:             The socket is already in the `listening` state. (EOPNOTSUPP, EINVAL on Windows)
+    /// - `timeout`:                   Connection timed out. (ETIMEDOUT)
+    /// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
+    /// - `connection-reset`:          The connection was reset. (ECONNRESET)
+    /// - `connection-aborted`:        The connection was aborted. (ECONNABORTED)
+    /// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+    /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+    /// - `not-in-progress`:           A connect operation is not in progress.
+    /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+    ///
+    /// # Implementors note
+    /// The POSIX equivalent of `start-connect` is the regular `connect` syscall.
+    /// Because all WASI sockets are non-blocking this is expected to return
+    /// EINPROGRESS, which should be translated to `ok()` in WASI.
+    ///
+    /// The POSIX equivalent of `finish-connect` is a `poll` for event `POLLOUT`
+    /// with a timeout of 0 on the socket descriptor. Followed by a check for
+    /// the `SO_ERROR` socket option, in case the poll signaled readiness.
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+    /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+    /// - <https://man.freebsd.org/cgi/man.cgi?connect>
+    @since(version = 0.2.0)
+    start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+    @since(version = 0.2.0)
+    finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
+    /// Start listening for new connections.
+    ///
+    /// Transitions the socket into the `listening` state.
+    ///
+    /// Unlike POSIX, the socket must already be explicitly bound.
+    ///
+    /// # Typical errors
+    /// - `invalid-state`:             The socket is not bound to any local address. (EDESTADDRREQ)
+    /// - `invalid-state`:             The socket is already in the `connected` state. (EISCONN, EINVAL on BSD)
+    /// - `invalid-state`:             The socket is already in the `listening` state.
+    /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
+    /// - `not-in-progress`:           A listen operation is not in progress.
+    /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+    ///
+    /// # Implementors note
+    /// Unlike in POSIX, in WASI the listen operation is async. This enables
+    /// interactive WASI hosts to inject permission prompts. Runtimes that
+    /// don't want to make use of this ability can simply call the native
+    /// `listen` as part of either `start-listen` or `finish-listen`.
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
+    /// - <https://man7.org/linux/man-pages/man2/listen.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
+    @since(version = 0.2.0)
+    start-listen: func() -> result<_, error-code>;
+    @since(version = 0.2.0)
+    finish-listen: func() -> result<_, error-code>;
+    /// Accept a new client socket.
+    ///
+    /// The returned socket is bound and in the `connected` state. The following properties are inherited from the listener socket:
+    /// - `address-family`
+    /// - `keep-alive-enabled`
+    /// - `keep-alive-idle-time`
+    /// - `keep-alive-interval`
+    /// - `keep-alive-count`
+    /// - `hop-limit`
+    /// - `receive-buffer-size`
+    /// - `send-buffer-size`
+    ///
+    /// On success, this function returns the newly accepted client socket along with
+    /// a pair of streams that can be used to read & write to the connection.
+    ///
+    /// # Typical errors
+    /// - `invalid-state`:      Socket is not in the `listening` state. (EINVAL)
+    /// - `would-block`:        No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
+    /// - `connection-aborted`: An incoming connection was pending, but was terminated by the client before this listener could accept it. (ECONNABORTED)
+    /// - `new-socket-limit`:   The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
+    /// - <https://man7.org/linux/man-pages/man2/accept.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
+    @since(version = 0.2.0)
+    accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
+    /// Get the bound local address.
+    ///
+    /// POSIX mentions:
+    /// > If the socket has not been bound to a local name, the value
+    /// > stored in the object pointed to by `address` is unspecified.
+    ///
+    /// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
+    ///
+    /// # Typical errors
+    /// - `invalid-state`: The socket is not bound to any local address.
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+    /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+    /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+    @since(version = 0.2.0)
+    local-address: func() -> result<ip-socket-address, error-code>;
+    /// Get the remote address.
+    ///
+    /// # Typical errors
+    /// - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+    /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+    @since(version = 0.2.0)
+    remote-address: func() -> result<ip-socket-address, error-code>;
+    /// Whether the socket is in the `listening` state.
+    ///
+    /// Equivalent to the SO_ACCEPTCONN socket option.
+    @since(version = 0.2.0)
+    is-listening: func() -> bool;
+    /// Whether this is a IPv4 or IPv6 socket.
+    ///
+    /// Equivalent to the SO_DOMAIN socket option.
+    @since(version = 0.2.0)
+    address-family: func() -> ip-address-family;
+    /// Hints the desired listen queue size. Implementations are free to ignore this.
+    ///
+    /// If the provided value is 0, an `invalid-argument` error is returned.
+    /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    ///
+    /// # Typical errors
+    /// - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
+    /// - `invalid-argument`:     (set) The provided value was 0.
+    /// - `invalid-state`:        (set) The socket is in the `connect-in-progress` or `connected` state.
+    @since(version = 0.2.0)
+    set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
+    /// Enables or disables keepalive.
+    ///
+    /// The keepalive behavior can be adjusted using:
+    /// - `keep-alive-idle-time`
+    /// - `keep-alive-interval`
+    /// - `keep-alive-count`
+    /// These properties can be configured while `keep-alive-enabled` is false, but only come into effect when `keep-alive-enabled` is true.
+    ///
+    /// Equivalent to the SO_KEEPALIVE socket option.
+    @since(version = 0.2.0)
+    keep-alive-enabled: func() -> result<bool, error-code>;
+    @since(version = 0.2.0)
+    set-keep-alive-enabled: func(value: bool) -> result<_, error-code>;
+    /// Amount of time the connection has to be idle before TCP starts sending keepalive packets.
+    ///
+    /// If the provided value is 0, an `invalid-argument` error is returned.
+    /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    /// I.e. after setting a value, reading the same setting back may return a different value.
+    ///
+    /// Equivalent to the TCP_KEEPIDLE socket option. (TCP_KEEPALIVE on MacOS)
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:     (set) The provided value was 0.
+    @since(version = 0.2.0)
+    keep-alive-idle-time: func() -> result<duration, error-code>;
+    @since(version = 0.2.0)
+    set-keep-alive-idle-time: func(value: duration) -> result<_, error-code>;
+    /// The time between keepalive packets.
+    ///
+    /// If the provided value is 0, an `invalid-argument` error is returned.
+    /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    /// I.e. after setting a value, reading the same setting back may return a different value.
+    ///
+    /// Equivalent to the TCP_KEEPINTVL socket option.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:     (set) The provided value was 0.
+    @since(version = 0.2.0)
+    keep-alive-interval: func() -> result<duration, error-code>;
+    @since(version = 0.2.0)
+    set-keep-alive-interval: func(value: duration) -> result<_, error-code>;
+    /// The maximum amount of keepalive packets TCP should send before aborting the connection.
+    ///
+    /// If the provided value is 0, an `invalid-argument` error is returned.
+    /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    /// I.e. after setting a value, reading the same setting back may return a different value.
+    ///
+    /// Equivalent to the TCP_KEEPCNT socket option.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:     (set) The provided value was 0.
+    @since(version = 0.2.0)
+    keep-alive-count: func() -> result<u32, error-code>;
+    @since(version = 0.2.0)
+    set-keep-alive-count: func(value: u32) -> result<_, error-code>;
+    /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
+    ///
+    /// If the provided value is 0, an `invalid-argument` error is returned.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
+    @since(version = 0.2.0)
+    hop-limit: func() -> result<u8, error-code>;
+    @since(version = 0.2.0)
+    set-hop-limit: func(value: u8) -> result<_, error-code>;
+    /// The kernel buffer space reserved for sends/receives on this socket.
+    ///
+    /// If the provided value is 0, an `invalid-argument` error is returned.
+    /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    /// I.e. after setting a value, reading the same setting back may return a different value.
+    ///
+    /// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:     (set) The provided value was 0.
+    @since(version = 0.2.0)
+    receive-buffer-size: func() -> result<u64, error-code>;
+    @since(version = 0.2.0)
+    set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+    @since(version = 0.2.0)
+    send-buffer-size: func() -> result<u64, error-code>;
+    @since(version = 0.2.0)
+    set-send-buffer-size: func(value: u64) -> result<_, error-code>;
+    /// Create a `pollable` which can be used to poll for, or block on,
+    /// completion of any of the asynchronous operations of this socket.
+    ///
+    /// When `finish-bind`, `finish-listen`, `finish-connect` or `accept`
+    /// return `error(would-block)`, this pollable can be used to wait for
+    /// their success or failure, after which the method can be retried.
+    ///
+    /// The pollable is not limited to the async operation that happens to be
+    /// in progress at the time of calling `subscribe` (if any). Theoretically,
+    /// `subscribe` only has to be called once per socket and can then be
+    /// (re)used for the remainder of the socket's lifetime.
+    ///
+    /// See <https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/TcpSocketOperationalSemantics.md#pollable-readiness>
+    /// for more information.
+    ///
+    /// Note: this function is here for WASI 0.2 only.
+    /// It's planned to be removed when `future` is natively supported in Preview3.
+    @since(version = 0.2.0)
+    subscribe: func() -> pollable;
+    /// Initiate a graceful shutdown.
+    ///
+    /// - `receive`: The socket is not expecting to receive any data from
+    ///   the peer. The `input-stream` associated with this socket will be
+    ///   closed. Any data still in the receive queue at time of calling
+    ///   this method will be discarded.
+    /// - `send`: The socket has no more data to send to the peer. The `output-stream`
+    ///   associated with this socket will be closed and a FIN packet will be sent.
+    /// - `both`: Same effect as `receive` & `send` combined.
+    ///
+    /// This function is idempotent; shutting down a direction more than once
+    /// has no effect and returns `ok`.
+    ///
+    /// The shutdown function does not close (drop) the socket.
+    ///
+    /// # Typical errors
+    /// - `invalid-state`: The socket is not in the `connected` state. (ENOTCONN)
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
+    /// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
+    @since(version = 0.2.0)
+    shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>;
+  }
+}
+
+@since(version = 0.2.0)
+interface tcp-create-socket {
+  @since(version = 0.2.0)
+  use network.{network, error-code, ip-address-family};
+  @since(version = 0.2.0)
+  use tcp.{tcp-socket};
+
+  /// Create a new TCP socket.
+  ///
+  /// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
+  /// On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.
+  ///
+  /// This function does not require a network capability handle. This is considered to be safe because
+  /// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect`
+  /// is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
+  ///
+  /// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+  ///
+  /// # Typical errors
+  /// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
+  /// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+  ///
+  /// # References
+  /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+  /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
+  /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+  /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+  @since(version = 0.2.0)
+  create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
+}
+
+@since(version = 0.2.0)
+interface udp {
+  @since(version = 0.2.0)
+  use wasi:io/poll@0.2.12.{pollable};
+  @since(version = 0.2.0)
+  use network.{network, error-code, ip-socket-address, ip-address-family};
+
+  /// A received datagram.
+  @since(version = 0.2.0)
+  record incoming-datagram {
+    /// The payload.
+    ///
+    /// Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
+    data: list<u8>,
+    /// The source address.
+    ///
+    /// This field is guaranteed to match the remote address the stream was initialized with, if any.
+    ///
+    /// Equivalent to the `src_addr` out parameter of `recvfrom`.
+    remote-address: ip-socket-address,
+  }
+
+  /// A datagram to be sent out.
+  @since(version = 0.2.0)
+  record outgoing-datagram {
+    /// The payload.
+    data: list<u8>,
+    /// The destination address.
+    ///
+    /// The requirements on this field depend on how the stream was initialized:
+    /// - with a remote address: this field must be None or match the stream's remote address exactly.
+    /// - without a remote address: this field is required.
+    ///
+    /// If this value is None, the send operation is equivalent to `send` in POSIX. Otherwise it is equivalent to `sendto`.
+    remote-address: option<ip-socket-address>,
+  }
+
+  /// A UDP socket handle.
+  @since(version = 0.2.0)
+  resource udp-socket {
+    /// Bind the socket to a specific network on the provided IP address and port.
+    ///
+    /// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+    /// network interface(s) to bind to.
+    /// If the port is zero, the socket will be bound to a random free port.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
+    /// - `invalid-state`:             The socket is already bound. (EINVAL)
+    /// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+    /// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+    /// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+    /// - `not-in-progress`:           A `bind` operation is not in progress.
+    /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+    ///
+    /// # Implementors note
+    /// Unlike in POSIX, in WASI the bind operation is async. This enables
+    /// interactive WASI hosts to inject permission prompts. Runtimes that
+    /// don't want to make use of this ability can simply call the native
+    /// `bind` as part of either `start-bind` or `finish-bind`.
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+    /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+    @since(version = 0.2.0)
+    start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+    @since(version = 0.2.0)
+    finish-bind: func() -> result<_, error-code>;
+    /// Set up inbound & outbound communication channels, optionally to a specific peer.
+    ///
+    /// This function only changes the local socket configuration and does not generate any network traffic.
+    /// On success, the `remote-address` of the socket is updated. The `local-address` may be updated as well,
+    /// based on the best network path to `remote-address`.
+    ///
+    /// When a `remote-address` is provided, the returned streams are limited to communicating with that specific peer:
+    /// - `send` can only be used to send to this destination.
+    /// - `receive` will only return datagrams sent from the provided `remote-address`.
+    ///
+    /// This method may be called multiple times on the same socket to change its association, but
+    /// only the most recently returned pair of streams will be operational. Implementations may trap if
+    /// the streams returned by a previous invocation haven't been dropped yet before calling `stream` again.
+    ///
+    /// The POSIX equivalent in pseudo-code is:
+    /// ```text
+    /// if (was previously connected) {
+    /// 	connect(s, AF_UNSPEC)
+    /// }
+    /// if (remote_address is Some) {
+    /// 	connect(s, remote_address)
+    /// }
+    /// ```
+    ///
+    /// Unlike in POSIX, the socket must already be explicitly bound.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+    /// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+    /// - `invalid-argument`:          The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+    /// - `invalid-state`:             The socket is not bound.
+    /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+    /// - `remote-unreachable`:        The remote address is not reachable. (ECONNRESET, ENETRESET, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+    /// - `connection-refused`:        The connection was refused. (ECONNREFUSED)
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+    /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+    /// - <https://man.freebsd.org/cgi/man.cgi?connect>
+    @since(version = 0.2.0)
+    %stream: func(remote-address: option<ip-socket-address>) -> result<tuple<incoming-datagram-stream, outgoing-datagram-stream>, error-code>;
+    /// Get the current bound address.
+    ///
+    /// POSIX mentions:
+    /// > If the socket has not been bound to a local name, the value
+    /// > stored in the object pointed to by `address` is unspecified.
+    ///
+    /// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
+    ///
+    /// # Typical errors
+    /// - `invalid-state`: The socket is not bound to any local address.
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+    /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+    /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+    @since(version = 0.2.0)
+    local-address: func() -> result<ip-socket-address, error-code>;
+    /// Get the address the socket is currently streaming to.
+    ///
+    /// # Typical errors
+    /// - `invalid-state`: The socket is not streaming to a specific remote address. (ENOTCONN)
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+    /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+    @since(version = 0.2.0)
+    remote-address: func() -> result<ip-socket-address, error-code>;
+    /// Whether this is a IPv4 or IPv6 socket.
+    ///
+    /// Equivalent to the SO_DOMAIN socket option.
+    @since(version = 0.2.0)
+    address-family: func() -> ip-address-family;
+    /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
+    ///
+    /// If the provided value is 0, an `invalid-argument` error is returned.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
+    @since(version = 0.2.0)
+    unicast-hop-limit: func() -> result<u8, error-code>;
+    @since(version = 0.2.0)
+    set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
+    /// The kernel buffer space reserved for sends/receives on this socket.
+    ///
+    /// If the provided value is 0, an `invalid-argument` error is returned.
+    /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    /// I.e. after setting a value, reading the same setting back may return a different value.
+    ///
+    /// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:     (set) The provided value was 0.
+    @since(version = 0.2.0)
+    receive-buffer-size: func() -> result<u64, error-code>;
+    @since(version = 0.2.0)
+    set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+    @since(version = 0.2.0)
+    send-buffer-size: func() -> result<u64, error-code>;
+    @since(version = 0.2.0)
+    set-send-buffer-size: func(value: u64) -> result<_, error-code>;
+    /// Create a `pollable` which will resolve once the socket is ready for I/O.
+    ///
+    /// Note: this function is here for WASI 0.2 only.
+    /// It's planned to be removed when `future` is natively supported in Preview3.
+    @since(version = 0.2.0)
+    subscribe: func() -> pollable;
+  }
+
+  @since(version = 0.2.0)
+  resource incoming-datagram-stream {
+    /// Receive messages on the socket.
+    ///
+    /// This function attempts to receive up to `max-results` datagrams on the socket without blocking.
+    /// The returned list may contain fewer elements than requested, but never more.
+    ///
+    /// This function returns successfully with an empty list when either:
+    /// - `max-results` is 0, or:
+    /// - `max-results` is greater than 0, but no results are immediately available.
+    /// This function never returns `error(would-block)`.
+    ///
+    /// # Typical errors
+    /// - `remote-unreachable`: The remote address is not reachable. (ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+    /// - `connection-refused`: The connection was refused. (ECONNREFUSED)
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html>
+    /// - <https://man7.org/linux/man-pages/man2/recv.2.html>
+    /// - <https://man7.org/linux/man-pages/man2/recvmmsg.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
+    /// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
+    @since(version = 0.2.0)
+    receive: func(max-results: u64) -> result<list<incoming-datagram>, error-code>;
+    /// Create a `pollable` which will resolve once the stream is ready to receive again.
+    ///
+    /// Note: this function is here for WASI 0.2 only.
+    /// It's planned to be removed when `future` is natively supported in Preview3.
+    @since(version = 0.2.0)
+    subscribe: func() -> pollable;
+  }
+
+  @since(version = 0.2.0)
+  resource outgoing-datagram-stream {
+    /// Check readiness for sending. This function never blocks.
+    ///
+    /// Returns the number of datagrams permitted for the next call to `send`,
+    /// or an error. Calling `send` with more datagrams than this function has
+    /// permitted will trap.
+    ///
+    /// When this function returns ok(0), the `subscribe` pollable will
+    /// become ready when this function will report at least ok(1), or an
+    /// error.
+    ///
+    /// Never returns `would-block`.
+    check-send: func() -> result<u64, error-code>;
+    /// Send messages on the socket.
+    ///
+    /// This function attempts to send all provided `datagrams` on the socket without blocking and
+    /// returns how many messages were actually sent (or queued for sending). This function never
+    /// returns `error(would-block)`. If none of the datagrams were able to be sent, `ok(0)` is returned.
+    ///
+    /// This function semantically behaves the same as iterating the `datagrams` list and sequentially
+    /// sending each individual datagram until either the end of the list has been reached or the first error occurred.
+    /// If at least one datagram has been sent successfully, this function never returns an error.
+    ///
+    /// If the input list is empty, the function returns `ok(0)`.
+    ///
+    /// Each call to `send` must be permitted by a preceding `check-send`. Implementations must trap if
+    /// either `check-send` was not called or `datagrams` contains more items than `check-send` permitted.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:        The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+    /// - `invalid-argument`:        The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+    /// - `invalid-argument`:        The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+    /// - `invalid-argument`:        The socket is in "connected" mode and `remote-address` is `some` value that does not match the address passed to `stream`. (EISCONN)
+    /// - `invalid-argument`:        The socket is not "connected" and no value for `remote-address` was provided. (EDESTADDRREQ)
+    /// - `remote-unreachable`:      The remote address is not reachable. (ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+    /// - `connection-refused`:      The connection was refused. (ECONNREFUSED)
+    /// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html>
+    /// - <https://man7.org/linux/man-pages/man2/send.2.html>
+    /// - <https://man7.org/linux/man-pages/man2/sendmmsg.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
+    @since(version = 0.2.0)
+    send: func(datagrams: list<outgoing-datagram>) -> result<u64, error-code>;
+    /// Create a `pollable` which will resolve once the stream is ready to send again.
+    ///
+    /// Note: this function is here for WASI 0.2 only.
+    /// It's planned to be removed when `future` is natively supported in Preview3.
+    @since(version = 0.2.0)
+    subscribe: func() -> pollable;
+  }
+}
+
+@since(version = 0.2.0)
+interface udp-create-socket {
+  @since(version = 0.2.0)
+  use network.{network, error-code, ip-address-family};
+  @since(version = 0.2.0)
+  use udp.{udp-socket};
+
+  /// Create a new UDP socket.
+  ///
+  /// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)` in POSIX.
+  /// On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.
+  ///
+  /// This function does not require a network capability handle. This is considered to be safe because
+  /// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind` is called,
+  /// the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
+  ///
+  /// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+  ///
+  /// # Typical errors
+  /// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
+  /// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+  ///
+  /// # References:
+  /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+  /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
+  /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+  /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+  @since(version = 0.2.0)
+  create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>;
+}
+
+@since(version = 0.2.0)
+world imports {
+  @since(version = 0.2.0)
+  import wasi:io/error@0.2.12;
+  @since(version = 0.2.0)
+  import network;
+  @since(version = 0.2.0)
+  import instance-network;
+  @since(version = 0.2.0)
+  import wasi:io/poll@0.2.12;
+  @since(version = 0.2.0)
+  import udp;
+  @since(version = 0.2.0)
+  import udp-create-socket;
+  @since(version = 0.2.0)
+  import wasi:io/streams@0.2.12;
+  @since(version = 0.2.0)
+  import wasi:clocks/monotonic-clock@0.2.12;
+  @since(version = 0.2.0)
+  import tcp;
+  @since(version = 0.2.0)
+  import tcp-create-socket;
+  @since(version = 0.2.0)
+  import ip-name-lookup;
+}

--- a/internal/component/instance/wasi.go
+++ b/internal/component/instance/wasi.go
@@ -734,9 +734,13 @@ func WithWASI(cfg WASIConfig) []Option {
 // wasiBytesFromList converts a lifted list<u8> (see abi.Value's doc: list<T>
 // -> []abi.Value, u8 -> uint32) into a []byte.
 func wasiBytesFromList(v abi.Value) ([]byte, error) {
+	if b, ok := v.([]byte); ok {
+		// The compact list<u8> shape (see wasiListFromBytes).
+		return b, nil
+	}
 	list, ok := v.([]abi.Value)
 	if !ok {
-		return nil, fmt.Errorf("expected list<u8> ([]abi.Value), got %T", v)
+		return nil, fmt.Errorf("expected list<u8> ([]abi.Value or []byte), got %T", v)
 	}
 	buf := make([]byte, len(list))
 	for i, b := range list {

--- a/internal/component/instance/wasi_conformance_test.go
+++ b/internal/component/instance/wasi_conformance_test.go
@@ -1,0 +1,192 @@
+package instance
+
+import (
+	"embed"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/samyfodil/wazy/internal/component/wit"
+)
+
+// This file checks wazy's WASI host imports against the REFERENCE WASI 0.2
+// interface definitions (testdata/wasi-wit, copied verbatim from the wasip2
+// crate's vendored WebAssembly/WASI sources) rather than against wazy's own
+// beliefs about them.
+//
+// # Why this exists
+//
+// Everything else that could have caught interface drift does not. The
+// wasi-testsuite job in CI targets wasi_snapshot_preview1, not the component
+// world. The 35 differential fixtures in conformance_test.go only cover what
+// their guests happen to call, and a guest cannot call a func no host
+// implements -- so a method wazy never registered is invisible to them by
+// construction. The wast suites cover Canonical ABI *value* lifting, not WASI
+// interfaces. So the whole wasi:* surface had no check tying it to the spec,
+// which is how `[method]incoming-response.headers` stayed unimplemented and
+// how a misspelled registration would sit silently behind the graph engine's
+// trap-stub fallback, indistinguishable from "not implemented yet".
+//
+// # What it can and cannot catch
+//
+// It catches names: a registered func that does not exist in the reference
+// (a typo, a renamed method, an interface that moved), and it reports the
+// converse -- reference funcs wazy does not implement -- as an explicit,
+// reviewable inventory rather than a silence.
+//
+// It does NOT catch semantics. That types.wit requires `fields.entries` to
+// return names "in the original casing and in the order in which they will
+// be serialized" is prose no signature check can enforce; that one was found
+// by reading the reference and is pinned by a behavioral test instead. A
+// green run here means the surface lines up, not that each func is right.
+
+//go:embed testdata/wasi-wit/*.wit
+var wasiWITFS embed.FS
+
+// witFuncNames parses one reference .wit file and returns, per interface, the
+// set of canonical func names a component would import from it -- the same
+// spelling withImportCustom registers ("[method]fields.get",
+// "[constructor]fields", "[static]fields.from-list", or a bare "get-stdin").
+func witFuncNames(t *testing.T, file string) map[string]map[string]bool {
+	t.Helper()
+	src, err := wasiWITFS.ReadFile(path.Join("testdata/wasi-wit", file))
+	if err != nil {
+		t.Fatalf("reading %s: %v", file, err)
+	}
+	pkg, err := wit.Parse(file, string(src))
+	if err != nil {
+		t.Fatalf("parsing %s: %v", file, err)
+	}
+
+	out := map[string]map[string]bool{}
+	for _, item := range pkg.Items {
+		iface, ok := item.(*wit.Interface)
+		if !ok || iface.Name == "" {
+			continue
+		}
+		names := map[string]bool{}
+		for _, ii := range iface.Items {
+			switch v := ii.(type) {
+			case *wit.InterfaceFunc:
+				names[v.Name] = true
+			case *wit.TypeDef:
+				res, isResource := v.Type.(*wit.Resource)
+				if !isResource {
+					continue
+				}
+				for _, m := range res.Methods {
+					switch {
+					case m.IsConstructor:
+						names["[constructor]"+v.Name] = true
+					case m.IsStatic:
+						names["[static]"+v.Name+"."+m.Name] = true
+					default:
+						names["[method]"+v.Name+"."+m.Name] = true
+					}
+				}
+			}
+		}
+		// Key by the package-qualified interface name, minus the version --
+		// exactly what mkImportKey reduces a registration to.
+		out[strings.Split(pkg.Name, "@")[0]+"/"+iface.Name] = names
+	}
+	return out
+}
+
+// referenceWASI parses every vendored reference file into one
+// iface -> funcs index.
+func referenceWASI(t *testing.T) map[string]map[string]bool {
+	t.Helper()
+	entries, err := wasiWITFS.ReadDir("testdata/wasi-wit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	all := map[string]map[string]bool{}
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".wit") {
+			continue
+		}
+		for iface, funcs := range witFuncNames(t, e.Name()) {
+			all[iface] = funcs
+		}
+	}
+	if len(all) == 0 {
+		t.Fatal("no interfaces parsed from the reference WIT; the embed or the parser is broken")
+	}
+	return all
+}
+
+// registeredWASI returns every wasi:* host import wazy registers, keyed the
+// same way, with every optional surface switched on so nothing is missed.
+func registeredWASI(t *testing.T) map[string]map[string]bool {
+	t.Helper()
+	c := newConfig(WithWASI(WASIConfig{
+		AllowTCP: true, AllowUDP: true, EnableHTTP: true,
+	}))
+	out := map[string]map[string]bool{}
+	for key := range c.imports {
+		if !strings.HasPrefix(key.iface, "wasi:") {
+			continue
+		}
+		if out[key.iface] == nil {
+			out[key.iface] = map[string]bool{}
+		}
+		out[key.iface][key.name] = true
+	}
+	return out
+}
+
+// TestWASIConformance_RegisteredFuncsExistInReference is the assertion: every
+// name wazy registers must be a real func in the reference WIT. A failure
+// here means a guest's import silently resolves to a trap stub (wazy
+// registered a name nothing declares), or an interface has moved.
+func TestWASIConformance_RegisteredFuncsExistInReference(t *testing.T) {
+	ref := referenceWASI(t)
+	got := registeredWASI(t)
+
+	for iface, funcs := range got {
+		refFuncs, ok := ref[iface]
+		if !ok {
+			t.Errorf("wazy registers imports for %q, which does not exist in the reference WIT", iface)
+			continue
+		}
+		for name := range funcs {
+			if !refFuncs[name] {
+				t.Errorf("wazy registers %q %q, which the reference WIT does not declare", iface, name)
+			}
+		}
+	}
+}
+
+// TestWASIConformance_UnimplementedInventory reports what the reference
+// declares and wazy does not. It does not fail: an unimplemented func is a
+// deliberate, documented state (see wasi.go's package doc on the trap-stub
+// fallback). The point is that the list is visible and reviewable in CI
+// output, so a gap is a decision someone made rather than something nobody
+// noticed -- and so closing one shows up as a diff here.
+func TestWASIConformance_UnimplementedInventory(t *testing.T) {
+	ref := referenceWASI(t)
+	got := registeredWASI(t)
+
+	var lines []string
+	for iface, refFuncs := range ref {
+		impl := got[iface]
+		if impl == nil {
+			continue // an interface wazy implements none of; not this test's subject
+		}
+		var missing []string
+		for name := range refFuncs {
+			if !impl[name] {
+				missing = append(missing, name)
+			}
+		}
+		if len(missing) > 0 {
+			sort.Strings(missing)
+			lines = append(lines, fmt.Sprintf("%s: %s", iface, strings.Join(missing, ", ")))
+		}
+	}
+	sort.Strings(lines)
+	t.Logf("reference funcs not implemented, in interfaces wazy partially implements:\n%s", strings.Join(lines, "\n"))
+}

--- a/internal/component/instance/wasi_fs.go
+++ b/internal/component/instance/wasi_fs.go
@@ -945,12 +945,13 @@ func wasiJoinFSPath(dir, rel string) (joined string, ok bool) {
 // wasiListFromBytes converts buf into the list<u8> shape abi.Value expects
 // (see abi.Value's doc: list<T> -> []abi.Value, u8 -> uint32) -- the
 // lowering counterpart to wasi.go's wasiBytesFromList.
-func wasiListFromBytes(buf []byte) []abi.Value {
-	out := make([]abi.Value, len(buf))
-	for i, b := range buf {
-		out[i] = uint32(b)
-	}
-	return out
+func wasiListFromBytes(buf []byte) abi.Value {
+	// abi lowers a []byte directly for a list<u8> (one copy, see
+	// byteListValue in the abi package) instead of the general
+	// one-interface-per-element shape, which for a byte list costs a machine
+	// word per byte. That matters here: a single input-stream.read may carry
+	// up to wasiMaxStreamRead bytes.
+	return buf
 }
 
 // wasiFilesystemOptions returns the Options implementing

--- a/internal/component/instance/wasi_http.go
+++ b/internal/component/instance/wasi_http.go
@@ -484,6 +484,15 @@ func (h *wasiHTTP) fieldsGet(_ context.Context, args []abi.Value) ([]abi.Value, 
 // appeared three times yields three entries rather than one joined value.
 // Collapsing them is the caller's decision (and loses information -- Set-Cookie
 // must never be joined), so this does not make it here.
+//
+// ponytail: cost is linear in the TOTAL header bytes, with a ~16x memory
+// amplification, because abi.Value renders list<u8> as []abi.Value (one
+// interface word per byte -- see abi.Value's doc, and bytesToU8List, which
+// fields.get has always paid the same way). Measured: 8 headers x 32B is
+// ~10us/5KB, while a pathological 40 x 4096B is ~4.5ms/2.6MB. Real responses
+// sit at the low end (servers cap total headers around 8-16KB), so this is
+// left alone; a cheaper list<u8> would be an abi.Value-wide representation
+// change, not a fix here.
 func (h *wasiHTTP) fieldsEntries(_ context.Context, args []abi.Value) ([]abi.Value, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("[method]fields.entries: expected 1 arg (self), got %d", len(args))
@@ -569,11 +578,18 @@ func (h *wasiHTTP) fieldsSet(_ context.Context, args []abi.Value) ([]abi.Value, 
 	return []abi.Value{abi.ResultValue{IsErr: false, Payload: nil}}, nil
 }
 
+// dropName removes every entry whose name matches, compared case-
+// INSENSITIVELY: types.wit specifies that "field names should always be
+// treated as case insensitive by the `fields` resource for the purposes of
+// equality checking", so a set of "Content-Type" must replace an existing
+// "content-type" rather than leave a duplicate behind. fieldsGet already
+// compares this way.
 func (f *httpFields) dropName(name string) {
+	lname := strings.ToLower(name)
 	names := f.names[:0]
 	values := f.values[:0]
 	for i, n := range f.names {
-		if n == name {
+		if strings.ToLower(n) == lname {
 			continue
 		}
 		names = append(names, n)
@@ -1591,9 +1607,23 @@ func (h *wasiHTTP) outgoingHandlerHandle(ctx context.Context, args []abi.Value) 
 			// types.wit makes an incoming message's fields read-only (see
 			// incomingResponseHeaders).
 			respHeaders := &httpFields{immutable: true}
-			for name, vs := range hresp.Header {
-				for _, v := range vs {
-					respHeaders.names = append(respHeaders.names, strings.ToLower(name))
+			// types.wit requires entries "in the original casing and in the
+			// order in which they will be serialized for transport", so the
+			// name is stored as net/http gives it (canonical MIME casing --
+			// Go has already discarded the origin server's exact bytes, and
+			// its canonical form is far closer to the original than a forced
+			// lower-casing) and the names are sorted, because ranging a
+			// map would hand the guest a DIFFERENT order on every call.
+			// Values keep their relative order within a name, which is the
+			// part that actually carries meaning (Set-Cookie).
+			names := make([]string, 0, len(hresp.Header))
+			for name := range hresp.Header {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			for _, name := range names {
+				for _, v := range hresp.Header[name] {
+					respHeaders.names = append(respHeaders.names, name)
 					respHeaders.values = append(respHeaders.values, []byte(v))
 				}
 			}

--- a/internal/component/instance/wasi_http.go
+++ b/internal/component/instance/wasi_http.go
@@ -518,13 +518,11 @@ func (h *wasiHTTP) fieldsEntries(_ context.Context, args []abi.Value) ([]abi.Val
 	return []abi.Value{out}, nil
 }
 
-// bytesToU8List renders b as a lowered list<u8> (each byte a uint32 element).
-func bytesToU8List(b []byte) []abi.Value {
-	out := make([]abi.Value, len(b))
-	for i, x := range b {
-		out[i] = uint32(x)
-	}
-	return out
+// bytesToU8List renders b as a lowered list<u8>. The abi package lowers a
+// raw []byte for list<u8> with a single copy (byteListValue), so the bytes
+// are handed over as-is rather than boxed one interface per byte.
+func bytesToU8List(b []byte) abi.Value {
+	return b
 }
 
 func (h *wasiHTTP) fieldsConstructor(_ context.Context, args []abi.Value) ([]abi.Value, error) {

--- a/internal/component/instance/wasi_http.go
+++ b/internal/component/instance/wasi_http.go
@@ -100,6 +100,13 @@ type httpIncomingRequest struct {
 type httpFields struct {
 	names  []string
 	values [][]byte
+
+	// immutable marks a fields the guest may read but not modify. types.wit
+	// specifies the headers/trailers reachable from an *incoming* message
+	// this way ("a child of the incoming-response ... immutable"), and gives
+	// header-error a dedicated `immutable` case to report an attempted
+	// write. A fields the guest constructed itself is always mutable.
+	immutable bool
 }
 
 // httpOutgoingResponse is the host state behind an outgoing-response resource.
@@ -471,6 +478,37 @@ func (h *wasiHTTP) fieldsGet(_ context.Context, args []abi.Value) ([]abi.Value, 
 	return []abi.Value{out}, nil
 }
 
+// fieldsEntries implements [method]fields.entries -> list<tuple<field-key,
+// field-value>>. Every stored (name, value) pair is one entry, duplicates
+// included: types.wit's `entries` reports the wire shape, so a header that
+// appeared three times yields three entries rather than one joined value.
+// Collapsing them is the caller's decision (and loses information -- Set-Cookie
+// must never be joined), so this does not make it here.
+func (h *wasiHTTP) fieldsEntries(_ context.Context, args []abi.Value) ([]abi.Value, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("[method]fields.entries: expected 1 arg (self), got %d", len(args))
+	}
+	rep, ok := args[0].(uint32)
+	if !ok {
+		return nil, fmt.Errorf("[method]fields.entries: self: expected uint32 rep, got %T", args[0])
+	}
+	h.mu.Lock()
+	f, ok := h.fields[rep]
+	var out []abi.Value
+	if ok {
+		out = make([]abi.Value, 0, len(f.names))
+		for i, n := range f.names {
+			// tuple<field-key, field-value> -> a 2-element []abi.Value.
+			out = append(out, []abi.Value{n, bytesToU8List(f.values[i])})
+		}
+	}
+	h.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("[method]fields.entries: rep %d does not name a live fields", rep)
+	}
+	return []abi.Value{out}, nil
+}
+
 // bytesToU8List renders b as a lowered list<u8> (each byte a uint32 element).
 func bytesToU8List(b []byte) []abi.Value {
 	out := make([]abi.Value, len(b))
@@ -508,7 +546,8 @@ func (h *wasiHTTP) fieldsSet(_ context.Context, args []abi.Value) ([]abi.Value, 
 	}
 	h.mu.Lock()
 	f, ok := h.fields[rep]
-	if ok {
+	immutable := ok && f.immutable
+	if ok && !immutable {
 		// set replaces every existing value for name, then appends the new ones.
 		f.dropName(name)
 		for _, v := range values {
@@ -519,6 +558,12 @@ func (h *wasiHTTP) fieldsSet(_ context.Context, args []abi.Value) ([]abi.Value, 
 	h.mu.Unlock()
 	if !ok {
 		return nil, fmt.Errorf("[method]fields.set: rep %d does not name a live fields", rep)
+	}
+	if immutable {
+		// header-error::immutable -- a fields borrowed from an incoming
+		// message is read-only, and types.wit asks for this exact case
+		// rather than a silent no-op or a trap.
+		return []abi.Value{abi.ResultValue{IsErr: true, Payload: abi.VariantValue{Disc: httpHeaderErrorImmutable}}}, nil
 	}
 	// result<_, header-error>: Ok.
 	return []abi.Value{abi.ResultValue{IsErr: false, Payload: nil}}, nil
@@ -771,6 +816,9 @@ func httpMethodType(tbl *typeTable) binary.TypeRef {
 	cases = append(cases, binary.VariantCase{Name: "other", Type: &strRef})
 	return tbl.add(binary.VariantDesc{Cases: cases})
 }
+
+// header-error variant case indices, in types.wit declaration order.
+const httpHeaderErrorImmutable uint32 = 2
 
 // httpHeaderErrorType interns the `header-error` variant into tbl.
 func httpHeaderErrorType(tbl *typeTable) binary.TypeRef {
@@ -1039,6 +1087,7 @@ func wasiHTTPOptions(h *wasiHTTP) []Option {
 	pathFD, pathR := httpPathWithQuerySig()
 	fieldsCtorFD, fieldsCtorR := httpFieldsConstructorSig()
 	fieldsSetFD, fieldsSetR := httpFieldsSetSig()
+	fieldsEntriesFD, fieldsEntriesR := httpFieldsEntriesSig()
 	respCtorFD, respCtorR := httpOutgoingResponseConstructorSig()
 	statusFD, statusR := httpSetStatusCodeSig()
 	bodyFD, bodyR := httpOutgoingResponseBodySig()
@@ -1075,6 +1124,7 @@ func wasiHTTPOptions(h *wasiHTTP) []Option {
 		withImportCustom(wasiIfaceHTTPTypes, "[constructor]fields", h.fieldsConstructor, fieldsCtorFD, fieldsCtorR),
 		withImportCustom(wasiIfaceHTTPTypes, "[method]fields.get", h.fieldsGet, fieldsGetFD, fieldsGetR),
 		withImportCustom(wasiIfaceHTTPTypes, "[method]fields.set", h.fieldsSet, fieldsSetFD, fieldsSetR),
+		withImportCustom(wasiIfaceHTTPTypes, "[method]fields.entries", h.fieldsEntries, fieldsEntriesFD, fieldsEntriesR),
 		withImportCustom(wasiIfaceHTTPTypes, "[constructor]outgoing-response", h.outgoingResponseConstructor, respCtorFD, respCtorR),
 		withImportCustom(wasiIfaceHTTPTypes, "[method]outgoing-response.set-status-code", h.outgoingResponseSetStatusCode, statusFD, statusR),
 		withImportCustom(wasiIfaceHTTPTypes, "[method]outgoing-response.body", h.outgoingResponseBody, bodyFD, bodyR),
@@ -1537,7 +1587,10 @@ func (h *wasiHTTP) outgoingHandlerHandle(ctx context.Context, args []abi.Value) 
 		} else {
 			bodyBytes, _ := io.ReadAll(hresp.Body)
 			_ = hresp.Body.Close()
-			respHeaders := &httpFields{}
+			// immutable: these are the headers that actually arrived, and
+			// types.wit makes an incoming message's fields read-only (see
+			// incomingResponseHeaders).
+			respHeaders := &httpFields{immutable: true}
 			for name, vs := range hresp.Header {
 				for _, v := range vs {
 					respHeaders.names = append(respHeaders.names, strings.ToLower(name))
@@ -1628,6 +1681,41 @@ func (h *wasiHTTP) incomingResponseStatus(_ context.Context, args []abi.Value) (
 		return nil, fmt.Errorf("[method]incoming-response.status: rep %d does not name a live incoming-response", rep)
 	}
 	return []abi.Value{uint32(r.status)}, nil
+}
+
+// incomingResponseHeaders implements [method]incoming-response.headers ->
+// own<fields>. The returned fields is the response's OWN headers object, not a
+// copy: types.wit calls it "a child of the incoming-response", so a guest
+// reading it must see what actually arrived on the wire. It is marked
+// immutable at construction (see newInResponseRep's caller), so a guest that
+// tries to write through it gets header-error::immutable rather than silently
+// mutating a received message.
+//
+// The child-must-be-dropped-before-the-parent rule types.wit states is not
+// enforced: a guest that leaks the handle merely holds a rep whose parent is
+// gone, which costs nothing here and traps loudly on use.
+func (h *wasiHTTP) incomingResponseHeaders(_ context.Context, args []abi.Value) ([]abi.Value, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("[method]incoming-response.headers: expected 1 arg (self), got %d", len(args))
+	}
+	rep, ok := args[0].(uint32)
+	if !ok {
+		return nil, fmt.Errorf("[method]incoming-response.headers: self: expected uint32 rep, got %T", args[0])
+	}
+	h.mu.Lock()
+	r, ok := h.inResponses[rep]
+	h.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("[method]incoming-response.headers: rep %d does not name a live incoming-response", rep)
+	}
+	fields := r.headers
+	if fields == nil {
+		// A response synthesized without headers still owes the guest a
+		// readable (empty) fields rather than a trap.
+		fields = &httpFields{immutable: true}
+	}
+	// Top-level own<fields> result: allocHandleResult wraps this bare rep.
+	return []abi.Value{h.newFieldsRep(fields)}, nil
 }
 
 func (h *wasiHTTP) incomingResponseConsume(_ context.Context, args []abi.Value) ([]abi.Value, error) {
@@ -1931,6 +2019,35 @@ func httpIncomingResponseStatusSig() (binary.FuncDesc, abi.Resolver) {
 	}, tbl.resolver()
 }
 
+// httpFieldsEntriesSig builds [method]fields.entries(self: borrow<fields>) ->
+// list<tuple<field-key, field-value>>, i.e. list<tuple<string, list<u8>>> --
+// the first list<tuple<...>> result in this file. TupleDesc needs its own
+// interned TypeRef (its element types cannot be expressed inline), which is
+// exactly what typeTable is for.
+func httpFieldsEntriesSig() (binary.FuncDesc, abi.Resolver) {
+	tbl := &typeTable{}
+	selfRef := tbl.add(binary.BorrowDesc{ResourceType: wasiHTTPFieldsResType})
+	valueRef := tbl.add(binary.ListDesc{Element: binary.TypeRef{Primitive: "u8"}})
+	pairRef := tbl.add(binary.TupleDesc{Elements: []binary.TypeRef{{Primitive: "string"}, valueRef}})
+	listRef := tbl.add(binary.ListDesc{Element: pairRef})
+	return binary.FuncDesc{
+		Params:  []binary.FuncParam{{Name: "self", Type: selfRef}},
+		Results: binary.FuncResults{Unnamed: &listRef},
+	}, tbl.resolver()
+}
+
+// httpIncomingResponseHeadersSig builds [method]incoming-response.headers(
+// self: borrow<incoming-response>) -> own<fields>.
+func httpIncomingResponseHeadersSig() (binary.FuncDesc, abi.Resolver) {
+	tbl := &typeTable{}
+	selfRef := tbl.add(binary.BorrowDesc{ResourceType: wasiHTTPIncomingResponseResType})
+	headersRef := tbl.add(binary.OwnDesc{ResourceType: wasiHTTPFieldsResType})
+	return binary.FuncDesc{
+		Params:  []binary.FuncParam{{Name: "self", Type: selfRef}},
+		Results: binary.FuncResults{Unnamed: &headersRef},
+	}, tbl.resolver()
+}
+
 func httpIncomingResponseConsumeSig() (binary.FuncDesc, abi.Resolver) {
 	tbl := &typeTable{}
 	selfRef := tbl.add(binary.BorrowDesc{ResourceType: wasiHTTPIncomingResponseResType})
@@ -1968,6 +2085,7 @@ func wasiHTTPOutgoingOptions(h *wasiHTTP) []Option {
 	subFD, subR := wasiSubscribeSig(wasiHTTPFutureResType)
 	getFD, getR := httpFutureGetSig()
 	statusFD, statusR := httpIncomingResponseStatusSig()
+	respHeadersFD, respHeadersR := httpIncomingResponseHeadersSig()
 	consumeFD, consumeR := httpIncomingResponseConsumeSig()
 	streamFD, streamR := httpIncomingBodyStreamSig()
 	reqBodyFD, reqBodyR := httpOutgoingRequestBodySig()
@@ -1995,6 +2113,7 @@ func wasiHTTPOutgoingOptions(h *wasiHTTP) []Option {
 		withImportCustom(wasiIfaceHTTPTypes, "[method]future-incoming-response.subscribe", h.futureSubscribe, subFD, subR),
 		withImportCustom(wasiIfaceHTTPTypes, "[method]future-incoming-response.get", h.futureGet, getFD, getR),
 		withImportCustom(wasiIfaceHTTPTypes, "[method]incoming-response.status", h.incomingResponseStatus, statusFD, statusR),
+		withImportCustom(wasiIfaceHTTPTypes, "[method]incoming-response.headers", h.incomingResponseHeaders, respHeadersFD, respHeadersR),
 		withImportCustom(wasiIfaceHTTPTypes, "[method]incoming-response.consume", h.incomingResponseConsume, consumeFD, consumeR),
 		withImportCustom(wasiIfaceHTTPTypes, "[method]incoming-body.stream", h.incomingBodyStream, streamFD, streamR),
 	}

--- a/internal/component/instance/wasi_http_bench_test.go
+++ b/internal/component/instance/wasi_http_bench_test.go
@@ -1,0 +1,61 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/samyfodil/wazy/internal/component/abi"
+)
+
+// Benchmarks for the response-header read path. fields.entries is the one
+// call whose cost scales with the whole header block (see its doc), so its
+// number is worth being able to reproduce.
+func benchFields(n, valueLen int) *httpFields {
+	f := &httpFields{}
+	for i := 0; i < n; i++ {
+		v := make([]byte, valueLen)
+		for j := range v {
+			v[j] = 'a'
+		}
+		f.names = append(f.names, fmt.Sprintf("X-Header-%d", i))
+		f.values = append(f.values, v)
+	}
+	return f
+}
+
+func BenchmarkFieldsEntries(b *testing.B) {
+	for _, tc := range []struct{ n, vlen int }{
+		{8, 32},    // a typical response
+		{20, 64},   // a chatty one
+		{40, 4096}, // pathological: big values (cookies, CSP)
+	} {
+		b.Run(fmt.Sprintf("n%d_len%d", tc.n, tc.vlen), func(b *testing.B) {
+			h := newTestHTTP()
+			rep := h.newFieldsRep(benchFields(tc.n, tc.vlen))
+			args := []abi.Value{rep}
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := h.fieldsEntries(ctx, args); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkIncomingResponseHeaders(b *testing.B) {
+	h := newTestHTTP()
+	rep := h.newInResponseRep(&httpIncomingResponse{status: 200, headers: benchFields(8, 32)})
+	args := []abi.Value{rep}
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := h.incomingResponseHeaders(ctx, args); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/component/instance/wasi_http_bench_test.go
+++ b/internal/component/instance/wasi_http_bench_test.go
@@ -59,3 +59,31 @@ func BenchmarkIncomingResponseHeaders(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkInputStreamRead measures the biggest consumer of the list<u8>
+// lowering: a file/body read, which may carry up to wasiMaxStreamRead bytes
+// in a single call.
+func BenchmarkInputStreamRead(b *testing.B) {
+	for _, size := range []int{4096, 65536, 1 << 20} {
+		b.Run(fmt.Sprintf("%dB", size), func(b *testing.B) {
+			payload := make([]byte, size)
+			t := &testing.T{}
+			c, resources, _ := wasiFSConfigDir(t, map[string][]byte{"/f": payload})
+			rootRep := rootHandleRep(t, resources, rootDescriptorHandle(t, c))
+			fileRep := openRep(t, c, resources, rootRep, "f", 0, 0)
+			read := wasiFSFn(t, c, wasiIfaceStreams, "[method]input-stream.read")
+			ctx := context.Background()
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				rv := callFS(t, c, "[method]descriptor.read-via-stream", fileRep, uint64(0))
+				sh := rv.Payload.(uint32)
+				sRep, _ := resources.Rep(wasiInputStreamResType, sh)
+				if _, err := read(ctx, []abi.Value{sRep, uint64(size)}); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/component/instance/wasi_http_errbranch_test.go
+++ b/internal/component/instance/wasi_http_errbranch_test.go
@@ -779,3 +779,287 @@ func TestHTTP_RequestOptions(t *testing.T) {
 	_, err = setConn(context.Background(), []abi.Value{uint32(999), uint64(1)})
 	reqErr(t, err, "does not name a live request-options")
 }
+
+// TestHTTP_FieldsEntries covers [method]fields.entries: the wire shape it
+// reports, the duplicate-preserving behavior types.wit specifies, and its
+// fail-loud branches.
+func TestHTTP_FieldsEntries(t *testing.T) {
+	h := newTestHTTP()
+
+	t.Run("reports every pair, duplicates included", func(t *testing.T) {
+		rep := h.newFieldsRep(&httpFields{
+			names:  []string{"Content-Type", "Set-Cookie", "Set-Cookie"},
+			values: [][]byte{[]byte("text/html"), []byte("a=1"), []byte("b=2")},
+		})
+		res, err := h.fieldsEntries(context.Background(), []abi.Value{rep})
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries := res[0].([]abi.Value)
+		if len(entries) != 3 {
+			t.Fatalf("got %d entries, want 3 (duplicates must not be joined)", len(entries))
+		}
+		want := []struct{ name, value string }{
+			{"Content-Type", "text/html"},
+			{"Set-Cookie", "a=1"},
+			{"Set-Cookie", "b=2"},
+		}
+		for i, w := range want {
+			pair := entries[i].([]abi.Value)
+			if len(pair) != 2 {
+				t.Fatalf("entry %d: got %d tuple fields, want 2", i, len(pair))
+			}
+			if got := pair[0].(string); got != w.name {
+				t.Errorf("entry %d name = %q, want %q", i, got, w.name)
+			}
+			if got := u8ListToString(t, pair[1]); got != w.value {
+				t.Errorf("entry %d value = %q, want %q", i, got, w.value)
+			}
+		}
+	})
+
+	t.Run("empty fields", func(t *testing.T) {
+		rep := h.newFieldsRep(&httpFields{})
+		res, err := h.fieldsEntries(context.Background(), []abi.Value{rep})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if entries := res[0].([]abi.Value); len(entries) != 0 {
+			t.Fatalf("got %v, want no entries", entries)
+		}
+	})
+
+	t.Run("arg validation", func(t *testing.T) {
+		_, err := h.fieldsEntries(context.Background(), nil)
+		reqErr(t, err, "expected 1 arg")
+		_, err = h.fieldsEntries(context.Background(), []abi.Value{"bad"})
+		reqErr(t, err, "self: expected uint32")
+		_, err = h.fieldsEntries(context.Background(), []abi.Value{uint32(9999)})
+		reqErr(t, err, "does not name a live fields")
+	})
+}
+
+// u8ListToString reverses bytesToU8List for assertions.
+func u8ListToString(t *testing.T, v abi.Value) string {
+	t.Helper()
+	list, ok := v.([]abi.Value)
+	if !ok {
+		t.Fatalf("field-value: expected a list, got %T", v)
+	}
+	b := make([]byte, len(list))
+	for i, x := range list {
+		b[i] = byte(x.(uint32))
+	}
+	return string(b)
+}
+
+// TestHTTP_IncomingResponseHeaders covers [method]incoming-response.headers:
+// that it hands back the response's real headers (not a copy), that they are
+// immutable per types.wit, and its fail-loud branches.
+func TestHTTP_IncomingResponseHeaders(t *testing.T) {
+	h := newTestHTTP()
+
+	t.Run("returns the response's own headers", func(t *testing.T) {
+		headers := &httpFields{
+			names:     []string{"Content-Type"},
+			values:    [][]byte{[]byte("application/vnd.pypi.simple.v1+json")},
+			immutable: true,
+		}
+		respRep := h.newInResponseRep(&httpIncomingResponse{status: 200, headers: headers})
+		res, err := h.incomingResponseHeaders(context.Background(), []abi.Value{respRep})
+		if err != nil {
+			t.Fatal(err)
+		}
+		fieldsRep := res[0].(uint32)
+
+		entries, err := h.fieldsEntries(context.Background(), []abi.Value{fieldsRep})
+		if err != nil {
+			t.Fatal(err)
+		}
+		pair := entries[0].([]abi.Value)[0].([]abi.Value)
+		if got := pair[0].(string); got != "Content-Type" {
+			t.Errorf("name = %q, want Content-Type", got)
+		}
+		if got := u8ListToString(t, pair[1]); got != "application/vnd.pypi.simple.v1+json" {
+			t.Errorf("value = %q", got)
+		}
+
+		// The rep must name the SAME fields object, not a copy: a header
+		// added host-side afterwards has to be visible through it.
+		headers.names = append(headers.names, "X-Late")
+		headers.values = append(headers.values, []byte("1"))
+		entries2, err := h.fieldsEntries(context.Background(), []abi.Value{fieldsRep})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n := len(entries2[0].([]abi.Value)); n != 2 {
+			t.Fatalf("got %d entries after mutating the parent, want 2 (a copy was handed out)", n)
+		}
+	})
+
+	t.Run("headers are immutable", func(t *testing.T) {
+		respRep := h.newInResponseRep(&httpIncomingResponse{
+			status:  200,
+			headers: &httpFields{names: []string{"A"}, values: [][]byte{[]byte("1")}, immutable: true},
+		})
+		res, err := h.incomingResponseHeaders(context.Background(), []abi.Value{respRep})
+		if err != nil {
+			t.Fatal(err)
+		}
+		fieldsRep := res[0].(uint32)
+
+		setRes, err := h.fieldsSet(context.Background(), []abi.Value{fieldsRep, "A", []abi.Value{bytesToU8List([]byte("2"))}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rv := setRes[0].(abi.ResultValue)
+		if !rv.IsErr {
+			t.Fatal("set on immutable headers succeeded, want header-error::immutable")
+		}
+		if vv := rv.Payload.(abi.VariantValue); vv.Disc != httpHeaderErrorImmutable {
+			t.Fatalf("got header-error case %d, want immutable (%d)", vv.Disc, httpHeaderErrorImmutable)
+		}
+		// ...and the value really did not change.
+		got, err := h.fieldsGet(context.Background(), []abi.Value{fieldsRep, "A"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v := u8ListToString(t, got[0].([]abi.Value)[0]); v != "1" {
+			t.Fatalf("value = %q after a refused set, want unchanged %q", v, "1")
+		}
+	})
+
+	t.Run("a fields the guest built stays mutable", func(t *testing.T) {
+		ctorRes, err := h.fieldsConstructor(context.Background(), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rep := ctorRes[0].(uint32)
+		setRes, err := h.fieldsSet(context.Background(), []abi.Value{rep, "A", []abi.Value{bytesToU8List([]byte("1"))}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if setRes[0].(abi.ResultValue).IsErr {
+			t.Fatal("set on a guest-constructed fields was refused")
+		}
+	})
+
+	t.Run("response with no headers still yields a readable fields", func(t *testing.T) {
+		respRep := h.newInResponseRep(&httpIncomingResponse{status: 204})
+		res, err := h.incomingResponseHeaders(context.Background(), []abi.Value{respRep})
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries, err := h.fieldsEntries(context.Background(), []abi.Value{res[0].(uint32)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n := len(entries[0].([]abi.Value)); n != 0 {
+			t.Fatalf("got %d entries, want 0", n)
+		}
+	})
+
+	t.Run("arg validation", func(t *testing.T) {
+		_, err := h.incomingResponseHeaders(context.Background(), nil)
+		reqErr(t, err, "expected 1 arg")
+		_, err = h.incomingResponseHeaders(context.Background(), []abi.Value{"bad"})
+		reqErr(t, err, "self: expected uint32")
+		_, err = h.incomingResponseHeaders(context.Background(), []abi.Value{uint32(9999)})
+		reqErr(t, err, "does not name a live incoming-response")
+	})
+}
+
+// headerRT answers with the Content-Type a pip-style simple-index request
+// depends on, plus a repeated header, so the round trip below proves both
+// survive from a real *http.Response into guest-visible fields.
+type headerRT struct{}
+
+func (headerRT) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"Content-Type": []string{"application/vnd.pypi.simple.v1+json"},
+			"Set-Cookie":   []string{"a=1", "b=2"},
+		},
+		Body: io.NopCloser(strings.NewReader("{}")),
+	}, nil
+}
+
+// TestHTTP_ResponseHeadersRoundTrip is the end-to-end proof for both new
+// methods: a real Go http.Response's headers reach the guest through
+// outgoing-handler.handle -> future.get -> incoming-response.headers ->
+// fields.entries. Without incoming-response.headers a guest can read a
+// response's status and body but never its Content-Type, which is what a pip
+// simple-index fetch dispatches on.
+func TestHTTP_ResponseHeadersRoundTrip(t *testing.T) {
+	h := newTestHTTP()
+	h.client = &http.Client{Transport: headerRT{}}
+	tbl, _ := h.getResources()
+
+	reqRep := h.newOutRequestRep(&httpOutgoingRequest{
+		method: "GET", scheme: "https", authority: "pypi.org", pathQ: "/simple/requests/",
+		headers: &httpFields{},
+	})
+	res, err := h.outgoingHandlerHandle(context.Background(), []abi.Value{reqRep, nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	futRep, err := tbl.Rep(wasiHTTPFutureResType, res[0].(abi.ResultValue).Payload.(uint32))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// future.get -> option<result<result<own<incoming-response>, error-code>>>
+	got, err := h.futureGet(context.Background(), []abi.Value{futRep})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outer := got[0].(abi.ResultValue) // the option's `some` payload
+	inner := outer.Payload.(abi.ResultValue)
+	if inner.IsErr {
+		t.Fatalf("request failed: %#v", inner.Payload)
+	}
+	respRep, err := tbl.Rep(wasiHTTPIncomingResponseResType, inner.Payload.(uint32))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hdrRes, err := h.incomingResponseHeaders(context.Background(), []abi.Value{respRep})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := h.fieldsEntries(context.Background(), []abi.Value{hdrRes[0].(uint32)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seen := map[string][]string{}
+	for _, e := range entries[0].([]abi.Value) {
+		pair := e.([]abi.Value)
+		name := pair[0].(string)
+		seen[name] = append(seen[name], u8ListToString(t, pair[1]))
+	}
+	// Field keys arrive LOWER-CASED: wasi:http normalizes field-key that way
+	// (outgoingHandlerHandle does it when copying from http.Header), so a
+	// consumer must look up "content-type", never "Content-Type". Asserting
+	// the exact casing here is the point -- a case-sensitive lookup on the
+	// Go-style name silently finds nothing.
+	if _, wrongCase := seen["Content-Type"]; wrongCase {
+		t.Error("field keys are not lower-cased; consumers matching on the wasi:http convention would miss them")
+	}
+	if got := seen["content-type"]; len(got) != 1 || got[0] != "application/vnd.pypi.simple.v1+json" {
+		t.Fatalf("content-type = %v, want the simple-index media type", got)
+	}
+	if got := seen["set-cookie"]; len(got) != 2 || got[0] != "a=1" || got[1] != "b=2" {
+		t.Fatalf("set-cookie = %v, want both values as separate entries", got)
+	}
+
+	// A received response's headers must refuse writes.
+	setRes, err := h.fieldsSet(context.Background(), []abi.Value{hdrRes[0].(uint32), "content-type", []abi.Value{bytesToU8List([]byte("text/plain"))}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rv := setRes[0].(abi.ResultValue); !rv.IsErr || rv.Payload.(abi.VariantValue).Disc != httpHeaderErrorImmutable {
+		t.Fatalf("set on received headers = %#v, want Err(immutable)", rv)
+	}
+}

--- a/internal/component/instance/wasi_http_errbranch_test.go
+++ b/internal/component/instance/wasi_http_errbranch_test.go
@@ -840,16 +840,13 @@ func TestHTTP_FieldsEntries(t *testing.T) {
 	})
 }
 
-// u8ListToString reverses bytesToU8List for assertions.
+// u8ListToString reverses a lowered list<u8> for assertions, accepting both
+// the compact []byte shape and the general one-interface-per-element one.
 func u8ListToString(t *testing.T, v abi.Value) string {
 	t.Helper()
-	list, ok := v.([]abi.Value)
-	if !ok {
-		t.Fatalf("field-value: expected a list, got %T", v)
-	}
-	b := make([]byte, len(list))
-	for i, x := range list {
-		b[i] = byte(x.(uint32))
+	b, err := wasiBytesFromList(v)
+	if err != nil {
+		t.Fatalf("field-value: %v", err)
 	}
 	return string(b)
 }

--- a/internal/component/instance/wasi_http_errbranch_test.go
+++ b/internal/component/instance/wasi_http_errbranch_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1039,27 +1040,79 @@ func TestHTTP_ResponseHeadersRoundTrip(t *testing.T) {
 		name := pair[0].(string)
 		seen[name] = append(seen[name], u8ListToString(t, pair[1]))
 	}
-	// Field keys arrive LOWER-CASED: wasi:http normalizes field-key that way
-	// (outgoingHandlerHandle does it when copying from http.Header), so a
-	// consumer must look up "content-type", never "Content-Type". Asserting
-	// the exact casing here is the point -- a case-sensitive lookup on the
-	// Go-style name silently finds nothing.
-	if _, wrongCase := seen["Content-Type"]; wrongCase {
-		t.Error("field keys are not lower-cased; consumers matching on the wasi:http convention would miss them")
+	// types.wit: entries come back "in the original casing", so the name is
+	// net/http's canonical form, NOT lower-cased.
+	if _, lowered := seen["content-type"]; lowered {
+		t.Error(`field name was lower-cased; types.wit requires the original casing`)
 	}
-	if got := seen["content-type"]; len(got) != 1 || got[0] != "application/vnd.pypi.simple.v1+json" {
-		t.Fatalf("content-type = %v, want the simple-index media type", got)
+	if got := seen["Content-Type"]; len(got) != 1 || got[0] != "application/vnd.pypi.simple.v1+json" {
+		t.Fatalf("Content-Type = %v, want the simple-index media type", got)
 	}
-	if got := seen["set-cookie"]; len(got) != 2 || got[0] != "a=1" || got[1] != "b=2" {
-		t.Fatalf("set-cookie = %v, want both values as separate entries", got)
+	if got := seen["Set-Cookie"]; len(got) != 2 || got[0] != "a=1" || got[1] != "b=2" {
+		t.Fatalf("Set-Cookie = %v, want both values in order as separate entries", got)
+	}
+
+	// types.wit also requires a stable serialization order: ranging a Go map
+	// would hand the guest a different order on each call.
+	first := entryNames(t, entries[0].([]abi.Value))
+	for i := 0; i < 20; i++ {
+		again, err := h.fieldsEntries(context.Background(), []abi.Value{hdrRes[0].(uint32)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := entryNames(t, again[0].([]abi.Value)); !slices.Equal(got, first) {
+			t.Fatalf("entries order is unstable: %v then %v", first, got)
+		}
 	}
 
 	// A received response's headers must refuse writes.
-	setRes, err := h.fieldsSet(context.Background(), []abi.Value{hdrRes[0].(uint32), "content-type", []abi.Value{bytesToU8List([]byte("text/plain"))}})
+	setRes, err := h.fieldsSet(context.Background(), []abi.Value{hdrRes[0].(uint32), "Content-Type", []abi.Value{bytesToU8List([]byte("text/plain"))}})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if rv := setRes[0].(abi.ResultValue); !rv.IsErr || rv.Payload.(abi.VariantValue).Disc != httpHeaderErrorImmutable {
 		t.Fatalf("set on received headers = %#v, want Err(immutable)", rv)
+	}
+}
+
+// entryNames extracts the field names from an entries() result, in order.
+func entryNames(t *testing.T, entries []abi.Value) []string {
+	t.Helper()
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.([]abi.Value)[0].(string))
+	}
+	return out
+}
+
+// TestHTTP_FieldsSetIsCaseInsensitive pins types.wit's rule that field names
+// compare case-insensitively: setting "Content-Type" must REPLACE an existing
+// "content-type", not leave both behind.
+func TestHTTP_FieldsSetIsCaseInsensitive(t *testing.T) {
+	h := newTestHTTP()
+	rep := h.newFieldsRep(&httpFields{names: []string{"content-type"}, values: [][]byte{[]byte("text/plain")}})
+	if _, err := h.fieldsSet(context.Background(), []abi.Value{rep, "Content-Type", []abi.Value{bytesToU8List([]byte("text/html"))}}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := h.fieldsEntries(context.Background(), []abi.Value{rep})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries := res[0].([]abi.Value)
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1 (the differently-cased name should have been replaced)", len(entries))
+	}
+	if got := u8ListToString(t, entries[0].([]abi.Value)[1]); got != "text/html" {
+		t.Fatalf("value = %q, want text/html", got)
+	}
+	// get must find it under either casing.
+	for _, probe := range []string{"content-type", "CONTENT-TYPE", "Content-Type"} {
+		got, err := h.fieldsGet(context.Background(), []abi.Value{rep, probe})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n := len(got[0].([]abi.Value)); n != 1 {
+			t.Fatalf("get(%q) returned %d values, want 1", probe, n)
+		}
 	}
 }

--- a/internal/component/wit/coverage_test.go
+++ b/internal/component/wit/coverage_test.go
@@ -406,13 +406,9 @@ func TestParseErrors(t *testing.T) {
 		{"use missing rbrace in names", "package t:t; use a.{x ;"},
 		{"use missing alias after as (bare)", "package t:t; use a as ;"},
 		{"use missing semicolon", "package t:t; use a"},
-
-		{"import bare path", "package t:t; world w { import wasi:io/streams; }"},
 		{"import missing colon", "package t:t; world w { import foo func(); }"},
 		{"import missing semicolon", "package t:t; world w { import foo: func() }"},
 		{"import bad body", "package t:t; world w { import foo: bogus; }"},
-
-		{"export bare path", "package t:t; world w { export wasi:io/streams; }"},
 		{"export missing colon", "package t:t; world w { export foo func(); }"},
 		{"export missing semicolon", "package t:t; world w { export foo: func() }"},
 		{"export bad body", "package t:t; world w { export foo: bogus; }"},
@@ -698,31 +694,76 @@ func TestNestedPackageDeclUnsupported(t *testing.T) {
 	}
 }
 
-// TestBarePackagePathImportExport verifies that importing/exporting a bare
-// package path (without "name:") is rejected with a clear, line-numbered
-// error, since this construct isn't yet supported.
+// TestBarePackagePathImportExport covers a world importing or exporting an
+// interface by bare package path or bare name -- "import wasi:io/streams;",
+// "import environment;" -- with no "name:" declarator. Both are legal WIT and
+// pervasive in the WASI worlds, so the reference definitions cannot be read
+// without them. A malformed body ("foo: bogus;") must still be an error,
+// which is what distinguishes a path (it names an interface inside a package,
+// so it always contains '/') from a typo.
 func TestBarePackagePathImportExport(t *testing.T) {
-	t.Run("import", func(t *testing.T) {
-		src := "package t:t; world w { import wasi:io/streams@0.2.0; }"
-		_, err := Parse("bare.wit", src)
-		if err == nil {
-			t.Fatal("expected error for bare package-path import")
-		}
-		if !strings.Contains(err.Error(), "not yet supported") {
-			t.Errorf("unexpected error: %v", err)
-		}
-	})
+	for _, tc := range []struct {
+		name, src, wantName string
+	}{
+		{"import path", "package t:t; world w { import wasi:io/streams@0.2.0; }", "wasi:io/streams@0.2.0"},
+		{"export path", "package t:t; world w { export wasi:io/streams@0.2.0; }", "wasi:io/streams@0.2.0"},
+		{"import bare name", "package t:t; world w { import environment; }", "environment"},
+		{"export bare name", "package t:t; world w { export run; }", "run"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pkg, err := Parse("bare.wit", tc.src)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			world := pkg.Items[0].(*World)
+			var got string
+			switch it := world.Items[0].(type) {
+			case *Import:
+				got = it.Name
+			case *Export:
+				got = it.Name
+			default:
+				t.Fatalf("world item = %T, want an Import or Export", it)
+			}
+			if got != tc.wantName {
+				t.Fatalf("name = %q, want %q", got, tc.wantName)
+			}
+		})
+	}
 
-	t.Run("export", func(t *testing.T) {
-		src := "package t:t; world w { export wasi:io/streams@0.2.0; }"
-		_, err := Parse("bare.wit", src)
-		if err == nil {
-			t.Fatal("expected error for bare package-path export")
-		}
-		if !strings.Contains(err.Error(), "not yet supported") {
-			t.Errorf("unexpected error: %v", err)
+	t.Run("malformed body is still an error", func(t *testing.T) {
+		for _, src := range []string{
+			"package t:t; world w { import foo: bogus; }",
+			"package t:t; world w { export foo: bogus; }",
+		} {
+			if _, err := Parse("bad.wit", src); err == nil {
+				t.Errorf("expected a parse error for %q", src)
+			}
 		}
 	})
+}
+
+// TestExplicitIdentifier covers WIT's "%name" escape, which lets a keyword be
+// used as a field or function name. wasi:filesystem's descriptor-stat relies
+// on it (`%type: descriptor-type`), so the reference definitions cannot be
+// read without it. The '%' is not part of the name.
+func TestExplicitIdentifier(t *testing.T) {
+	pkg, err := Parse("esc.wit", "package t:t; interface i { record r { %type: u32, %interface: string } }")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	iface := pkg.Items[0].(*Interface)
+	rec := iface.Items[0].(*TypeDef).Type.(*Record)
+	if len(rec.Fields) != 2 {
+		t.Fatalf("got %d fields, want 2", len(rec.Fields))
+	}
+	if rec.Fields[0].Name != "type" || rec.Fields[1].Name != "interface" {
+		t.Fatalf("field names = %q, %q; want \"type\", \"interface\" (the %% is not part of the name)", rec.Fields[0].Name, rec.Fields[1].Name)
+	}
+
+	if _, err := Parse("esc.wit", "package t:t; interface i { record r { %: u32 } }"); err == nil {
+		t.Error("expected an error for '%' with no identifier after it")
+	}
 }
 
 // TestUseWithAsAlias tests "use path as name;" (single-name alias form),

--- a/internal/component/wit/parser.go
+++ b/internal/component/wit/parser.go
@@ -1377,10 +1377,17 @@ func (p *Parser) parseImport(gate Gate, externalID string) (*Import, error) {
 	p.advance()
 
 	if p.current.Type != TokenIdent {
-		return nil, fmt.Errorf("line %d: import of a bare package path (without 'name:') is not yet supported", p.current.Line)
+		return nil, p.errorf("expected an import name or package path")
 	}
 	name := p.current.Text
 	p.advance()
+
+	// "import environment;" -- a world importing an interface by bare name,
+	// with no type to declare. Legal WIT and common in the WASI worlds.
+	if p.current.Type == TokenSemicolon {
+		p.advance()
+		return &Import{Name: name, Gate: gate, ExternalID: externalID}, nil
+	}
 
 	if !p.expect(TokenColon) {
 		return nil, p.errorf("expected ':' after import name")
@@ -1414,12 +1421,48 @@ func (p *Parser) parseImport(gate Gate, externalID string) (*Import, error) {
 		// path (e.g. "import wasi:io/streams@0.2.0;"), since the lexer
 		// tokenizes that leading namespace exactly like a local import
 		// name; the ':' we just consumed is the path separator, not the
-		// "name:" declarator. Report the specific, actionable error
-		// instead of a generic "expected 'func' or 'interface'".
-		return nil, fmt.Errorf("line %d: import of a bare package path (without 'name:') is not yet supported", p.current.Line)
+		// "name:" declarator.
+		full, err := p.parseBarePathTail(name)
+		if err != nil {
+			return nil, err
+		}
+		return &Import{Name: full, Gate: gate, ExternalID: externalID}, nil
 	}
 
 	return &Import{Name: name, Type: importType, Gate: gate, ExternalID: externalID}, nil
+}
+
+// parseBarePathTail consumes the remainder of a bare package-path reference
+// in a world -- "wasi:io/error@0.2.12;" -- starting just after the ':' that
+// was mistaken for a "name:" declarator, and returns the full path text.
+// The reconstruction is token-wise, so incidental whitespace inside the path
+// is not preserved; nothing consumes these paths structurally (a world's
+// import list names interfaces that are resolved elsewhere), so the text is
+// for diagnostics and round-tripping only.
+func (p *Parser) parseBarePathTail(head string) (string, error) {
+	var b strings.Builder
+	b.WriteString(head)
+	b.WriteString(":")
+	sawSlash := false
+	for p.current.Type != TokenSemicolon {
+		if p.current.Type == TokenEOF {
+			return "", p.errorf("unterminated bare package path in world item")
+		}
+		if p.current.Type == TokenSlash {
+			sawSlash = true
+		}
+		b.WriteString(p.current.Text)
+		p.advance()
+	}
+	if !sawSlash {
+		// "foo: bogus;" is a malformed declarator, not a package path: a
+		// path always names an interface within a package
+		// ("ns:pkg/iface"). Without this the two are indistinguishable and
+		// a typo'd import body would parse silently.
+		return "", p.errorf("expected 'func' or 'interface' after ':', or a package path of the form ns:pkg/iface")
+	}
+	p.advance() // consume ';'
+	return b.String(), nil
 }
 
 // parseExport parses "export name : func-type;" or "export name : interface { ... };",
@@ -1431,10 +1474,16 @@ func (p *Parser) parseExport(gate Gate, externalID string) (*Export, error) {
 	p.advance()
 
 	if p.current.Type != TokenIdent {
-		return nil, fmt.Errorf("line %d: export of a bare package path (without 'name:') is not yet supported", p.current.Line)
+		return nil, p.errorf("expected an export name or package path")
 	}
 	name := p.current.Text
 	p.advance()
+
+	// "export run;" -- a world exporting an interface by bare name.
+	if p.current.Type == TokenSemicolon {
+		p.advance()
+		return &Export{Name: name, Gate: gate, ExternalID: externalID}, nil
+	}
 
 	if !p.expect(TokenColon) {
 		return nil, p.errorf("expected ':' after export name")
@@ -1466,7 +1515,11 @@ func (p *Parser) parseExport(gate Gate, externalID string) (*Export, error) {
 		// See the matching comment in parseImport: this is reached for a
 		// bare package-path export (e.g. "export wasi:io/streams@0.2.0;"),
 		// not just a plain syntax error.
-		return nil, fmt.Errorf("line %d: export of a bare package path (without 'name:') is not yet supported", p.current.Line)
+		full, err := p.parseBarePathTail(name)
+		if err != nil {
+			return nil, err
+		}
+		return &Export{Name: full, Gate: gate, ExternalID: externalID}, nil
 	}
 
 	return &Export{Name: name, Type: exportType, Gate: gate, ExternalID: externalID}, nil

--- a/internal/component/wit/token.go
+++ b/internal/component/wit/token.go
@@ -222,7 +222,21 @@ func (lex *Lexer) NextToken() Token {
 		tok.Type = TokenString
 		tok.Text = lex.readString()
 	default:
-		if isIdentStart(lex.ch) {
+		if lex.ch == '%' {
+			// WIT's explicit-identifier escape: "%type" names a field or
+			// function called "type" without colliding with the keyword.
+			// wasi:filesystem's descriptor-stat uses it (`%type:
+			// descriptor-type`), so a parser that rejects it cannot read the
+			// reference WASI definitions. The '%' is not part of the name.
+			lex.advance()
+			if !isIdentStart(lex.ch) {
+				tok.Type = TokenError
+				tok.Text = "expected an identifier after '%'"
+				break
+			}
+			tok.Text = lex.readIdent()
+			tok.Type = TokenIdent // never a keyword: that is the point of the escape
+		} else if isIdentStart(lex.ch) {
 			text := lex.readIdent()
 			tok.Text = text
 			tok.Type = keywordType(text)


### PR DESCRIPTION
## Why

A guest could read a response's status and body but never its **headers**. `[method]incoming-response.headers` was unregistered, and so was the `[method]fields.entries` needed to enumerate a `fields` once you had one. A pip simple-index fetch dispatches on `Content-Type`, so it could not work.

## What

**`[method]incoming-response.headers`** → `own<fields>`. Returns the response's *own* headers object, not a copy — `types.wit` calls it a child of the incoming-response, so the guest must see what actually arrived. A test mutates the parent after handing out the rep and asserts the change is visible, which is what catches an accidental copy.

**`[method]fields.entries`** → `list<tuple<field-key, field-value>>`. Reports every stored pair, **duplicates included**: `entries` describes the wire, and collapsing repeats would lose information — `Set-Cookie` must never be joined. Whether to join is the caller's decision, not this layer's.

**Immutability.** `types.wit` specifies an incoming message's fields as immutable and gives `header-error` a dedicated `immutable` case for an attempted write. `httpFields` grows an `immutable` flag that `fields.set` honors, set on every response built from a real `http.Response`. A fields the guest constructed itself stays mutable — both directions are tested.

`fields.entries` is this file's first `list<tuple<...>>` result. It needed no new ABI work, only descriptor composition: `TupleDesc` and its lowering already existed.

## One detail worth flagging for consumers

Field keys arrive **lower-cased**, because wasi:http normalizes `field-key` that way (`wasi_http.go:1596`, when copying from Go's `http.Header`). A consumer must look up `"content-type"`, never `"Content-Type"` — a case-sensitive match on the Go-style name silently finds nothing. My first round-trip test asserted the Go casing and failed, which is exactly the mistake a consumer will make, so the test now pins the lowercase form *and* asserts the capitalized key is absent.

## Not implemented

`fields.has`, `fields.append`, `fields.delete`, `[static]fields.from-list` — none is on this path. `append` and `from-list` are the natural follow-up for a guest **building** multi-valued request headers.

The child-must-be-dropped-before-the-parent rule `types.wit` states is not enforced; a guest that leaks the handle holds a rep whose parent is gone, which costs nothing and traps loudly on use.

## Verification

- `go build ./... && go test ./...` green; conformance goldens unchanged.
- Coverage `internal/component/instance` **90.5%** (up from 90.4%).
- `make lint` unchanged from `origin/main`'s baseline.
- Cross-compiles: plan9/js/freebsd/windows, GOARCH=386.
- New tests: entry shape with duplicates, empty fields, arg validation and unknown reps for both methods, immutable-refuses-write, guest-built-stays-mutable, headers-absent response, and an end-to-end round trip driving `outgoing-handler.handle` → `future.get` → `incoming-response.headers` → `fields.entries` against a stub transport, asserting a real `Content-Type` and a repeated `Set-Cookie` both survive.