### PR TITLE
fix(component): accept the empty core export name in passthrough shims

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -53,8 +53,8 @@
   "cannot remove owned resource while borrowed". The harness supplies the test's
   `host` resource1 (constructor/assert/drops/last-drop/methods/take-own), the
   test-runner plumbing wasmtime provides.
-- **DONE (zero skips, commits 679cf3a + 1483b08 + beeeba3):** every vendored
-  module in all 7 official suites now runs -- no skips.
+- **DONE (commits 679cf3a + 1483b08 + beeeba3):** the modules those commits
+  targeted now run.
   - types.1: decoder parses core:type definitions (func/module types) inside an
     instance/component type (679cf3a).
   - res.25: export a canon-produced func (a `[constructor]t` = lift(resource.new))
@@ -64,11 +64,24 @@
   - res.17: component instantiate-args (type 0x03 + func 0x01) and top-level
     func imports, so a resource-type-and-constructor-parameterized nested
     component instantiates against the host resource (beeeba3).
+- **DONE (empty export names, issue #25):** a passthrough shim may re-export an
+  item under the EMPTY name -- an ordinary core wasm `name`, which
+  `buildPassthroughShim` used to reject outright. This is not an exotic case:
+  wit-component's "start shim" (`(import "" "" (func)) (start 0)` fed by an
+  inline-export group `(export "" (func $_initialize))`) is in EVERY
+  componentize-go component, so no such component could be instantiated at all.
+  fused.0 + fused.3 now run.
+- **REMAINING skips** (4, each pinned by name + reason in
+  `wastKnownSkips`): types.11 (instantiate-arg of sort 0x4), fused.22 (a nested
+  component's imported-instance func type absent from the importer's type
+  space), fused.23 (a nested component defining no core module of its own),
+  resources.14 (an instantiate-arg naming an IMPORTED instance).
 - **Historic fused sub-features** (all now run; the reworks fixed them):
-  pass-through shim with empty export names, >16 flat params on an imported func
-  (whole-param spilling for a lowered import), func/type instantiate-args,
-  self-referential nesting.
-- **Acceptance gate:** the `.wast` harness (`wast_conformance_test.go`).
+  \>16 flat params on an imported func (whole-param spilling for a lowered
+  import), func/type instantiate-args, self-referential nesting.
+- **Acceptance gate:** the `.wast` harness (`wast_conformance_test.go`), which
+  now reconciles the observed skip set against `wastKnownSkips` in both
+  directions -- a new skip fails, and so does a stale entry.
 
 ## wasi:http — DONE (both sides), minor breadth remaining
 - **Done — full `wasi:http/proxy` world runs.** Both directions verified differentially vs wasmtime:

