### PR TITLE
fix(wasm): don't cache a shared FunctionType's key from guest execution

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -257,8 +257,9 @@ func requireHostModuleEquals(t *testing.T, expected, actual *wasm.Module) {
 	for i := range expected.TypeSection {
 		tp := &expected.TypeSection[i]
 		tp.CacheNumInUint64()
-		// When creating the compiled module, we get the type IDs for types, which results in caching type keys.
-		_ = tp.String()
+		// Host module assembly caches each type's key, so a later lookup from guest execution never writes to a
+		// shared FunctionType. See wasm.FunctionType.CacheKey.
+		tp.CacheKey()
 	}
 	require.Equal(t, expected.TypeSection, actual.TypeSection)
 	require.Equal(t, expected.ImportSection, actual.ImportSection)

--- a/imports/emscripten/emscripten_test.go
+++ b/imports/emscripten/emscripten_test.go
@@ -40,6 +40,14 @@ type arbitrary struct{}
 var testCtx = context.WithValue(context.Background(), arbitrary{}, "arbitrary")
 
 // TestGrow is an integration test until we have an Emscripten example.
+// cachedKey mirrors NewInvokeFunc, which caches its type's key up front so
+// that (*InvokeFunc).Call never writes to a shared FunctionType. See
+// https://github.com/tetratelabs/wazero/issues/2520.
+func cachedKey(ft *wasm.FunctionType) *wasm.FunctionType {
+	ft.CacheKey()
+	return ft
+}
+
 func TestGrow(t *testing.T) {
 	var log bytes.Buffer
 
@@ -138,42 +146,42 @@ func TestNewFunctionExporterForModule(t *testing.T) {
 					ExportName: "invoke_v",
 					ParamTypes: []wasm.ValueType{i32},
 					ParamNames: []string{"index"},
-					Code:       wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: &wasm.FunctionType{}}},
+					Code:       wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: cachedKey(&wasm.FunctionType{})}},
 				},
 				{
 					ExportName:  "invoke_i",
 					ParamTypes:  []wasm.ValueType{i32},
 					ParamNames:  []string{"index"},
 					ResultTypes: []wasm.ValueType{i32},
-					Code:        wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: &wasm.FunctionType{Results: []wasm.ValueType{i32}}}},
+					Code:        wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: cachedKey(&wasm.FunctionType{Results: []wasm.ValueType{i32}})}},
 				},
 				{
 					ExportName:  "invoke_p",
 					ParamTypes:  []wasm.ValueType{i32},
 					ParamNames:  []string{"index"},
 					ResultTypes: []wasm.ValueType{i32},
-					Code:        wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: &wasm.FunctionType{Results: []wasm.ValueType{i32}}}},
+					Code:        wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: cachedKey(&wasm.FunctionType{Results: []wasm.ValueType{i32}})}},
 				},
 				{
 					ExportName:  "invoke_j",
 					ParamTypes:  []wasm.ValueType{i32},
 					ParamNames:  []string{"index"},
 					ResultTypes: []wasm.ValueType{i64},
-					Code:        wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: &wasm.FunctionType{Results: []wasm.ValueType{i64}}}},
+					Code:        wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: cachedKey(&wasm.FunctionType{Results: []wasm.ValueType{i64}})}},
 				},
 				{
 					ExportName:  "invoke_f",
 					ParamTypes:  []wasm.ValueType{i32},
 					ParamNames:  []string{"index"},
 					ResultTypes: []wasm.ValueType{f32},
-					Code:        wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: &wasm.FunctionType{Results: []wasm.ValueType{f32}}}},
+					Code:        wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: cachedKey(&wasm.FunctionType{Results: []wasm.ValueType{f32}})}},
 				},
 				{
 					ExportName:  "invoke_d",
 					ParamTypes:  []wasm.ValueType{i32},
 					ParamNames:  []string{"index"},
 					ResultTypes: []wasm.ValueType{f64},
-					Code:        wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: &wasm.FunctionType{Results: []wasm.ValueType{f64}}}},
+					Code:        wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: cachedKey(&wasm.FunctionType{Results: []wasm.ValueType{f64}})}},
 				},
 			},
 		},
