### PR TITLE
docs: add a real-world case study on a 6.5 MB Rust module

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -2,14 +2,16 @@ name: Test
 on:
   pull_request:
     branches: [main]
-    paths-ignore:  # skip when only docs or image assets change
+    paths-ignore:  # skip when only docs, image assets, or the link-checker change
       - '**/*.md'
       - '.github/assets/**'
+      - '.github/workflows/docs.yaml'
   push:
     branches: [main]
-    paths-ignore:  # skip when only docs or image assets change
+    paths-ignore:  # skip when only docs, image assets, or the link-checker change
       - '**/*.md'
       - '.github/assets/**'
+      - '.github/workflows/docs.yaml'
 
 env:  # Update this prior to requiring a higher minor version in go.mod
   GO_VERSION: "1.26"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,10 +2,10 @@ name: Docs
 on:
   pull_request:
     branches: [main]
-    paths: ['README.md']
+    paths: ['README.md', '.github/workflows/docs.yaml']
   push:
     branches: [main]
-    paths: ['README.md']
+    paths: ['README.md', '.github/workflows/docs.yaml']
 
 concurrency:
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,7 +21,9 @@ jobs:
       - name: Check README links
         uses: lycheeverse/lychee-action@v2
         with:
-          # accept rate-limit codes so a busy shields.io/pkg.go.dev doesn't red the build
-          args: --no-progress --max-retries 3 --accept 200,204,206,429 README.md
+          # accept rate-limit codes so a busy shields.io/pkg.go.dev doesn't red the
+          # build; give transient 5xx failures more time to clear with backoff
+          # instead of accepting 500 outright (which would mask a truly broken link)
+          args: --no-progress --max-retries 5 --retry-wait-time 3 --accept 200,204,206,429 README.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -2,14 +2,16 @@ name: Standard Library Integration Tests
 on:
   pull_request:
     branches: [main]
-    paths-ignore:  # skip when only docs or image assets change
+    paths-ignore:  # skip when only docs, image assets, or the link-checker change
       - '**/*.md'
       - '.github/assets/**'
+      - '.github/workflows/docs.yaml'
   push:
     branches: [main]
-    paths-ignore:  # skip when only docs or image assets change
+    paths-ignore:  # skip when only docs, image assets, or the link-checker change
       - '**/*.md'
       - '.github/assets/**'
+      - '.github/workflows/docs.yaml'
 
 defaults:
   run:  # use bash for all operating systems unless overridden

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,9 +2,10 @@ name: Release CLI
 on:
   pull_request:
     branches: [main]
-    paths-ignore:  # skip when only docs or image assets change
+    paths-ignore:  # skip when only docs, image assets, or the link-checker change
       - '**/*.md'
       - '.github/assets/**'
+      - '.github/workflows/docs.yaml'
   push:
     branches: [main]
     tags: 'v[0-9]+.[0-9]+.[0-9]+**'  # Ex. v0.2.0 v0.2.1-rc2

--- a/README.md
+++ b/README.md
@@ -60,6 +60,29 @@ wazy.HostFunc2(builder, func(ctx context.Context, mod api.Module, x, y uint32) u
 
 `HostFunc0`–`HostFunc8` and `HostProc0`–`HostProc8` cover most functions. `WithGoModuleFunction` handles the rest. All zero-allocation.
 
+### At scale: a 6.5 MB Rust module
+
+The suite above is kernels — its largest guest is a 37 KB TinyGo module. [go-anydoc][anydoc], Go bindings for a Rust document converter, reports what happens two orders of magnitude up: a 6.5 MB `wasm32-wasip1` command module (Rust 1.88, `opt-level = 3`, `wasm-opt -O3`) with a deep call graph, run as a single instantiate — stdin in, stdout out, almost no host calls, and a long stretch of compute in between.
+
+Same `.wasm`, same input, same machine, byte-identical output:
+
+| Converting | wazero v1.12.0 | wazy | |
+| --- | :---: | :---: | :---: |
+| 1 KB docx, compiled | 0.4 ms | 0.62 ms | 0.6x |
+| 5 MB docx body, compiled | 0.86 s | 0.19 s | **4.5x** |
+| 7.5 MB PDF, compiled | 3.4 s | 0.75 s | **4.5x** |
+| 1 KB docx, interpreted | 3.5 ms | 2.7 ms | 1.3x |
+| 5 MB docx body, interpreted | 11.1 s | 8.6 s | 1.3x |
+| 7.5 MB PDF, interpreted | 41.4 s | 32.6 s | 1.3x |
+
+Long compute is where the compiler wins; a document small enough that instantiation dominates goes the other way. On the same 7.5 MB PDF against other runtimes: native Rust 0.28 s, wasmtime with Cranelift 0.37 s, **wazy 0.75 s**, wasmtime with Winch 0.90 s, wazero 3.4 s — ahead of a baseline native compiler while staying pure Go.
+
+The advantage tracks memory-access intensity, and [`benchmarks/vs-wazero`](benchmarks/vs-wazero) shows the same shape one scale down: `fibonacci` a wash, `reverse_array` +4%, `random_mat_mul` +15%, `base64` +24%, `string_manipulation` +27%, this module +350%. What a micro-kernel cannot surface is size — a real module with a large working set is where the gap opens up.
+
+Switching runtimes was one import change, since the API mirrors wazero's, and the port kept cross-compilation to riscv64, ppc64le, 386 and s390x.
+
+<sub>Apple M5 Pro (18-core), 48 GB, macOS 26.5, Go 1.26.1, `CGO_ENABLED=0`, wazy `v0.0.0-20260807033006-cd2607360a17`, against `anydoc.wasm` 6,542,355 bytes. Best of 3 for the large inputs, best of 20 for the small one, excluding `CompileModule`. Reported in [#29][i29].</sub>
+
 ## The Component Model and WASI 0.2
 
 wazy runs [WebAssembly Component Model][cm] components and [WASI 0.2][wasi] — genuine `wasm32-wasip2` binaries (rustc, wasm-tools), not just core modules and not hand-written `.wat`. [wazero][wazero] targets neither. This works today, exercised by real rustc components and the official component-model test suites:
@@ -145,3 +168,5 @@ Apache 2.0. See [LICENSE](LICENSE).
 [cm]: https://component-model.bytecodealliance.org/
 [wasi]: https://wasi.dev/
 [pr679]: https://github.com/WebAssembly/component-model/pull/679
+[anydoc]: https://github.com/xusenlin/go-anydoc
+[i29]: https://github.com/samyfodil/wazy/issues/29


### PR DESCRIPTION
Follow-up to #29, as suggested there.

Adds a short case study at the end of the `Fast` section: a 6.5 MB
`wasm32-wasip1` Rust module, 4.5x over wazero on compiled execution, with the
environment and methodology so the numbers are reproducible. It also keeps the
case where wazy loses — a 1 KB document, where instantiation dominates.

Placed after `vs wazero` since it extends that argument, but happy to move it
wherever you prefer.