### PR TITLE
fix: resolve type IDs against the instantiating store

### DIFF
--- a/config.go
+++ b/config.go
@@ -388,6 +388,9 @@ type compiledModule struct {
 	// closeWithModule prevents leaking compiled code when a module is compiled implicitly.
 	closeWithModule bool
 	typeIDs         []wasm.FunctionTypeID
+	// typeIDStore is the store that assigned typeIDs. Type IDs are interned per store, in the order that store saw
+	// types, so they only mean anything to it -- see runtime.InstantiateModule.
+	typeIDStore *wasm.Store
 }
 
 // Name implements CompiledModule.Name

--- a/runtime.go
+++ b/runtime.go
@@ -351,6 +351,7 @@ func (r *runtime) CompileModule(ctx context.Context, binary []byte) (CompiledMod
 		return nil, err
 	}
 	c.typeIDs = typeIDs
+	c.typeIDStore = r.store
 
 	if !hasCompiled {
 		// On a miss, CompileModule performs its own (single) probe of memory
@@ -449,8 +450,19 @@ func (r *runtime) InstantiateModule(
 		name = code.module.NameSection.ModuleName
 	}
 
+	// Type IDs are interned per store, in the order that store saw types, so code.typeIDs mean nothing to another
+	// store. A CompiledModule reaches one when two runtimes share a compilation cache, and import checks compare
+	// type IDs, so stale ones reject structurally identical signatures. Re-resolve in that case; when this is the
+	// store that assigned them, they are already this store's.
+	typeIDs := code.typeIDs
+	if code.typeIDStore != r.store {
+		if typeIDs, err = r.store.GetFunctionTypeIDs(code.module.TypeSection); err != nil {
+			return nil, err
+		}
+	}
+
 	// Instantiate the module.
-	mod, err = r.store.Instantiate(ctx, code.module, name, sysCtx, code.typeIDs)
+	mod, err = r.store.Instantiate(ctx, code.module, name, sysCtx, typeIDs)
 	if err != nil {
 		// If there was an error, don't leak the compiled module.
 		if code.closeWithModule {

--- a/runtime_typeid_test.go
+++ b/runtime_typeid_test.go
@@ -1,0 +1,71 @@
+package wazy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samyfodil/wazy/api"
+	"github.com/samyfodil/wazy/internal/testing/binaryencoding"
+	"github.com/samyfodil/wazy/internal/testing/require"
+	"github.com/samyfodil/wazy/internal/wasm"
+)
+
+// TestInstantiateModule_typeIDsAreThisStores is a regression test for
+// https://github.com/tetratelabs/wazero/issues/2511.
+//
+// A CompiledModule caches the type IDs the compiling store assigned, in the
+// order that store saw types. Instantiating it on a different runtime -- what
+// sharing a compilation cache amounts to -- meant checking imports against
+// IDs that mean nothing to the instantiating store, so structurally identical
+// signatures were rejected.
+func TestInstantiateModule_typeIDsAreThisStores(t *testing.T) {
+	ctx := context.Background()
+
+	// Declares three types so the imported one is at a non-zero index. A store
+	// that registers only the imported signature assigns it ID 0, while the
+	// compiling store assigned it 2.
+	guest := binaryencoding.EncodeModule(&wasm.Module{
+		TypeSection: []wasm.FunctionType{
+			{Params: []wasm.ValueType{wasm.ValueTypeI32}, Results: []wasm.ValueType{wasm.ValueTypeI32}},
+			{Params: []wasm.ValueType{wasm.ValueTypeI64}, Results: []wasm.ValueType{wasm.ValueTypeI64}},
+			// Index 2: the imported signature.
+			{Params: []wasm.ValueType{wasm.ValueTypeI32, wasm.ValueTypeI64}, Results: []wasm.ValueType{wasm.ValueTypeI64}},
+		},
+		ImportSection:   []wasm.Import{{Module: "env", Name: "proxy", Type: wasm.ExternTypeFunc, DescFunc: 2}},
+		FunctionSection: []wasm.Index{0},
+		CodeSection:     []wasm.Code{{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeEnd}}},
+		ExportSection:   []wasm.Export{{Name: "echo", Type: wasm.ExternTypeFunc, Index: 1}},
+	})
+
+	// Two runtimes sharing a compilation cache: this is what lets a module
+	// compiled by one be instantiated by the other, and it is the pattern the
+	// cache exists for.
+	cache := NewCompilationCache()
+	defer cache.Close(ctx)
+	config := NewRuntimeConfig().WithCompilationCache(cache)
+
+	// Compile on one runtime.
+	compiler := NewRuntimeWithConfig(ctx, config)
+	defer compiler.Close(ctx)
+	compiled, err := compiler.CompileModule(ctx, guest)
+	require.NoError(t, err)
+
+	// Instantiate on another, whose store has only ever seen the imported
+	// signature, so its IDs differ from the compiling store's.
+	r := NewRuntimeWithConfig(ctx, config)
+	defer r.Close(ctx)
+
+	_, err = HostFunc2(r.NewHostModuleBuilder("env").NewFunctionBuilder(),
+		func(_ context.Context, _ api.Module, x uint32, y uint64) uint64 {
+			return uint64(x) + y
+		}).Export("proxy").Instantiate(ctx)
+	require.NoError(t, err)
+
+	mod, err := r.InstantiateModule(ctx, compiled, NewModuleConfig())
+	require.NoError(t, err)
+	defer mod.Close(ctx)
+
+	results, err := mod.ExportedFunction("echo").Call(ctx, 42)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), results[0])
+}


### PR DESCRIPTION
`InstantiateModule` passed `code.typeIDs` — the type IDs assigned by whichever store *compiled* the module:

```go
mod, err = r.store.Instantiate(ctx, code.module, name, sysCtx, code.typeIDs)
```

Type IDs are interned per store, in the order that store happened to see types, so they mean nothing to another store. Import checks compare them, so when a `CompiledModule` is instantiated by a different store, structurally identical signatures are rejected — with an error that contradicts itself:

```
import func[env.proxy]: signature mismatch: i32i64_i64 != i32i64_i64
```

This is [tetratelabs/wazero#2511](https://github.com/tetratelabs/wazero/pull/2511), a regression from the typed-function-references work, which wazy also carries.

## When it bites

A `CompiledModule` reaches a second store when two runtimes **share a compilation cache** — which is the pattern the cache exists for, and the only way wazy allows it at all: without a shared cache the engine refuses outright with `source module must be compiled before instantiation`, so the two runtimes in the regression test share one.

The mismatch needs the two stores to have seen types in different orders, so it is order-dependent rather than deterministic — a module whose imported signature sits at a non-zero type index, instantiated on a store that assigned that signature a different ID.

## The fix

Re-resolve the IDs against the instantiating store when it is not the store that assigned them:

```go
typeIDs := code.typeIDs
if code.typeIDStore != r.store {
	if typeIDs, err = r.store.GetFunctionTypeIDs(code.module.TypeSection); err != nil {
		return nil, err
	}
}
```

`compiledModule` now records which store assigned its IDs. Upstream re-resolves unconditionally; the identity check keeps the common path — same runtime compiles and instantiates — exactly as it was, so instantiation does not pay a per-type map lookup it cannot need. Types are interned, so re-resolving on the same store would return identical IDs anyway; this just skips the work.

## Verification

`TestInstantiateModule_typeIDsAreThisStores` compiles on one runtime and instantiates on another through a shared cache, then calls the export. Against the previous code it fails with the `i32i64_i64 != i32i64_i64` mismatch above; with this change it passes.

Full suite green; golangci-lint v1.64.5 clean.
