### PR TITLE
fix(sys): allow fd_renumber onto the stdio slots

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -2480,6 +2480,40 @@ func Test_fdRenumber(t *testing.T) {
 `,
 		},
 		{
+			// The stdio slots are preopens, but they are streams rather than
+			// path-resolution roots, so renumbering onto one is allowed: this
+			// is what wasi-libc's freopen does, via dup3. See
+			// https://github.com/tetratelabs/wazero/issues/2518.
+			name:          "to=stdin",
+			from:          fileFD,
+			to:            sys.FdStdin,
+			expectedErrno: wasip1.ErrnoSuccess,
+			expectedLog: `
+==> wasi_snapshot_preview1.fd_renumber(fd=4,to=0)
+<== errno=ESUCCESS
+`,
+		},
+		{
+			name:          "to=stdout",
+			from:          fileFD,
+			to:            sys.FdStdout,
+			expectedErrno: wasip1.ErrnoSuccess,
+			expectedLog: `
+==> wasi_snapshot_preview1.fd_renumber(fd=4,to=1)
+<== errno=ESUCCESS
+`,
+		},
+		{
+			name:          "from=stderr",
+			from:          sys.FdStderr,
+			to:            fileFD,
+			expectedErrno: wasip1.ErrnoSuccess,
+			expectedLog: `
+==> wasi_snapshot_preview1.fd_renumber(fd=2,to=4)
+<== errno=ESUCCESS
+`,
+		},
+		{
 			name:          "file to dir",
 			from:          fileFD,
 			to:            dirFD,

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -308,11 +308,26 @@ func (c *FSContext) OpenFile(fs sys.FS, path string, flag sys.Oflag, perm fs.Fil
 }
 
 // Renumber assigns the file pointed by the descriptor `from` to `to`.
+// isDirPreopen reports whether fd is a pre-opened *directory*, the thing
+// Renumber must refuse: removing one breaks path resolution for every relative
+// path underneath it.
+//
+// The stdio slots are registered as preopens too (see stdio.go), but they are
+// streams, not roots, and the WASI spec carves out nothing for them. Refusing
+// them breaks wasi-libc's freopen, which is open-then-dup3 with dup3 backed by
+// fd_renumber: freopen(path, mode, stdin) would fail, and musl's failure path
+// then closes the original stream, leaving the guest with no stdin at all.
+// wasmtime allows renumbering the stdio slots. See
+// https://github.com/tetratelabs/wazero/issues/2518.
+func isDirPreopen(f *FileEntry, fd int32) bool {
+	return f.IsPreopen && fd > FdStderr
+}
+
 func (c *FSContext) Renumber(from, to int32) sys.Errno {
 	fromFile, ok := c.openedFiles.Lookup(from)
 	if !ok || to < 0 {
 		return sys.EBADF
-	} else if fromFile.IsPreopen {
+	} else if isDirPreopen(fromFile, from) {
 		return sys.ENOTSUP
 	}
 
@@ -322,7 +337,7 @@ func (c *FSContext) Renumber(from, to int32) sys.Errno {
 	// https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_renumberfd-fd-to-fd---errno
 	// https://github.com/bytecodealliance/wasmtime/blob/main/crates/wasi-common/src/snapshots/preview_1.rs#L531-L546
 	if toFile, ok := c.openedFiles.Lookup(to); ok {
-		if toFile.IsPreopen {
+		if isDirPreopen(toFile, to) {
 			return sys.ENOTSUP
 		}
 		_ = toFile.File.Close()

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -286,6 +286,38 @@ func TestFSContext_Renumber(t *testing.T) {
 		// Both are preopen.
 		require.Equal(t, sys.ENOTSUP, fsc.Renumber(3, 3))
 	})
+
+	// The stdio slots are registered as preopens, but they are streams, not
+	// roots. Refusing them breaks wasi-libc's freopen, whose dup3 is
+	// fd_renumber. See https://github.com/tetratelabs/wazero/issues/2518.
+	t.Run("stdio", func(t *testing.T) {
+		for _, stdioFd := range []int32{FdStdin, FdStdout, FdStderr} {
+			// A preopen, like a directory root, but renumberable.
+			stdio, ok := fsc.LookupFile(stdioFd)
+			require.True(t, ok)
+			require.True(t, stdio.IsPreopen)
+
+			// Renumbering onto it replaces it, which is what freopen needs.
+			fromFd, errno := fsc.OpenFile(dirFS, dirName, sys.O_RDONLY, 0)
+			require.EqualErrno(t, 0, errno)
+			opened, ok := fsc.LookupFile(fromFd)
+			require.True(t, ok)
+
+			require.EqualErrno(t, 0, fsc.Renumber(fromFd, stdioFd))
+
+			replaced, ok := fsc.LookupFile(stdioFd)
+			require.True(t, ok)
+			require.Equal(t, opened, replaced)
+
+			_, ok = fsc.LookupFile(fromFd)
+			require.False(t, ok)
+
+			// And renumbering it away works too: it is an ordinary stream.
+			require.EqualErrno(t, 0, fsc.Renumber(stdioFd, 200+stdioFd))
+			_, ok = fsc.LookupFile(stdioFd)
+			require.False(t, ok)
+		}
+	})
 }
 
 // This is similar to https://github.com/WebAssembly/wasi-testsuite/blob/ac32f57400cdcdd0425d3085c24fc7fc40011d1c/tests/rust/src/bin/fd_readdir.rs#L120


### PR DESCRIPTION
The stdio descriptors are registered as preopens (`internal/sys/stdio.go`), and `Renumber` refused any renumbering whose source or target was a preopen:

```go
} else if fromFile.IsPreopen {
	return sys.ENOTSUP
}
...
if toFile.IsPreopen {
	return sys.ENOTSUP
}
```

That guard exists for **directory** preopens, whose removal breaks path resolution for every relative path beneath them. The stdio slots are streams, not roots, and the WASI spec carves out nothing for them.

## Why it matters

wasi-libc implements `freopen` as open-the-new-file-then-`dup3`-onto-the-old-fd, and its `dup3` is backed by `fd_renumber`. So a guest calling `freopen(path, "r", stdin)` got `ENOTSUP` — and musl's failure path then `fclose`s the original stream, so the guest ends up with **no stdin at all** rather than a redirected one. wasmtime permits renumbering onto the stdio slots.

Upstream reports this breaking a real module: PGlite's WASI build of PostgreSQL replays its initdb bootstrap by `freopen`ing a script onto stdin, and dies with `input in flex scanner failed`. See [tetratelabs/wazero#2518](https://github.com/tetratelabs/wazero/issues/2518).

## The fix

Scope the guard to directory preopens:

```go
func isDirPreopen(f *FileEntry, fd int32) bool {
	return f.IsPreopen && fd > FdStderr
}
```

Applied to both ends, since the reasoning is symmetric: a stdio slot is an ordinary stream whether it is the source or the target of the renumber. Directory preopens are still refused exactly as before.

## Verification

Two levels, both failing before this change and passing after:

- `internal/sys.TestFSContext_Renumber/stdio` — renumbering onto each of fds 0/1/2 replaces the entry (what freopen needs), and renumbering one away works too. The existing directory-preopen cases are untouched and still return `ENOTSUP`.
- `wasi_snapshot_preview1.Test_fdRenumber` — new `to=stdin`, `to=stdout` and `from=stderr` cases, asserting `ESUCCESS` and the host-function log, next to the unchanged `from=preopen` / `to=preopen` cases.

Full suite green, including the WASI conformance tests; golangci-lint v1.64.5 clean.