@@ -206,7 +214,7 @@ func TestNewFunctionExporterForModule(t *testing.T) {
 					ExportName: "invoke_v",
 					ParamTypes: []wasm.ValueType{i32},
 					ParamNames: []string{"index"},
-					Code:       wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: &wasm.FunctionType{}}},
+					Code:       wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: cachedKey(&wasm.FunctionType{})}},
 				},
 			},
 		},
@@ -232,7 +240,7 @@ func TestNewFunctionExporterForModule(t *testing.T) {
 					ExportName: "invoke_v",
 					ParamTypes: []wasm.ValueType{i32},
 					ParamNames: []string{"index"},
-					Code:       wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: &wasm.FunctionType{}}},
+					Code:       wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: cachedKey(&wasm.FunctionType{})}},
 				},
 				internal.NotifyMemoryGrowth,
 			},
@@ -256,7 +264,7 @@ func TestNewFunctionExporterForModule(t *testing.T) {
 					ExportName: "invoke_vi",
 					ParamTypes: []wasm.ValueType{i32, i32},
 					ParamNames: []string{"index", "a1"},
-					Code:       wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: &wasm.FunctionType{Params: []wasm.ValueType{i32}}}},
+					Code:       wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: cachedKey(&wasm.FunctionType{Params: []wasm.ValueType{i32}})}},
 				},
 			},
 		},
@@ -283,10 +291,10 @@ func TestNewFunctionExporterForModule(t *testing.T) {
 					ParamTypes:  []wasm.ValueType{i32, i32, i32, i32, i32},
 					ParamNames:  []string{"index", "a1", "a2", "a3", "a4"},
 					ResultTypes: []wasm.ValueType{i32},
-					Code: wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: &wasm.FunctionType{
+					Code: wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: cachedKey(&wasm.FunctionType{
 						Params:  []wasm.ValueType{i32, i32, i32, i32},
 						Results: []wasm.ValueType{i32},
-					}}},
+					})}},
 				},
 			},
 		},
@@ -311,9 +319,9 @@ func TestNewFunctionExporterForModule(t *testing.T) {
 					ExportName: "invoke_viiiddiiiiii",
 					ParamTypes: []wasm.ValueType{i32, i32, i32, i32, f64, f64, i32, i32, i32, i32, i32, i32},
 					ParamNames: []string{"index", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "a10", "a11"},
-					Code: wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: &wasm.FunctionType{
+					Code: wasm.Code{GoFunc: &internal.InvokeFunc{FunctionType: cachedKey(&wasm.FunctionType{
 						Params: []wasm.ValueType{i32, i32, i32, f64, f64, i32, i32, i32, i32, i32, i32},
-					}}},
+					})}},
 				},
 			},
 		},

--- a/internal/emscripten/emscripten.go
+++ b/internal/emscripten/emscripten.go
@@ -67,6 +67,9 @@ func NewInvokeFunc(importName string, params, results []api.ValueType) *wasm.Hos
 	if len(params) > 1 {
 		fn.FunctionType.Params = wasm.FromApiValueType(params[1:])
 	}
+	// This type is shared by every instance of the host module and is looked up by Call, from guest execution on
+	// any number of goroutines. Cache its key now, while it is still exclusively owned. See FunctionType.CacheKey.
+	fn.FunctionType.CacheKey()
 
 	// Now, make friendly parameter names.
 	paramNames := make([]string, len(params))

