### PR TITLE
ci: grant the release job contents:write so it can create the draft release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,6 +134,8 @@ jobs:
     needs: pre_release_test
     name: Release
     runs-on: ubuntu-24.04
+    permissions:  # the default workflow token is read-only; gh release create needs write
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:  # Ensure release_notes.sh can see prior commits


### PR DESCRIPTION
The `v0.1.0` tag built and passed the per-OS artifact tests, then the `release` job failed:

```
HTTP 403: Resource not accessible by integration (https://api.github.com/repos/samyfodil/wazy/releases)
```

This repo's default workflow token is read-only (`default_workflow_permissions: read`), so `gh release create` cannot write a release. A job-level `permissions:` block overrides that default for the `release` job alone — the build and per-OS test jobs stay read-only, which is why this is preferable to switching the repository-wide setting to write.

The v0.1.0 draft was created manually from locally built artifacts. With this in place, the next tag produces its draft release on its own.