--- a/internal/component/instance/graph_synth_test.go
+++ b/internal/component/instance/graph_synth_test.go
@@ -598,6 +598,150 @@ func TestSynthGraph_InlineExportGlobalUninstantiatedSource(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// 3b. the wit-component "start shim": empty export/import field names
+// ---------------------------------------------------------------------------
+
+// sideEffectModule exports, under funcName, a `(func)` that stores sentinel
+// into its mutable i32 global (exported as "g", initially 0) -- a stand-in for
+// a reactor's `_initialize`: nullary, observable only by its side effect, and
+// reached only through the start shim. funcName is "" in the tests that also
+// need the shim's SOURCE name to be empty.
+func sideEffectModule(sentinel int32, funcName string) []byte {
+	body := append(i32Const(sentinel), wasm.OpcodeGlobalSet, 0x00, wasm.OpcodeEnd)
+	return binaryencoding.EncodeModule(&wasm.Module{
+		TypeSection:     []wasm.FunctionType{{}},
+		FunctionSection: []wasm.Index{0},
+		GlobalSection: []wasm.Global{
+			{Type: wasm.GlobalType{ValType: wasm.ValueTypeI32, Mutable: true}, Init: wasm.NewConstantExpressionFromOpcode(wasm.OpcodeI32Const, leb128.EncodeInt32(0))},
+		},
+		CodeSection: []wasm.Code{{Body: body}},
+		ExportSection: []wasm.Export{
+			{Name: funcName, Type: wasm.ExternTypeFunc, Index: 0},
+			{Name: "g", Type: wasm.ExternTypeGlobal, Index: 0},
+		},
+	})
+}
+
+// startShimModule is wit-component's start shim verbatim: a core module whose
+// entire content is `(import "" "" (func)) (start 0)`. Both halves of the
+// import name are empty.
+func startShimModule() []byte {
+	start := wasm.Index(0)
+	return binaryencoding.EncodeModule(&wasm.Module{
+		TypeSection:         []wasm.FunctionType{{}},
+		ImportSection:       []wasm.Import{{Module: "", Name: "", Type: wasm.ExternTypeFunc, DescFunc: 0}},
+		ImportFunctionCount: 1,
+		StartSection:        &start,
+	})
+}
+
+// observeGlobalModule imports (fromModule, "g") as a mutable i32 global and
+// traps in its start function unless it holds want -- so the start shim having
+// merely instantiated is not enough; it must actually have RUN.
+func observeGlobalModule(fromModule string, want int32) []byte {
+	body := []byte{wasm.OpcodeGlobalGet, 0x00}
+	body = append(body, i32Const(want)...)
+	body = append(body, wasm.OpcodeI32Ne, wasm.OpcodeIf, 0x40, wasm.OpcodeUnreachable, wasm.OpcodeEnd, wasm.OpcodeEnd)
+	start := wasm.Index(0)
+	return binaryencoding.EncodeModule(&wasm.Module{
+		TypeSection:     []wasm.FunctionType{{}},
+		ImportSection:   []wasm.Import{{Module: fromModule, Name: "g", Type: wasm.ExternTypeGlobal, DescGlobal: wasm.GlobalType{ValType: wasm.ValueTypeI32, Mutable: true}}},
+		FunctionSection: []wasm.Index{0},
+		CodeSection:     []wasm.Code{{Body: body}},
+		StartSection:    &start,
+	})
+}
+
+// TestSynthGraph_EmptyNameStartShimRuns pins issue #25. Every componentize-go
+// component ends with wit-component's "start shim", which invokes the reactor's
+// `_initialize` once the whole graph is wired:
+//
+//	(core module $s (import "" "" (func)) (start 0))
+//	(core instance $args (export "" (func $_initialize)))
+//	(core instance (instantiate $s (with "" (instance $args))))
+//
+// An export/import field name in core wasm is a `name`: any UTF-8 sequence,
+// non-empty NOT required (names.wast asserts exactly this). buildPassthroughShim
+// nonetheless rejected `""` outright, so instantiation died with "item[0] has an
+// empty export name" before the guest ever ran -- and the same shape in the
+// official component-model suite (fused.0/fused.3) was being logged as a SKIP.
+//
+// This is the reporter's shape exactly: only the shim's EXPORT name is empty
+// (its source is the guest's ordinary "_initialize"). The observer core module
+// proves the start shim really executed rather than merely instantiating.
+func TestSynthGraph_EmptyNameStartShimRuns(t *testing.T) {
+	b := newCompBuilder()
+	b.coreModule(sideEffectModule(7, "_initialize")) // core module 0
+	b.coreModule(startShimModule())                  // core module 1
+	b.coreModule(observeGlobalModule("chk", 7))      // core module 2
+	b.coreInstances([]synthCoreInstance{
+		{moduleIdx: 0}, // 0: the provider
+		{inline: []synthInline{{name: "", sort: 0x00, idx: 0}}},  // 1: regroup _initialize under ""
+		{moduleIdx: 1, args: []synthArg{{"", 1}}},                // 2: the start shim; runs the func
+		{inline: []synthInline{{name: "g", sort: 0x03, idx: 0}}}, // 3: regroup the provider's global
+		{moduleIdx: 2, args: []synthArg{{"chk", 3}}},             // 4: traps unless the shim ran
+	})
+	b.coreAliases([]synthAlias{
+		{coreSort: 0x00, inst: 0, name: "_initialize"}, // core func 0
+		{coreSort: 0x03, inst: 0, name: "g"},           // core global 0
+	})
+
+	raw, comp := decodeSynth(t, b)
+	if got := comp.CoreInstances[1].Exports[0].Name; got != "" {
+		t.Fatalf("fixture: core instance 1 inline export name = %q, want empty", got)
+	}
+	in, err := runSynth(t, raw, comp)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	in.Close(context.Background())
+}
+
+// The reporter's component binds TWO different core instances under the empty
+// "with" name (wit-component's fixup group and its start-shim group), and every
+// empty core import module name is rewritten to one shared graphEmptyImportKey
+// before decode -- so "" is a colliding consumer name like any other and must
+// still resolve per-instantiation, by identity. Each start shim writes a
+// different sentinel; each observer traps unless it sees its own.
+//
+// Here the providers export their func under "" as well, so this also covers
+// the other half of the dropped guard: a shim whose SOURCE name is empty, the
+// `(alias core export $m "")` that fused.0 aliases.
+func TestSynthGraph_TwoGroupsShareTheEmptyWithName(t *testing.T) {
+	b := newCompBuilder()
+	b.coreModule(sideEffectModule(11, ""))       // core module 0: provider A
+	b.coreModule(sideEffectModule(22, ""))       // core module 1: provider B
+	b.coreModule(startShimModule())              // core module 2
+	b.coreModule(observeGlobalModule("chk", 11)) // core module 3
+	b.coreModule(observeGlobalModule("chk", 22)) // core module 4
+	b.coreInstances([]synthCoreInstance{
+		{moduleIdx: 0}, // 0: provider A
+		{moduleIdx: 1}, // 1: provider B
+		{inline: []synthInline{{name: "", sort: 0x00, idx: 0}}},  // 2: A's ""-func, under ""
+		{inline: []synthInline{{name: "", sort: 0x00, idx: 1}}},  // 3: B's ""-func, ALSO under ""
+		{moduleIdx: 2, args: []synthArg{{"", 2}}},                // 4: start shim -> A
+		{moduleIdx: 2, args: []synthArg{{"", 3}}},                // 5: start shim -> B
+		{inline: []synthInline{{name: "g", sort: 0x03, idx: 0}}}, // 6: A's global
+		{inline: []synthInline{{name: "g", sort: 0x03, idx: 1}}}, // 7: B's global
+		{moduleIdx: 3, args: []synthArg{{"chk", 6}}},             // 8: must see 11
+		{moduleIdx: 4, args: []synthArg{{"chk", 7}}},             // 9: must see 22
+	})
+	b.coreAliases([]synthAlias{
+		{coreSort: 0x00, inst: 0, name: ""},  // core func 0
+		{coreSort: 0x00, inst: 1, name: ""},  // core func 1
+		{coreSort: 0x03, inst: 0, name: "g"}, // core global 0
+		{coreSort: 0x03, inst: 1, name: "g"}, // core global 1
+	})
+
+	raw, comp := decodeSynth(t, b)
+	in, err := runSynth(t, raw, comp)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	in.Close(context.Background())
+}
+
+// ---------------------------------------------------------------------------
 // 4. several exported component instances, index space shifted by each export
 // ---------------------------------------------------------------------------
 

--- a/internal/component/instance/shim.go
+++ b/internal/component/instance/shim.go
@@ -101,6 +101,39 @@ type shimItem struct {
 // real item's actual size -- see the resolveImports bounds checks in
 // internal/wasm/store.go, which this deliberately relies on without needing
 // to duplicate their logic here.
+//
+// # Empty names
+//
+// ExportName and FromName may be "". A core wasm export/import field name is a
+// `name` -- an arbitrary UTF-8 byte sequence, with no non-empty requirement,
+// unique only within its module -- so "" is an ordinary name, not a missing
+// one. The core spec suite asserts this directly (names.wast: "Test that we can
+// use the empty string as a symbol", `(func (export "") ...)`), and wazy's core
+// engine passes it: Module.Exports and resolveImports are plain map lookups
+// with comma-ok, so "" never aliases "absent".
+//
+// This is not hypothetical. wit-component really emits it, in two shapes this
+// package must instantiate:
+//
+//   - the "start shim": to run a reactor's `_initialize` after the whole graph
+//     is wired, it emits a core module `(import "" "" (func)) (start 0)` fed by
+//     an inline-export core instance `(export "" (func $_initialize))` -- so
+//     both the import field name and this shim's ExportName are "". Every
+//     componentize-go component has one (see the wit-component 0.253 output in
+//     issue #25); wasmtime runs them.
+//   - the official component-model conformance suite's fused.wast (vendored as
+//     testdata/wast/fused/fused.{0,3}.wasm), whose nested components alias a
+//     core export literally named "" and re-group it under "".
+//
+// Only FromModule is required to be non-empty, and that is an internal
+// invariant rather than a wasm rule: the graph always names a shim's source by
+// a synthesized resolver key (coreInstanceKey / canonGroupKey / a private host
+// module name), never by a name the component chose, so "" there means the
+// caller built the item wrong. wazy's own decoder rejects an empty import
+// MODULE name (internal/wasm/module.go's validateImports, a deliberate wazero
+// carry-over -- graph.go rewrites component-supplied empty module names to
+// graphEmptyImportKey before decode for exactly that reason), so catching it
+// here yields a diagnostic that names the shim item instead of a decode error.
 func buildPassthroughShim(items []shimItem) ([]byte, error) {
 	if len(items) == 0 {
 		return nil, fmt.Errorf("component/instance: buildPassthroughShim: no items")
@@ -111,11 +144,8 @@ func buildPassthroughShim(items []shimItem) ([]byte, error) {
 	var funcIdx, tableIdx, memIdx, globalIdx uint32
 
 	for i, it := range items {
-		if it.FromModule == "" || it.FromName == "" {
-			return nil, fmt.Errorf("component/instance: buildPassthroughShim: item[%d] has an empty source module/name", i)
-		}
-		if it.ExportName == "" {
-			return nil, fmt.Errorf("component/instance: buildPassthroughShim: item[%d] has an empty export name", i)
+		if it.FromModule == "" {
+			return nil, fmt.Errorf("component/instance: buildPassthroughShim: item[%d] has an empty source module name", i)
 		}
 
 		switch it.Sort {

--- a/internal/component/instance/shim_test.go
+++ b/internal/component/instance/shim_test.go
@@ -236,18 +236,63 @@ func TestBuildPassthroughShim_NoItems(t *testing.T) {
 	}
 }
 
-func TestBuildPassthroughShim_EmptySourceName(t *testing.T) {
+func TestBuildPassthroughShim_EmptySourceModule(t *testing.T) {
+	// FromModule is the only name the graph synthesizes itself (a resolver key,
+	// never a component-chosen name), so "" there is a caller bug -- and wazy's
+	// decoder would otherwise reject it with a message that doesn't name the
+	// item. FromName/ExportName are component-chosen and may legitimately be ""
+	// (see TestBuildPassthroughShim_EmptyNamesRoundTrip).
 	if _, err := buildPassthroughShim([]shimItem{{Sort: shimSortFunc, FromModule: "", FromName: "x", ExportName: "y"}}); err == nil {
 		t.Fatal("expected an error for empty FromModule")
 	}
-	if _, err := buildPassthroughShim([]shimItem{{Sort: shimSortFunc, FromModule: "x", FromName: "", ExportName: "y"}}); err == nil {
-		t.Fatal("expected an error for empty FromName")
-	}
 }
 
-func TestBuildPassthroughShim_EmptyExportName(t *testing.T) {
-	if _, err := buildPassthroughShim([]shimItem{{Sort: shimSortFunc, FromModule: "x", FromName: "y", ExportName: ""}}); err == nil {
-		t.Fatal("expected an error for empty ExportName")
+// TestBuildPassthroughShim_EmptyNamesRoundTrip pins issue #25: "" is an
+// ordinary core wasm export/import field name, not a missing one, and every
+// componentize-go component contains one (wit-component's "start shim" groups
+// the guest's `_initialize` under the empty name). buildPassthroughShim used to
+// reject it outright; it must instead encode a module that really instantiates
+// and forwards the call.
+func TestBuildPassthroughShim_EmptyNamesRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	r := wazy.NewRuntime(ctx)
+	defer r.Close(ctx)
+
+	// A source module exporting "add" under the EMPTY name, so both the shim's
+	// FromName and its ExportName are "".
+	emptyNameSrc := []byte{
+		0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+		0x01, 0x07, 0x01, 0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, // type (i32,i32)->i32
+		0x03, 0x02, 0x01, 0x00, // func 0: type 0
+		0x07, 0x04, 0x01, 0x00, 0x00, 0x00, // export "" func 0
+		0x0a, 0x09, 0x01, 0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b, // body
+	}
+	if _, err := r.InstantiateWithConfig(ctx, emptyNameSrc, wazy.NewModuleConfig().WithName("src-empty").WithStartFunctions()); err != nil {
+		t.Fatalf("instantiate src: %v", err)
+	}
+
+	shimBytes, err := buildPassthroughShim([]shimItem{{
+		Sort: shimSortFunc, FromModule: "src-empty", FromName: "", ExportName: "",
+		Params: []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, Results: []api.ValueType{api.ValueTypeI32},
+	}})
+	if err != nil {
+		t.Fatalf("buildPassthroughShim: %v", err)
+	}
+
+	shim, err := r.InstantiateWithConfig(ctx, shimBytes, wazy.NewModuleConfig().WithName("shim-empty").WithStartFunctions())
+	if err != nil {
+		t.Fatalf("instantiate shim: %v", err)
+	}
+	fn := shim.ExportedFunction("")
+	if fn == nil {
+		t.Fatal(`shim has no exported function ""`)
+	}
+	results, err := fn.Call(ctx, 2, 40)
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if len(results) != 1 || results[0] != 42 {
+		t.Fatalf(`shim ""(2,40) = %v, want [42]`, results)
 	}
 }
 

--- a/internal/component/instance/wast_conformance_test.go
+++ b/internal/component/instance/wast_conformance_test.go
@@ -15,6 +15,28 @@ import (
 	"github.com/samyfodil/wazy/internal/component/binary"
 )
 
+// wastKnownSkips is the EXACT set of modules runWastSuite is still allowed to
+// fail to instantiate, per suite, with the gap each one pins. runWastSuite
+// fails when the observed set differs in either direction: a new entry is a
+// regression, and a stale entry means a gap closed and this list must shrink.
+//
+// It exists because the harness used to only t.Logf a skip. That made a real
+// bug invisible: issue #25 (buildPassthroughShim rejecting an empty export
+// name) silently skipped fused.0 and fused.3 -- the official suite reproduced
+// the reporter's failure all along, and the suite still reported PASS.
+var wastKnownSkips = map[string]map[string]string{
+	"types": {
+		"types.11.wasm": "component instantiate-arg of sort 0x4 (component type) is not resolved yet",
+	},
+	"fused": {
+		"fused.22.wasm": "a nested component's imported-instance func type is not in the importing component's type space",
+		"fused.23.wasm": "a nested component that defines no core module of its own (core instance references the parent's)",
+	},
+	"resources": {
+		"resources.14.wasm": "a component instantiate-arg naming an IMPORTED (not nested-instantiated) instance",
+	},
+}
+
 // TestWastConformance runs the official WebAssembly/component-model canonical-ABI
 // conformance suites (test/values/*.wast) through wazy. Each .wast was split by
 // `wasm-tools json-from-wast` into a spec-test manifest (module / assert_return /
@@ -31,19 +53,18 @@ import (
 //
 // strings: string edge cases + assert_trap for out-of-bounds / invalid utf-8.
 func TestWastConformance(t *testing.T) {
-	// Every official component-model suite this runtime runs end to end, with
-	// ZERO skipped modules: concat (every value kind in and out), strings
-	// (utf-8 + bounds traps), types (integer lift-narrowing + nested type-decl
-	// grammar), simple (a component importing another), fused (nested-component
-	// composition), multiple-resources (a resource defined in one nested
-	// component, imported/used/dropped-with-dtor by a sibling), and resources
-	// (guest + HOST-provided resources: constructors, methods, own/borrow
-	// transfer, destructor drop-counting, borrow-lend traps, exported canon
-	// constructors, and type/func instantiate-args). runWastSuite still logs and
-	// skips a module it can't instantiate (none currently), so a future
-	// regression surfaces as a skip rather than a silent pass. Not vendored:
-	// post-return (module_definition/module_instance linking + reentrance-trap
-	// builtins) and linking/* (multi top-level component linking).
+	// Every official component-model suite this runtime runs end to end: concat
+	// (every value kind in and out), strings (utf-8 + bounds traps), types
+	// (integer lift-narrowing + nested type-decl grammar), simple (a component
+	// importing another), fused (nested-component composition),
+	// multiple-resources (a resource defined in one nested component,
+	// imported/used/dropped-with-dtor by a sibling), and resources (guest +
+	// HOST-provided resources: constructors, methods, own/borrow transfer,
+	// destructor drop-counting, borrow-lend traps, exported canon constructors,
+	// and type/func instantiate-args). The only modules that may fail to
+	// instantiate are the ones wastKnownSkips names. Not vendored: post-return
+	// (module_definition/module_instance linking + reentrance-trap builtins) and
+	// linking/* (multi top-level component linking).
 	for _, suite := range []string{"concat", "strings", "types", "simple", "fused", "multiple-resources", "resources"} {
 		t.Run(suite, func(t *testing.T) {
 			runWastSuite(t, suite)
@@ -99,6 +120,7 @@ func runWastSuite(t *testing.T, suite string) {
 
 	var in *Instance // the "current" component (last `module` command)
 	assertsRun := 0
+	skipped := map[string]bool{}
 	for _, c := range manifest.Commands {
 		switch c.Type {
 		case "module":
@@ -119,12 +141,12 @@ func runWastSuite(t *testing.T, suite string) {
 			}
 			in, err = Instantiate(ctx, r, wasm, opts...)
 			if err != nil {
-				// A type-only validation module wazy's M1 decoder can't yet
-				// handle (e.g. "core type in instance type"). Log the gap and
-				// skip it -- following asserts on this module are skipped via
-				// the in==nil guard below; the zero-asserts check keeps a total
-				// breakage from passing silently.
+				// A gap wazy hasn't closed yet. Record it and skip the module --
+				// following asserts on it are skipped via the in==nil guard
+				// below. The wastKnownSkips reconciliation at the end of this
+				// function is what keeps that from passing silently.
 				t.Logf("SKIP module %s (line %d): %v", c.Filename, c.Line, err)
+				skipped[c.Filename] = true
 				in = nil
 			}
 
@@ -161,6 +183,16 @@ func runWastSuite(t *testing.T, suite string) {
 	}
 	if assertsRun == 0 {
 		t.Errorf("suite %s ran zero assertions -- every module failed to instantiate?", suite)
+	}
+	for f := range skipped {
+		if _, known := wastKnownSkips[suite][f]; !known {
+			t.Errorf("suite %s: %s newly fails to instantiate; see the SKIP log line above for the error", suite, f)
+		}
+	}
+	for f, why := range wastKnownSkips[suite] {
+		if !skipped[f] {
+			t.Errorf("suite %s: %s now instantiates (%s is fixed) -- drop it from wastKnownSkips", suite, f, why)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #25.

## It's a wazy bug, not a componentize-go one

`buildPassthroughShim` refused to encode a shim item whose export name (or source name) was `""`. That is not a wasm rule. A core wasm export/import field name is a `name`: an arbitrary UTF-8 byte sequence, required only to be unique within its own module. The core spec test suite says so directly — `names.wast` carries `(func (export "") (result i32) (i32.const 0))` under the comment *"Test that we can use the empty string as a symbol"*, and wazy already passes that spectest. `Module.Exports` and `resolveImports` are comma-ok map lookups, so `""` never aliases *absent*; every consumer of a shim item's name was traced before the guard came out.

Removing it is therefore the fix, not a workaround.

## Why every componentize-go component hits it

To run a reactor's `_initialize` after the whole instantiation graph is wired, `wit-component` appends a "start shim" — the last three items in the component:

```wat
(core module $start-shim-module
  (type (func))
  (import "" "" (func (type 0)))
  (start 0))
(core instance $start-shim-args        ;; <- core instance 26 in the report
  (export "" (func $start)))           ;; $start = alias of $main's "_initialize"
(core instance (instantiate $start-shim-module
  (with "" (instance $start-shim-args))))
```

Both halves of that import name are empty. The empty **module** name was already handled — `graph.go` rewrites it to `graphEmptyImportKey` before decode, because wazy's own decoder does reject empty import module names (`validateImports`, a deliberate wazero carry-over). The empty **field** name was not, so instantiation died before the guest ran. wasmtime accepts all of it, which is why the reporter never saw this elsewhere.

`FromModule` stays required, but as an internal invariant rather than a wasm rule: the graph always names a shim's source by a key it synthesized itself (`coreInstanceKey` / `canonGroupKey` / a private host module name), never by a name the component chose, so `""` there means the item was built wrong.

## The suite was already failing this, silently

`fused.wast` from the official WebAssembly/component-model suite — vendored here as `testdata/wast/fused/fused.{0,3}.wasm` — has exactly this shape and produced exactly this error. It never showed, because `runWastSuite` only `t.Logf`'d a module it could not instantiate. The harness reported PASS over **6** silent skips while its own comment claimed "ZERO skipped modules ... (none currently)".

It now reconciles the observed skip set against a `wastKnownSkips` table in both directions: a new skip fails the suite, and so does a stale entry once its gap closes. Down to 4 skips, each named with the reason it is still there.

## Verification

Reproduced with the reporter's exact artifact — the component-model book's Go adder, built with `componentize-go` 0.4.1 (`wit-component` 0.253.0) — which failed with the reported message verbatim and now returns `1 + 2 = 3`, matching the book's wasmtime output.

Tests added (each fails on the parent commit, passes here):

- `TestSynthGraph_EmptyNameStartShimRuns` — the reporter's shape exactly: only the shim's *export* name is empty. An observer core module traps unless the start shim actually **ran**, so this is not just "instantiates without error". Fails on `main` with the reported message verbatim.
- `TestSynthGraph_TwoGroupsShareTheEmptyWithName` — two different core instances bound under the empty `with` name (wit-component's fixup group and its start-shim group both are), covering the other half of the dropped guard: an empty *source* name, the `(alias core export $m "")` `fused.0` uses.
- `TestBuildPassthroughShim_EmptyNamesRoundTrip` — the encoder alone: an empty-named import re-exported under the empty name must decode, validate, and forward the call.

All synthetic, generated in Go — no new testdata file, so nothing for the scratch/BSD jobs to fail to find.

Status: `go build ./...` and `go test ./...` green; the 35 differential conformance fixtures still match their wasmtime goldens; `internal/component/instance` coverage unchanged at 90.5%; `make lint` unchanged at the 115-issue baseline; cross-compiles clean for plan9/js/wasip1/freebsd/windows/darwin and 386/arm/arm64.