--- a/internal/emscripten/invoke_race_test.go
+++ b/internal/emscripten/invoke_race_test.go
@@ -1,0 +1,54 @@
+package emscripten
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/samyfodil/wazy/api"
+	"github.com/samyfodil/wazy/internal/testing/require"
+	"github.com/samyfodil/wazy/internal/wasm"
+)
+
+// TestNewInvokeFunc_typeKeyIsCached is a regression test for a data race of the
+// shape of https://github.com/tetratelabs/wazero/issues/2520.
+//
+// NewInvokeFunc builds a FunctionType in Go, so it never passes through the
+// decoder's eager key caching. That type is held by the host module and shared
+// by every instance of it, while (*InvokeFunc).Call looks its ID up per call,
+// from guest execution -- so a lazily-cached key would be written concurrently.
+//
+// Run under -race: two goroutines resolving the shared type at once is exactly
+// what a pool of instances doing emscripten invoke_* calls does.
+func TestNewInvokeFunc_typeKeyIsCached(t *testing.T) {
+	hf := NewInvokeFunc("invoke_iii",
+		[]api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI32},
+		[]api.ValueType{api.ValueTypeI32})
+
+	shared := hf.Code.GoFunc.(*InvokeFunc).FunctionType
+
+	// Nothing may touch shared before the goroutines: reading its key here
+	// would populate any lazy cache and hide the very race under test.
+	//
+	// Two stores resolving the same shared type concurrently, as two module
+	// instances calling invoke_* would.
+	s1, s2 := wasm.NewStore(api.CoreFeaturesV2, nil), wasm.NewStore(api.CoreFeaturesV2, nil)
+	var wg sync.WaitGroup
+	ids := make([]wasm.FunctionTypeID, 2)
+	for i, s := range []*wasm.Store{s1, s2} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id, err := s.GetFunctionTypeID(shared)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			ids[i] = id
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, ids[0], ids[1])
+	// The key is cached up front, so no call site had to write it.
+	require.Equal(t, "i32i32_i32", shared.String())
+}

--- a/internal/wasm/binary/decoder_test.go
+++ b/internal/wasm/binary/decoder_test.go
@@ -123,10 +123,9 @@ func TestDecodeModule(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			m, e := DecodeModule(binaryencoding.EncodeModule(tc.input), api.CoreFeaturesV1, wasm.MemoryLimitPages, false, 0, false, false)
 			require.NoError(t, e)
-			// Set the FunctionType keys on the input.
+			// Set the FunctionType keys on the input, as decoding does.
 			for i := range tc.input.TypeSection {
-				tp := &(tc.input.TypeSection)[i]
-				_ = tp.String()
+				tc.input.TypeSection[i].CacheKey()
 			}
 			if len(tc.input.ImportSection) > 0 {
 				expImportPerModule := make(map[string][]*wasm.Import)

--- a/internal/wasm/binary/function.go
+++ b/internal/wasm/binary/function.go
@@ -50,13 +50,12 @@ func decodeFunctionType(enabledFeatures api.CoreFeatures, buf []byte, offset int
 	ret.Params = paramTypes
 	ret.Results = resultTypes
 
-	// Eagerly cache the key here, while decoding is single-threaded. This is NOT deferred to first use because
-	// key() lazily populates FunctionType.string, and that first population can happen concurrently: the runtime
-	// call_indirect helpers reach it through Store.GetFunctionTypeID on a *shared* FunctionType — e.g.
-	// internal/emscripten (*InvokeFunc).Call and experimental/table.LookupFunction both call key() while
-	// executing guest code, which is multi-goroutine. Populating it now makes every later key()/String() a pure
-	// read of an already-set field. key() itself is cheap (single pre-sized Builder), so eager caching is cheap.
-	_ = ret.String()
+	// Cache the key here, while decoding is single-threaded and this type is not yet shared. The runtime
+	// call_indirect helpers reach key() through Store.GetFunctionTypeID on a *shared* FunctionType — e.g.
+	// internal/emscripten (*InvokeFunc).Call and table.LookupFunction both call it while executing guest code,
+	// which is multi-goroutine — so key() itself never writes. Populating it now makes every later key()/String()
+	// a pure read. key() is cheap (single pre-sized Builder), so eager caching is cheap.
+	ret.CacheKey()
 
 	return offset, nil
 }

--- a/internal/wasm/binary/function_test.go
+++ b/internal/wasm/binary/function_test.go
@@ -86,8 +86,8 @@ func TestFunctionType(t *testing.T) {
 			var actual wasm.FunctionType
 			_, err := decodeFunctionType(api.CoreFeaturesV2, b, 0, &valueTypeArena{}, &actual)
 			require.NoError(t, err)
-			// Set the FunctionType key on the input.
-			_ = tc.input.String()
+			// Set the FunctionType key on the input, as decoding does.
+			tc.input.CacheKey()
 			require.Equal(t, actual, tc.input)
 		})
 	}

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -159,5 +159,8 @@ func (m *Module) maybeAddType(params, results []ValueType, enabledFeatures api.C
 
 	result := m.SectionElementCount(SectionIDType)
 	m.TypeSection = append(m.TypeSection, FunctionType{Params: params, Results: results})
+	// Cache the key while this host module is still being assembled, i.e. before any instance can reach it. See
+	// FunctionType.CacheKey.
+	m.TypeSection[len(m.TypeSection)-1].CacheKey()
 	return result, nil
 }

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -142,6 +142,13 @@ func TestNewHostModule(t *testing.T) {
 }
 
 func requireHostModuleEquals(t *testing.T, expected, actual *Module) {
+	// NewHostModule caches each type's key while the module is still exclusively owned, so that a later lookup
+	// from guest execution never writes to a shared FunctionType (see FunctionType.CacheKey). Do the same to the
+	// expectation, so these fixtures can stay plain literals.
+	for i := range expected.TypeSection {
+		expected.TypeSection[i].CacheKey()
+	}
+
 	// `require.Equal(t, expected, actual)` fails reflect pointers don't match, so brute compare:
 	require.Equal(t, expected.TypeSection, actual.TypeSection)
 	require.Equal(t, expected.ImportSection, actual.ImportSection)

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -930,15 +930,34 @@ func (f *FunctionType) EqualsType(other *FunctionType) bool {
 	return f.RecGroupSize == other.RecGroupSize && f.RecGroupPosition == other.RecGroupPosition
 }
 
-// key gets or generates the key for Store.typeIDs. e.g. "i32_v" for one i32 parameter and no (void) result.
+// key gets the key for Store.typeIDs. e.g. "i32_v" for one i32 parameter and no (void) result.
 //
-// The key is built with a single pre-sized strings.Builder rather than repeated string += concatenation (which
-// reallocated on every operand). Grow is pre-computed from the operand name lengths so the no-rec-group case
-// allocates exactly once; a rec-group suffix (rare) may cost one extra grow.
+// This never writes to f. A FunctionType is shared by every instance created from one CompiledModule, and key()
+// is reached from guest execution -- internal/emscripten (*InvokeFunc).Call and table.LookupFunction both call it
+// while wasm is running, on any number of goroutines. Caching here would be a data race on f.string (the shape of
+// https://github.com/tetratelabs/wazero/issues/2520). Callers that own f exclusively -- the decoder, host module
+// assembly -- call CacheKey first, which makes this a pure read from then on.
 func (f *FunctionType) key() string {
 	if f.string != "" {
 		return f.string
 	}
+	return f.buildKey()
+}
+
+// CacheKey computes and stores key(), so later key()/String() calls are pure reads.
+//
+// Call this only while f is exclusively owned, i.e. before it is reachable from a second goroutine: during decode,
+// or as a host FunctionType is constructed. It is a no-op once the key is set.
+func (f *FunctionType) CacheKey() {
+	if f.string == "" {
+		f.string = f.buildKey()
+	}
+}
+
+// buildKey generates the key. It is built with a single pre-sized strings.Builder rather than repeated string +=
+// concatenation (which reallocated on every operand). Grow is pre-computed from the operand name lengths so the
+// no-rec-group case allocates exactly once; a rec-group suffix (rare) may cost one extra grow.
+func (f *FunctionType) buildKey() string {
 	// 3 covers the worst-case separators ("v_" + "v" when both operand lists are empty).
 	n := 3
 	for _, b := range f.Params {
@@ -966,8 +985,7 @@ func (f *FunctionType) key() string {
 	if f.RecGroupSize > 1 {
 		fmt.Fprintf(&sb, "|rec%d/%d", f.RecGroupPosition, f.RecGroupSize)
 	}
-	f.string = sb.String()
-	return f.string
+	return sb.String()
 }
 
 // String implements fmt.Stringer.

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -35,7 +35,16 @@ func TestFunctionType_String(t *testing.T) {
 		t.Run(tc.functype.String(), func(t *testing.T) {
 			require.Equal(t, tc.exp, tc.functype.String())
 			require.Equal(t, tc.exp, tc.functype.key())
+
+			// Reading the key must not write it: a FunctionType is shared
+			// across instances and read from guest execution on many
+			// goroutines. Only CacheKey, called while exclusively owned,
+			// populates it. See FunctionType.CacheKey.
+			require.Equal(t, "", tc.functype.string)
+
+			tc.functype.CacheKey()
 			require.Equal(t, tc.exp, tc.functype.string)
+			require.Equal(t, tc.exp, tc.functype.String())
 		})
 	}
 }


### PR DESCRIPTION
`FunctionType.key()` cached its result into `f.string` on first read:

```go
func (f *FunctionType) key() string {
	if f.string != "" {
		return f.string
	}
	...
	f.string = sb.String()   // written from wherever key() was first called
	return f.string
}
```

A `FunctionType` is shared by every instance created from one `CompiledModule`, and `key()` is reached **while wasm is running** — `internal/emscripten`'s `(*InvokeFunc).Call` resolves a type ID on every `invoke_*` call, and `table.LookupFunction` does the same. Two instances calling concurrently raced on that field. This is [tetratelabs/wazero#2520](https://github.com/tetratelabs/wazero/issues/2520).

## Why the existing mitigation didn't cover it

The binary decoder already cached keys eagerly, with a comment naming this exact hazard — so every type that comes from a decoded module was safe. But a `FunctionType` built in Go never passes through the decoder. `NewInvokeFunc` builds one per `invoke_*` import:

```go
fn := &InvokeFunc{&wasm.FunctionType{Results: wasm.FromApiValueType(results)}}
```

It lives in the host module, is shared by every instance of it, and is not part of any `TypeSection` — so nothing pre-cached it, and the first `Call` on each goroutine wrote it. That is the pooled-instances-plus-emscripten shape upstream hit.

## The fix

`key()` becomes a pure read: cached value if present, otherwise compute and return without storing. Callers that own the type exclusively call the new `CacheKey()` to keep the fast path — the decoder (as before), host module assembly in `maybeAddType`, and `NewInvokeFunc`.

Correctness no longer depends on remembering to pre-cache: a type nobody cached just recomputes its key, which is a pre-sized single-allocation build. Pre-caching is now only about speed.

## Verification

`internal/emscripten.TestNewInvokeFunc_typeKeyIsCached` races two stores resolving one `NewInvokeFunc` type, as a pool of instances doing `invoke_*` calls would. Against the previous code it fails:

```
WARNING: DATA RACE
  wasm.(*FunctionType).key()  module.go:944   (write)
  wasm.(*FunctionType).key()  module.go:941   (read)
```

and passes with this change. The test deliberately touches nothing on the shared type before the goroutines start — reading its key first would populate the cache and hide the race.

Full suite green; `-race` green on `internal/wasm`, `internal/emscripten`, `imports/emscripten` and the root package; golangci-lint v1.64.5 clean.

Test fixtures that asserted the old contract were updated: several compared whole `FunctionType` structs and relied on a read populating `string` as a side effect, which is precisely the behaviour being removed. `TestFunctionType_String` now pins the new invariant — a read leaves the field empty, `CacheKey` fills it.
