### PR TITLE
perf(component): cut per-request allocations on the component ABI path, and fix resource leaks in three host implementations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@ WebAssembly runtime for Go.
 - `api/` — stable API types shared across the tree.
 - `experimental/` — opt-in, unstable API.
 - `imports/wasi_snapshot_preview1/` — WASI preview1 host module.
+- `component/` — the public Component Model API (`Instantiate`, host imports, value shapes).
+- `internal/component/` — the component implementation: `binary/` decoding, `abi/` canonical lift/lower, `instance/` graph instantiation and resources.
+- `imports/wasip2/` — WASI 0.2 host implementation, written against the public `component` API.
 - `internal/engine/native/` — the optimizing compiler (amd64 + arm64 JIT).
 - `internal/engine/interpreter/` — the portable interpreter (fallback where the compiler is unsupported).
 - `internal/sysfs/` — host filesystem; `internal/wasip1/` — WASI wire layer.
@@ -49,8 +52,23 @@ Use the Makefile; it encodes the real invocations.
 - **Fresh-checkout CI:** some integration suites (libsodium, stdlibs) download or
   compile fixtures into git-ignored `testdata/` dirs. Code that `//go:embed`s such a
   dir must sit behind a build tag, or a clean checkout won't compile.
-- **Host functions:** use the generic, reflection-free `HostFunc0..8` / `HostProc0..8`
+- **Host functions:** use the generic, reflection-free `HostFunc0..16` / `HostProc0..16`
   in `host_typed.go`. Do not reintroduce `reflect`-based host dispatch.
+- **Component value shapes:** a `record`/`tuple` is a `[]Value` in declaration order,
+  a `variant` a `VariantValue`, a `result` a `ResultValue`, an `option` `nil` or the
+  inner value. A `list` of a fixed-width primitive is the Go slice of that primitive
+  (`[]byte`, `[]uint32`, `[]float64`, `[]bool`, `[]rune`); every other list is a
+  `[]Value`. Read one with `component.ListOf[T]`, which takes either shape and does
+  not copy the typed one. Lowering accepts both, so only *reading* a list cares.
+- **Component ABI hot paths:** the lift/lower tree runs per value per call, so an
+  allocation there is an allocation per request. Two habits it has been burned by:
+  boxing a value type into an interface inside a recursive walk, and building a
+  structure only to read its length (`FlatWidth` exists because `Flatten` was being
+  called for `len`). `BenchmarkServeHTTP` in `imports/wasip2` guards the total.
+- **Host resources:** a `WithResourceTag` without a matching `WithHostResourceDtor`
+  leaks — the handle goes away and the host state it named does not. Destructors for
+  one tag compose, since `wasi:filesystem`, `wasi:sockets` and `wasi:http` all mint
+  streams under the shared stream tags.
 - **arm64:** JIT changes must be verified on arm64. Under emulation:
   `GOARCH=arm64 CGO_ENABLED=0 go test ./internal/engine/native/...` (needs qemu-user).
 - **wasip1 FS semantics:** the stdlib suite

--- a/component/component.go
+++ b/component/component.go
@@ -76,8 +76,12 @@ func NewCompileCache() *CompileCache { return instance.NewCompileCache() }
 
 // Value is a component-level call value: a Go value matching the Canonical
 // ABI's lifting of a WIT type (uint32, int64, float64, string, []any for
-// lists/records/tuples, uint32 for resource handles). It is the element type of
-// Call/CallExport arguments and results and of host-import args/results.
+// records/tuples and for lists of anything but a fixed-width primitive,
+// uint32 for resource handles). It is the element type of Call/CallExport
+// arguments and results and of host-import args/results.
+//
+// A list of a fixed-width primitive is the Go slice of that primitive rather
+// than a []Value -- see ListDesc in types.go.
 type Value = abi.Value
 
 // TypeDesc, PrimitiveDesc, and the rest of the WIT type vocabulary live in

--- a/component/list.go
+++ b/component/list.go
@@ -1,0 +1,60 @@
+package component
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// ListOf returns a list Value as a []T.
+//
+// A list of a fixed-width primitive lifts to the Go slice of that primitive
+// (see ListDesc), so a host function reading one can take it directly. Lists
+// of anything else -- strings, records, nested lists -- lift as []Value, and a
+// caller wanting []string or []MyRecord has to walk them. ListOf does both:
+//
+//	names, err := component.ListOf[string](args[0])   // list<string>
+//	sizes, err := component.ListOf[uint32](args[1])   // list<u32>
+//
+// The typed shape costs nothing -- it is returned as it arrived, not copied --
+// so this is not a slow compatibility wrapper for the case it was written for.
+//
+// It also accepts the []Value shape for a scalar list, which is what a host
+// function written before lists were typed will have been asserting, and what
+// a caller building one by hand still produces. Converting between the two is
+// what the slower path does, element by element.
+//
+// An element that is not a T, and cannot be converted to one, is an error
+// naming its index: a list is not a place to guess.
+func ListOf[T any](v Value) ([]T, error) {
+	// Already the requested shape. This is the whole point of the typed rule
+	// and has to stay allocation-free.
+	if typed, ok := v.([]T); ok {
+		return typed, nil
+	}
+
+	vals, ok := v.([]Value)
+	if !ok {
+		var zero T
+		return nil, fmt.Errorf("component: expected a list of %T, got %T", zero, v)
+	}
+
+	out := make([]T, len(vals))
+	target := reflect.TypeOf(out).Elem()
+	for i, e := range vals {
+		if t, ok := e.(T); ok {
+			out[i] = t
+			continue
+		}
+		// A scalar arrives in the element Value shape, which is widened: a
+		// u16 element is a uint32, an s8 an int32. Converting narrows it back
+		// to the T the caller asked for, and cannot lose anything, since the
+		// value came from a field of that width.
+		ev := reflect.ValueOf(e)
+		if !ev.IsValid() || !ev.CanConvert(target) {
+			var zero T
+			return nil, fmt.Errorf("component: list element %d is %T, want %T", i, e, zero)
+		}
+		out[i] = ev.Convert(target).Interface().(T)
+	}
+	return out, nil
+}

--- a/component/list_test.go
+++ b/component/list_test.go
@@ -1,0 +1,143 @@
+package component_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/samyfodil/wazy/component"
+)
+
+// ListOf exists so a host function can read a list without caring which of the
+// two shapes it arrived in: the typed slice a scalar list lifts to, or the
+// []Value everything else lifts to and older host functions still hand over.
+
+func TestListOfTypedShape(t *testing.T) {
+	in := []uint32{1, 2, 3}
+
+	got, err := component.ListOf[uint32](component.Value(in))
+	if err != nil {
+		t.Fatalf("ListOf: %v", err)
+	}
+	if len(got) != 3 || got[0] != 1 || got[2] != 3 {
+		t.Fatalf("got %v, want [1 2 3]", got)
+	}
+
+	// The typed shape is returned as it arrived. A copy would make the fast
+	// path quietly as expensive as the slow one.
+	if &got[0] != &in[0] {
+		t.Error("the typed slice was copied; it should be returned as-is")
+	}
+}
+
+func TestListOfValueShape(t *testing.T) {
+	// What a host function written before typed lists hands over, and what
+	// lifting still produces for a list of anything but a fixed-width scalar.
+	vals := []component.Value{uint32(1), uint32(2), uint32(3)}
+
+	got, err := component.ListOf[uint32](vals)
+	if err != nil {
+		t.Fatalf("ListOf: %v", err)
+	}
+	if len(got) != 3 || got[1] != 2 {
+		t.Fatalf("got %v, want [1 2 3]", got)
+	}
+}
+
+// A scalar element arrives widened -- a u16 as uint32, an s8 as int32 -- so
+// asking for the narrow type has to convert rather than fail.
+func TestListOfNarrowsWidenedScalars(t *testing.T) {
+	t.Run("u16 from uint32", func(t *testing.T) {
+		got, err := component.ListOf[uint16]([]component.Value{uint32(1), uint32(0xFFFF)})
+		if err != nil {
+			t.Fatalf("ListOf: %v", err)
+		}
+		if got[1] != 0xFFFF {
+			t.Errorf("got %v, want [1 65535]", got)
+		}
+	})
+
+	t.Run("s8 from int32", func(t *testing.T) {
+		got, err := component.ListOf[int8]([]component.Value{int32(-128), int32(127)})
+		if err != nil {
+			t.Fatalf("ListOf: %v", err)
+		}
+		if got[0] != -128 || got[1] != 127 {
+			t.Errorf("got %v, want [-128 127]", got)
+		}
+	})
+}
+
+// The case with no typed shape at all: a list of strings is always []Value, and
+// walking it is exactly what this saves a caller from writing.
+func TestListOfStrings(t *testing.T) {
+	got, err := component.ListOf[string]([]component.Value{"a", "b"})
+	if err != nil {
+		t.Fatalf("ListOf: %v", err)
+	}
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("got %v, want [a b]", got)
+	}
+}
+
+func TestListOfFloatsAndBools(t *testing.T) {
+	fs, err := component.ListOf[float64]([]component.Value{1.5, math.Inf(1)})
+	if err != nil {
+		t.Fatalf("floats: %v", err)
+	}
+	if fs[0] != 1.5 || !math.IsInf(fs[1], 1) {
+		t.Errorf("got %v", fs)
+	}
+
+	bs, err := component.ListOf[bool]([]component.Value{true, false})
+	if err != nil {
+		t.Fatalf("bools: %v", err)
+	}
+	if !bs[0] || bs[1] {
+		t.Errorf("got %v, want [true false]", bs)
+	}
+}
+
+func TestListOfEmpty(t *testing.T) {
+	got, err := component.ListOf[uint32]([]component.Value{})
+	if err != nil {
+		t.Fatalf("ListOf: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want an empty list", got)
+	}
+}
+
+// Failures name what was wrong and where, since a list of the wrong thing is a
+// mistake in the host function's idea of the WIT, not a runtime condition.
+func TestListOfErrors(t *testing.T) {
+	t.Run("not a list", func(t *testing.T) {
+		if _, err := component.ListOf[uint32](component.Value("nope")); err == nil {
+			t.Error("expected an error for a non-list value")
+		}
+	})
+
+	t.Run("element of an unconvertible type", func(t *testing.T) {
+		_, err := component.ListOf[uint32]([]component.Value{uint32(1), "two"})
+		if err == nil {
+			t.Fatal("expected an error for a string element")
+		}
+		if want := "element 1"; !contains(err.Error(), want) {
+			t.Errorf("error %q should name the offending index (%q)", err, want)
+		}
+	})
+
+	t.Run("bool is not a number", func(t *testing.T) {
+		if _, err := component.ListOf[uint32]([]component.Value{true}); err == nil {
+			t.Error("expected an error converting bool to uint32")
+		}
+	})
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/component/types.go
+++ b/component/types.go
@@ -58,8 +58,14 @@ type (
 	RecordDesc = binary.RecordDesc
 	// VariantDesc is a discriminated union. Its Value is a VariantValue.
 	VariantDesc = binary.VariantDesc
-	// ListDesc is an unbounded sequence. Its Value is a []Value -- or, for
-	// list<u8> specifically, a []byte, which lowers with a single copy.
+	// ListDesc is an unbounded sequence. Its Value is the Go slice of the
+	// element type when that element is a fixed-width primitive -- []byte for
+	// list<u8>, []uint32 for list<u32>, []float64 for list<f64>, []bool,
+	// []rune for list<char>, and so on -- and a []Value otherwise, as for a
+	// list of strings or of records.
+	//
+	// Both shapes are accepted when lowering a scalar list, so a host func
+	// may hand over either; lifting produces the typed one.
 	ListDesc = binary.ListDesc
 	// TupleDesc is a positional product type. Its Value is a []Value.
 	TupleDesc = binary.TupleDesc

--- a/examples/custom-wit/README.md
+++ b/examples/custom-wit/README.md
@@ -55,9 +55,25 @@ drop, which then fails with a cross-type error that doesn't mention tags.
 **Values have shapes.** A `record` and a `tuple` arrive as `[]Value` in
 declaration order; a `variant` is a `VariantValue{Disc, Payload}`; a `result`
 is a `ResultValue{IsErr, Payload}`; `option` is `nil` for none or the inner
-value for some; `list<u8>` arrives as `[]byte`. Note that returning a Go
-`error` from a host func *traps the guest* — a WIT-declared failure is a
-`ResultValue` with `IsErr` set, which is an ordinary value the guest handles.
+value for some.
+
+A `list` of a fixed-width primitive arrives as the Go slice of that primitive —
+`[]byte` for `list<u8>`, `[]uint32` for `list<u32>`, and so on — while a list of
+anything else, `list<string>` included, arrives as `[]Value`. `component.ListOf`
+reads either:
+
+```go
+value, err := component.ListOf[byte](args[2])    // list<u8>
+keys, err := component.ListOf[string](args[0])   // list<string>
+```
+
+It returns the typed shape as it arrived rather than copying, so reaching for it
+costs nothing when the list is already typed. Both shapes are accepted when you
+*return* a list, so a host func producing one can hand over whichever it has.
+
+Note that returning a Go `error` from a host func *traps the guest* — a
+WIT-declared failure is a `ResultValue` with `IsErr` set, which is an ordinary
+value the guest handles.
 
 ## Testing host funcs without a guest
 

--- a/examples/custom-wit/custom_wit.go
+++ b/examples/custom-wit/custom_wit.go
@@ -97,7 +97,11 @@ func main() {
 		if !ok {
 			return nil, fmt.Errorf("put: bucket rep %d does not exist", rep)
 		}
-		value, err := bytesOf(args[2])
+		// list<u8> arrives as a []byte -- a list of any fixed-width primitive
+		// lifts to the Go slice of that primitive. ListOf takes that shape as
+		// it is, and converts the general []Value shape a value built by hand
+		// still has.
+		value, err := component.ListOf[byte](args[2])
 		if err != nil {
 			return nil, fmt.Errorf("put %q: %w", key, err)
 		}
@@ -178,26 +182,4 @@ func main() {
 		log.Panicln(err)
 	}
 	fmt.Printf("guest: %s\n", results[0].(string))
-}
-
-// bytesOf reads a lifted list<u8>. The ABI hands one over as a []byte when it
-// can (a single copy, rather than one interface per byte), but a value built
-// elsewhere may still arrive in the general []Value shape, so accept both.
-func bytesOf(v component.Value) ([]byte, error) {
-	switch t := v.(type) {
-	case []byte:
-		return t, nil
-	case []component.Value:
-		out := make([]byte, len(t))
-		for i, e := range t {
-			b, ok := e.(uint32)
-			if !ok {
-				return nil, fmt.Errorf("list<u8>[%d]: expected u8, got %T", i, e)
-			}
-			out[i] = byte(b)
-		}
-		return out, nil
-	default:
-		return nil, fmt.Errorf("expected list<u8>, got %T", v)
-	}
 }

--- a/imports/wasi_otel/lift.go
+++ b/imports/wasi_otel/lift.go
@@ -200,36 +200,33 @@ func (l *lifter) optStr(v component.Value, what string) *string {
 	return &s
 }
 
-// f64s lifts a list<f64>, which arrives as a []float64 -- the typed slice a
-// list of a fixed-width primitive lifts to -- or as the general []Value shape
-// from a caller that built one by hand.
+// f64s lifts a list<f64>, and u64s a list<u64>.
+//
+// Both go through component.ListOf, which takes either shape a list can
+// arrive in -- the typed slice a list of a fixed-width primitive lifts to, or
+// the general []Value -- and returns the typed one without copying when it is
+// already that. Spelling the conversion out here instead would be the same
+// code an embedder would have to write, which is what the helper exists to
+// spare them.
 func (l *lifter) f64s(v component.Value, what string) []float64 {
-	if l.err != nil || v == nil {
-		return nil
-	}
-	if typed, ok := v.([]float64); ok {
-		return typed
-	}
-	items := l.list(v, what)
-	out := make([]float64, len(items))
-	for i, item := range items {
-		out[i] = l.f64(item, what)
-	}
-	return out
+	return liftTypedList[float64](l, v, what)
 }
 
-// u64s lifts a list<u64>, in either shape, as f64s does.
 func (l *lifter) u64s(v component.Value, what string) []uint64 {
+	return liftTypedList[uint64](l, v, what)
+}
+
+// liftTypedList folds component.ListOf into the lifter's error accumulation,
+// so a malformed list reports like every other malformed field rather than
+// unwinding separately.
+func liftTypedList[T any](l *lifter, v component.Value, what string) []T {
 	if l.err != nil || v == nil {
 		return nil
 	}
-	if typed, ok := v.([]uint64); ok {
-		return typed
-	}
-	items := l.list(v, what)
-	out := make([]uint64, len(items))
-	for i, item := range items {
-		out[i] = l.u64(item, what)
+	out, err := component.ListOf[T](v)
+	if err != nil {
+		l.fail("%s: %v", what, err)
+		return nil
 	}
 	return out
 }

--- a/imports/wasi_otel/lift.go
+++ b/imports/wasi_otel/lift.go
@@ -200,6 +200,40 @@ func (l *lifter) optStr(v component.Value, what string) *string {
 	return &s
 }
 
+// f64s lifts a list<f64>, which arrives as a []float64 -- the typed slice a
+// list of a fixed-width primitive lifts to -- or as the general []Value shape
+// from a caller that built one by hand.
+func (l *lifter) f64s(v component.Value, what string) []float64 {
+	if l.err != nil || v == nil {
+		return nil
+	}
+	if typed, ok := v.([]float64); ok {
+		return typed
+	}
+	items := l.list(v, what)
+	out := make([]float64, len(items))
+	for i, item := range items {
+		out[i] = l.f64(item, what)
+	}
+	return out
+}
+
+// u64s lifts a list<u64>, in either shape, as f64s does.
+func (l *lifter) u64s(v component.Value, what string) []uint64 {
+	if l.err != nil || v == nil {
+		return nil
+	}
+	if typed, ok := v.([]uint64); ok {
+		return typed
+	}
+	items := l.list(v, what)
+	out := make([]uint64, len(items))
+	for i, item := range items {
+		out[i] = l.u64(item, what)
+	}
+	return out
+}
+
 // keyValues lifts a list<key-value>.
 func (l *lifter) keyValues(v component.Value, what string) []KeyValue {
 	items := l.list(v, what)

--- a/imports/wasi_otel/metrics.go
+++ b/imports/wasi_otel/metrics.go
@@ -367,17 +367,8 @@ func liftHistogram(l *lifter, v component.Value) Histogram {
 	for i, p := range points {
 		pf := l.fields(p, 8, what+".data-point")
 
-		bounds := l.list(pf[2], what+".bounds")
-		outBounds := make([]float64, len(bounds))
-		for j, b := range bounds {
-			outBounds[j] = l.f64(b, what+".bounds")
-		}
-
-		counts := l.list(pf[3], what+".bucket-counts")
-		outCounts := make([]uint64, len(counts))
-		for j, c := range counts {
-			outCounts[j] = l.u64(c, what+".bucket-counts")
-		}
+		outBounds := l.f64s(pf[2], what+".bounds")
+		outCounts := l.u64s(pf[3], what+".bucket-counts")
 
 		out[i] = HistogramDataPoint{
 			Attributes:   l.keyValues(pf[0], what+".data-point.attributes"),
@@ -432,13 +423,8 @@ func liftExponentialHistogram(l *lifter, v component.Value) ExponentialHistogram
 
 func liftExponentialBucket(l *lifter, v component.Value, what string) ExponentialBucket {
 	f := l.fields(v, 2, what)
-	counts := l.list(f[1], what+".counts")
-	out := make([]uint64, len(counts))
-	for i, c := range counts {
-		out[i] = l.u64(c, what+".counts")
-	}
 	return ExponentialBucket{
 		Offset: l.s32(f[0], what+".offset"),
-		Counts: out,
+		Counts: l.u64s(f[1], what+".counts"),
 	}
 }

--- a/imports/wasip2/wasi.go
+++ b/imports/wasip2/wasi.go
@@ -383,15 +383,23 @@ func WithWASI(cfg WASIConfig) []component.Option {
 		stdinBytes, stdinReadErr = io.ReadAll(cfg.Stdin)
 	}
 
-	writerForRep := func(rep uint32) (io.Writer, error) {
+	// writerForRep reports the stdio io.Writer rep names, or false. Callers
+	// that need the "does not name a stdout/stderr stream" error for a rep
+	// nothing recognizes build it via unknownOutStreamErr -- only on that
+	// final miss, so probing a non-stdio rep (every fs/socket/http body
+	// stream write does) never allocates a discarded error.
+	writerForRep := func(rep uint32) (io.Writer, bool) {
 		switch rep {
 		case wasiStdoutRep:
-			return stdout, nil
+			return stdout, true
 		case wasiStderrRep:
-			return stderr, nil
+			return stderr, true
 		default:
-			return nil, fmt.Errorf("wasi:io/streams: output-stream rep %d does not name a stdout/stderr stream", rep)
+			return nil, false
 		}
+	}
+	unknownOutStreamErr := func(rep uint32) error {
+		return fmt.Errorf("wasi:io/streams: output-stream rep %d does not name a stdout/stderr stream", rep)
 	}
 
 	getStderr := func(context.Context, []component.Value) ([]component.Value, error) {
@@ -577,14 +585,13 @@ func WithWASI(cfg WASIConfig) []component.Option {
 	// section for why sockets' reps start at a disjoint 1<<20 base), so
 	// trying them in order is unambiguous. A rep none of the three
 	// recognizes is a genuinely unknown output-stream handle;
-	// writerForRep's own "does not name a stdout/stderr stream" error is
+	// unknownOutStreamErr's "does not name a stdout/stderr stream" error is
 	// returned for that case (matching checkWrite/blockingFlush's identical
 	// fallback below) rather than fs's/sockets' differently-worded "not
 	// found" errors, so all three output-stream methods report an unknown
 	// rep the same way.
 	writeSink := func(rep uint32, buf []byte) error {
-		w, werr := writerForRep(rep)
-		if werr == nil {
+		if w, ok := writerForRep(rep); ok {
 			_, err := w.Write(buf)
 			return err
 		}
@@ -597,7 +604,7 @@ func WithWASI(cfg WASIConfig) []component.Option {
 		if found, err := httphost.bodyStreamWrite(rep, buf); found {
 			return err
 		}
-		return werr
+		return unknownOutStreamErr(rep)
 	}
 
 	checkWrite := func(_ context.Context, args []component.Value) ([]component.Value, error) {
@@ -608,11 +615,11 @@ func WithWASI(cfg WASIConfig) []component.Option {
 		if !ok {
 			return nil, fmt.Errorf("[method]output-stream.check-write: self: expected uint32 rep, got %T", args[0])
 		}
-		if _, err := writerForRep(rep); err != nil {
+		if _, ok := writerForRep(rep); !ok {
 			if _, found := fs.writeStreamNode(rep); !found {
 				if _, found := sockets.outStreamNode(rep); !found {
 					if !httphost.isBodyStreamRep(rep) {
-						return nil, err
+						return nil, unknownOutStreamErr(rep)
 					}
 				}
 			}
@@ -620,7 +627,7 @@ func WithWASI(cfg WASIConfig) []component.Option {
 		// A large, fixed budget: there is no real backpressure to model
 		// against a Go io.Writer, an in-memory file, or a net.Conn, so this
 		// never has to make the guest wait.
-		return []component.Value{component.ResultValue{IsErr: false, Payload: uint64(1) << 40}}, nil
+		return wasiCheckWriteBudget, nil
 	}
 
 	write := func(_ context.Context, args []component.Value) ([]component.Value, error) {
@@ -638,7 +645,7 @@ func WithWASI(cfg WASIConfig) []component.Option {
 		if err := writeSink(rep, buf); err != nil {
 			return nil, fmt.Errorf("[method]output-stream.write: %w", err)
 		}
-		return []component.Value{component.ResultValue{IsErr: false, Payload: nil}}, nil
+		return wasiResultOk, nil
 	}
 
 	blockingFlush := func(_ context.Context, args []component.Value) ([]component.Value, error) {
@@ -649,7 +656,7 @@ func WithWASI(cfg WASIConfig) []component.Option {
 		if !ok {
 			return nil, fmt.Errorf("[method]output-stream.blocking-flush: self: expected uint32 rep, got %T", args[0])
 		}
-		if _, err := writerForRep(rep); err != nil {
+		if _, ok := writerForRep(rep); !ok {
 			// No internal buffering on any side (stdio writes straight
 			// through to the configured io.Writer; fs writes commit
 			// straight to the mount -- see writeStreamWrite's doc; socket
@@ -658,11 +665,11 @@ func WithWASI(cfg WASIConfig) []component.Option {
 			// beyond confirming rep actually names a live stream.
 			if _, found := fs.writeStreamNode(rep); !found {
 				if _, found := sockets.outStreamNode(rep); !found {
-					return nil, err
+					return nil, unknownOutStreamErr(rep)
 				}
 			}
 		}
-		return []component.Value{component.ResultValue{IsErr: false, Payload: nil}}, nil
+		return wasiResultOk, nil
 	}
 
 	checkWriteFD, checkWriteResolve := wasiCheckWriteSig()

--- a/imports/wasip2/wasi_fs.go
+++ b/imports/wasip2/wasi_fs.go
@@ -1838,6 +1838,20 @@ func wasiFilesystemOptions(fs *wasiFS, sockets *wasiSockets) []component.Option 
 		component.WithResourceTag(wasiIfaceStreams, "output-stream", wasiOutputStreamResType),
 		component.WithResourceTag(wasiIfaceError, "error", wasiErrorResType),
 
+		// Releasing the node a dropped handle named. Without these the maps
+		// only ever grew: an instance kept every descriptor, directory stream
+		// and file stream a guest had ever opened, for as long as the instance
+		// lived.
+		//
+		// The stream tags are shared with wasi:sockets and wasi:http, which
+		// mint their own streams under them from disjoint rep ranges, so each
+		// of these ignores a rep it does not own, and registerDtor composes
+		// destructors for a tag rather than replacing them.
+		component.WithHostResourceDtor(wasiDescriptorResType, fs.dropDescriptor),
+		component.WithHostResourceDtor(wasiDirEntryStreamResType, fs.dropDirStream),
+		component.WithHostResourceDtor(wasiInputStreamResType, fs.dropInputStream),
+		component.WithHostResourceDtor(wasiOutputStreamResType, fs.dropOutputStream),
+
 		component.WithImportCustom(wasiIfacePreopens, "get-directories", getDirectories, dirFD, dirResolve),
 
 		component.WithImportCustom(wasiIfaceFilesystemTypes, "filesystem-error-code", filesystemErrorCode, fsErrFD, fsErrResolve),
@@ -1895,6 +1909,38 @@ func wasiErrorCodeType(tbl *typeTable) component.TypeRef {
 		"not-permitted", "pipe", "read-only", "invalid-seek", "text-file-busy",
 		"cross-device",
 	}})
+}
+
+// The destructors behind WithHostResourceDtor. Each releases the node its rep
+// named, and ignores a rep it does not own -- the stream tags are shared with
+// the other host implementations that mint streams.
+
+func (f *wasiFS) dropDescriptor(_ context.Context, rep uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.descs, rep)
+	return nil
+}
+
+func (f *wasiFS) dropDirStream(_ context.Context, rep uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.dirStreams, rep)
+	return nil
+}
+
+func (f *wasiFS) dropInputStream(_ context.Context, rep uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.streams, rep)
+	return nil
+}
+
+func (f *wasiFS) dropOutputStream(_ context.Context, rep uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.writeStreams, rep)
+	return nil
 }
 
 // wasiDatetimeType interns wasi:clocks/wall-clock's `datetime` into tbl.

--- a/imports/wasip2/wasi_http.go
+++ b/imports/wasip2/wasi_http.go
@@ -83,6 +83,29 @@ var httpMethodCases = []string{
 	"GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH",
 }
 
+// httpMethodResults[i] is the shared result slice for httpMethodCases[i].
+// A method variant with no payload is call-invariant, and the instance layer
+// only reads a HostFunc's returned slice (lowerHostResultsPlanned), so every
+// incoming-request.method call can share one boxed value instead of
+// allocating a fresh slice + VariantValue box per request.
+var httpMethodResults = func() [][]component.Value {
+	out := make([][]component.Value, len(httpMethodCases))
+	for i := range httpMethodCases {
+		out[i] = []component.Value{component.VariantValue{Disc: uint32(i)}}
+	}
+	return out
+}()
+
+// wasiResultOk is the shared result slice for every host func whose success
+// is a payload-less `result<_, E>` Ok -- fields.set, outgoing-response.
+// set-status-code, outgoing-body.finish, output-stream.write/blocking-flush.
+// Shareable for the same only-read reason as httpMethodResults.
+var wasiResultOk = []component.Value{component.ResultValue{IsErr: false, Payload: nil}}
+
+// wasiCheckWriteBudget is output-stream.check-write's fixed Ok(1<<40) budget
+// (see checkWrite in wasi.go), shared across calls for the same reason.
+var wasiCheckWriteBudget = []component.Value{component.ResultValue{IsErr: false, Payload: uint64(1) << 40}}
+
 // httpIncomingRequest is the host state behind an incoming-request resource:
 // the inbound request serveHTTP synthesized for the guest to read.
 type httpIncomingRequest struct {
@@ -155,6 +178,14 @@ type wasiHTTP struct {
 
 	nextBodyStream uint32
 	bodyStreams    map[uint32]*httpOutgoingBody
+
+	// handlerInstanceName caches the full exported-instance name
+	// findExportInstance resolves for wasi:http/incoming-handler. The export
+	// list is immutable once the Instance exists, so serveHTTPCall pays the
+	// scan (and the InstanceExports slice it allocates) once rather than per
+	// request. Guarded by mu; "" means not resolved yet (a component that
+	// lacks the export re-scans, but that is a once-per-request error path).
+	handlerInstanceName string
 
 	// --- outgoing (client) side ---
 
@@ -350,7 +381,7 @@ func (h *wasiHTTP) incomingRequestMethod(_ context.Context, args []component.Val
 	up := strings.ToUpper(req.method)
 	for i, name := range httpMethodCases {
 		if name == up {
-			return []component.Value{component.VariantValue{Disc: uint32(i)}}, nil
+			return httpMethodResults[i], nil
 		}
 	}
 	// other(string): discriminant 9, payload the raw method token.
@@ -572,7 +603,7 @@ func (h *wasiHTTP) fieldsSet(_ context.Context, args []component.Value) ([]compo
 		return []component.Value{component.ResultValue{IsErr: true, Payload: component.VariantValue{Disc: httpHeaderErrorImmutable}}}, nil
 	}
 	// result<_, header-error>: Ok.
-	return []component.Value{component.ResultValue{IsErr: false, Payload: nil}}, nil
+	return wasiResultOk, nil
 }
 
 // dropName removes every entry whose name matches, compared case-
@@ -637,7 +668,7 @@ func (h *wasiHTTP) outgoingResponseSetStatusCode(_ context.Context, args []compo
 	if !ok {
 		return nil, fmt.Errorf("[method]outgoing-response.set-status-code: rep %d does not name a live outgoing-response", rep)
 	}
-	return []component.Value{component.ResultValue{IsErr: false, Payload: nil}}, nil
+	return wasiResultOk, nil
 }
 
 func (h *wasiHTTP) outgoingResponseBody(_ context.Context, args []component.Value) ([]component.Value, error) {
@@ -740,7 +771,7 @@ func (h *wasiHTTP) outgoingBodyFinish(_ context.Context, args []component.Value)
 		return nil, fmt.Errorf("[static]outgoing-body.finish: rep %d does not name a live outgoing-body", rep)
 	}
 	// result<_, error-code>: Ok.
-	return []component.Value{component.ResultValue{IsErr: false, Payload: nil}}, nil
+	return wasiResultOk, nil
 }
 
 func (h *wasiHTTP) responseOutparamSet(_ context.Context, args []component.Value) ([]component.Value, error) {
@@ -1194,12 +1225,22 @@ func serveHTTPRequest(in *component.Instance, w http.ResponseWriter, r *http.Req
 // back the response the guest set. Split out (taking already-decomposed request
 // parts) so tests can drive one request without a live net/http server.
 func serveHTTPCall(in *component.Instance, ctx context.Context, method string, u *url.URL, headers http.Header, reqBody []byte, reqTrailer http.Header) (status uint16, respHeader http.Header, respBody []byte, respTrailer http.Header, err error) {
-	if httpHostOf(in) == nil {
+	h := httpHostOf(in)
+	if h == nil {
 		return 0, nil, nil, nil, fmt.Errorf("component/instance: ServeHTTP: instance was not created with WithWASI(WASIConfig{EnableHTTP: true})")
 	}
-	handlerInstance, ok := findExportInstance(in, wasiIfaceHTTPIncomingHandler)
-	if !ok {
-		return 0, nil, nil, nil, fmt.Errorf("component/instance: ServeHTTP: component does not export %s", wasiIfaceHTTPIncomingHandler)
+	h.mu.Lock()
+	handlerInstance := h.handlerInstanceName
+	h.mu.Unlock()
+	if handlerInstance == "" {
+		var ok bool
+		handlerInstance, ok = findExportInstance(in, wasiIfaceHTTPIncomingHandler)
+		if !ok {
+			return 0, nil, nil, nil, fmt.Errorf("component/instance: ServeHTTP: component does not export %s", wasiIfaceHTTPIncomingHandler)
+		}
+		h.mu.Lock()
+		h.handlerInstanceName = handlerInstance
+		h.mu.Unlock()
 	}
 
 	pathQ := u.Path
@@ -1210,11 +1251,11 @@ func serveHTTPCall(in *component.Instance, ctx context.Context, method string, u
 		pathQ += "?" + u.RawQuery
 	}
 	req := &httpIncomingRequest{method: strings.ToUpper(method), pathQ: pathQ, headers: headers.Clone(), body: reqBody, trailers: reqTrailer.Clone()}
-	reqRep := httpHostOf(in).newIncomingRep(req)
+	reqRep := h.newIncomingRep(req)
 	reqHandle := in.Resources().NewOwn(wasiHTTPIncomingRequestResType, reqRep)
 
 	capture := &httpCapture{}
-	outRep := httpHostOf(in).newOutparamRep(capture)
+	outRep := h.newOutparamRep(capture)
 	outHandle := in.Resources().NewOwn(wasiHTTPResponseOutparamResType, outRep)
 
 	if _, err := in.CallExport(ctx, handlerInstance, "handle", reqHandle, outHandle); err != nil {

--- a/imports/wasip2/wasi_http.go
+++ b/imports/wasip2/wasi_http.go
@@ -1168,6 +1168,26 @@ func wasiHTTPOptions(h *wasiHTTP) []component.Option {
 		component.WithResourceTag(wasiIfaceHTTPTypes, "response-outparam", wasiHTTPResponseOutparamResType),
 		component.WithResourceTag(wasiIfaceHTTPTypes, "future-trailers", wasiHTTPFutureTrailersResType),
 
+		// Releasing host state when the guest drops the handle naming it.
+		// Every resource here is a key into one of the maps above, and
+		// without a destructor the entry outlived the handle: an instance
+		// accumulated one per resource the guest ever made. serveHTTPCall
+		// releases what it owns itself, on the request path it controls;
+		// these cover everything the guest creates and drops on its own,
+		// which is the whole client side and any server-side resource a
+		// guest drops early.
+		component.WithHostResourceDtor(wasiHTTPIncomingRequestResType, h.dropIncomingRequest),
+		component.WithHostResourceDtor(wasiHTTPFieldsResType, h.dropFields),
+		component.WithHostResourceDtor(wasiHTTPOutgoingResponseResType, h.dropOutgoingResponse),
+		component.WithHostResourceDtor(wasiHTTPOutgoingBodyResType, h.dropOutgoingBody),
+		component.WithHostResourceDtor(wasiHTTPResponseOutparamResType, h.dropOutparam),
+		component.WithHostResourceDtor(wasiHTTPOutgoingRequestResType, h.dropOutRequest),
+		component.WithHostResourceDtor(wasiHTTPFutureResType, h.dropFuture),
+		component.WithHostResourceDtor(wasiHTTPIncomingResponseResType, h.dropIncomingResponse),
+		component.WithHostResourceDtor(wasiHTTPIncomingBodyResType, h.dropIncomingBody),
+		component.WithHostResourceDtor(wasiHTTPRequestOptionsResType, h.dropRequestOptions),
+		component.WithHostResourceDtor(wasiHTTPFutureTrailersResType, h.dropFutureTrailers),
+
 		component.WithImportCustom(wasiIfaceHTTPTypes, "[static]incoming-body.finish", h.incomingBodyFinish, inBodyFinishFD, inBodyFinishR),
 		component.WithImportCustom(wasiIfaceHTTPTypes, "[method]future-trailers.subscribe", h.futureTrailersSubscribe, ftSubFD, ftSubR),
 		component.WithImportCustom(wasiIfaceHTTPTypes, "[method]future-trailers.get", h.futureTrailersGet, ftGetFD, ftGetR),
@@ -1298,6 +1318,92 @@ func serveHTTPCall(in *component.Instance, ctx context.Context, method string, u
 		}
 	}
 	return resp.status, hdr, respBody, trailer, nil
+}
+
+// The destructors behind WithHostResourceDtor: each drops the entry its
+// resource named. Dropping a rep that is already gone is not an error --
+// serveHTTPCall releases the server-side request state itself, and a guest
+// dropping its handle afterwards must not fail because the host got there
+// first.
+
+func (h *wasiHTTP) dropIncomingRequest(_ context.Context, rep uint32) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.incoming, rep)
+	return nil
+}
+
+func (h *wasiHTTP) dropFields(_ context.Context, rep uint32) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.fields, rep)
+	return nil
+}
+
+func (h *wasiHTTP) dropOutgoingResponse(_ context.Context, rep uint32) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.responses, rep)
+	return nil
+}
+
+func (h *wasiHTTP) dropOutgoingBody(_ context.Context, rep uint32) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if b := h.bodies[rep]; b != nil && b.streamRep != 0 {
+		delete(h.bodyStreams, b.streamRep)
+	}
+	delete(h.bodies, rep)
+	return nil
+}
+
+func (h *wasiHTTP) dropOutparam(_ context.Context, rep uint32) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.outparams, rep)
+	return nil
+}
+
+func (h *wasiHTTP) dropOutRequest(_ context.Context, rep uint32) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.outRequests, rep)
+	return nil
+}
+
+func (h *wasiHTTP) dropFuture(_ context.Context, rep uint32) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.futures, rep)
+	return nil
+}
+
+func (h *wasiHTTP) dropIncomingResponse(_ context.Context, rep uint32) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.inResponses, rep)
+	return nil
+}
+
+func (h *wasiHTTP) dropIncomingBody(_ context.Context, rep uint32) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.inBodies, rep)
+	return nil
+}
+
+func (h *wasiHTTP) dropRequestOptions(_ context.Context, rep uint32) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.reqOptions, rep)
+	return nil
+}
+
+func (h *wasiHTTP) dropFutureTrailers(_ context.Context, rep uint32) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.futureTrailers, rep)
+	return nil
 }
 
 // releaseServeState drops the per-request host state serveHTTPCall minted or

--- a/imports/wasip2/wasi_http.go
+++ b/imports/wasip2/wasi_http.go
@@ -147,6 +147,14 @@ type httpOutgoingBody struct {
 	// trailers holds the option<trailers> a guest passes to
 	// outgoing-body.finish (nil when it finishes with None, the common case).
 	trailers *httpFields
+
+	// rep and streamRep are the reps this body was minted under, recorded so
+	// serveHTTPCall can release them when the request that created it is
+	// done. Without them the only way back from the body to its map keys
+	// would be a scan. streamRep is 0 until the guest takes the body's
+	// output-stream, which a response with no body never does.
+	rep       uint32
+	streamRep uint32
 }
 
 // httpCapture is the slot a response-outparam names: what the guest set.
@@ -314,6 +322,7 @@ func (h *wasiHTTP) newBodyRep(b *httpOutgoingBody) uint32 {
 	rep := h.nextRep
 	h.nextRep++
 	h.bodies[rep] = b
+	b.rep = rep
 	return rep
 }
 
@@ -334,6 +343,7 @@ func (h *wasiHTTP) newBodyStreamRep(b *httpOutgoingBody) uint32 {
 	rep := h.nextBodyStream
 	h.nextBodyStream++
 	h.bodyStreams[rep] = b
+	b.streamRep = rep
 	return rep
 }
 
@@ -1257,6 +1267,9 @@ func serveHTTPCall(in *component.Instance, ctx context.Context, method string, u
 	capture := &httpCapture{}
 	outRep := h.newOutparamRep(capture)
 	outHandle := in.Resources().NewOwn(wasiHTTPResponseOutparamResType, outRep)
+	// Every exit from here on is done with the outparam and the body behind
+	// it, including the error ones.
+	defer func() { h.releaseServeState(reqRep, outRep, capture) }()
 
 	if _, err := in.CallExport(ctx, handlerInstance, "handle", reqHandle, outHandle); err != nil {
 		return 0, nil, nil, nil, fmt.Errorf("component/instance: ServeHTTP: guest handle: %w", err)
@@ -1285,6 +1298,38 @@ func serveHTTPCall(in *component.Instance, ctx context.Context, method string, u
 		}
 	}
 	return resp.status, hdr, respBody, trailer, nil
+}
+
+// releaseServeState drops the per-request host state serveHTTPCall minted or
+// caused to be minted, once the response has been read out of it.
+//
+// The incoming request, the response-outparam, and the outgoing-body the guest
+// takes from the response it sets are reachable only through the call that
+// created them: once the guest's handle export has returned and the capture has
+// been read, nothing can name them again. They were previously left in the maps, so a long-lived
+// instance accumulated one capture and one body per request it ever served,
+// and the rep counter climbed without bound -- which also made every handle
+// value expensive to box, small integers being free and large ones not.
+//
+// The response body slice handed back to the caller aliases the body's
+// buffer, which stays alive through that slice; dropping the map entry does
+// not disturb it.
+func (h *wasiHTTP) releaseServeState(reqRep, outRep uint32, capture *httpCapture) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	delete(h.incoming, reqRep)
+	delete(h.outparams, outRep)
+
+	if capture == nil || capture.resp == nil {
+		return
+	}
+	if b := capture.resp.body; b != nil {
+		delete(h.bodies, b.rep)
+		if b.streamRep != 0 {
+			delete(h.bodyStreams, b.streamRep)
+		}
+	}
 }
 
 // findExportInstance returns the full exported-instance name whose

--- a/imports/wasip2/wasi_http_retention_test.go
+++ b/imports/wasip2/wasi_http_retention_test.go
@@ -2,6 +2,7 @@ package wasip2
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -71,4 +72,64 @@ func TestServeHTTPReleasesPerRequestState(t *testing.T) {
 	// difference between "released" and "released late".
 	serve(200)
 	assertEmpty(220)
+}
+
+// TestOutgoingHandlerReleasesPerRequestState is the client-side counterpart.
+//
+// These resources are the guest's, not the host's: the guest builds an
+// outgoing-request, gets a future back, consumes the incoming-response, reads
+// its body, and drops each handle when done. Nothing on the host side owns
+// their lifetime, so releasing them is the destructor's job -- and with no
+// destructor registered, every outbound request the guest ever made left a
+// future, a response and a body behind.
+func TestOutgoingHandlerReleasesPerRequestState(t *testing.T) {
+	ctx := context.Background()
+	r := wazy.NewRuntime(ctx)
+	defer r.Close(ctx)
+
+	client := &http.Client{Transport: backendRoundTripper{t: t}}
+	inst, err := component.Instantiate(ctx, r, realHTTPOutgoingWasm,
+		WithWASI(WASIConfig{EnableHTTP: true, HTTPClient: client})...)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	defer inst.Close(ctx)
+
+	host := httpHostOf(inst)
+
+	fetch := func(n int) {
+		t.Helper()
+		for i := 0; i < n; i++ {
+			if _, _, _, _, err := serveHTTPCall(inst, ctx, "GET", mustURL("/trigger"), http.Header{}, nil, nil); err != nil {
+				t.Fatalf("request %d: %v", i, err)
+			}
+		}
+	}
+
+	assertEmpty := func(after int) {
+		t.Helper()
+		host.mu.Lock()
+		defer host.mu.Unlock()
+		for _, m := range []struct {
+			name string
+			n    int
+		}{
+			{"outRequests", len(host.outRequests)},
+			{"futures", len(host.futures)},
+			{"inResponses", len(host.inResponses)},
+			{"inBodies", len(host.inBodies)},
+			{"reqOptions", len(host.reqOptions)},
+			{"futureTrailers", len(host.futureTrailers)},
+		} {
+			if m.n != 0 {
+				t.Errorf("after %d requests: %s holds %d entries, want 0", after, m.name, m.n)
+			}
+		}
+	}
+
+	fetch(10)
+	assertEmpty(10)
+
+	fetch(90)
+	assertEmpty(100)
 }

--- a/imports/wasip2/wasi_http_retention_test.go
+++ b/imports/wasip2/wasi_http_retention_test.go
@@ -1,0 +1,74 @@
+package wasip2
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/samyfodil/wazy"
+	"github.com/samyfodil/wazy/component"
+)
+
+// TestServeHTTPReleasesPerRequestState pins that serving a request leaves no
+// host state behind.
+//
+// A response-outparam and the outgoing-body taken from the response are
+// reachable only through the call that made them, so both must be gone once it
+// returns. They were not: an instance accumulated one of each per request it
+// ever served, which on a long-lived server is an unbounded leak rather than a
+// performance detail. Counting after two different numbers of requests is what
+// distinguishes "released" from "grows with load".
+func TestServeHTTPReleasesPerRequestState(t *testing.T) {
+	ctx := context.Background()
+	r := wazy.NewRuntime(ctx)
+	defer r.Close(ctx)
+
+	inst, err := component.Instantiate(ctx, r, realHTTPIncomingWasm, WithWASI(WASIConfig{EnableHTTP: true})...)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	defer inst.Close(ctx)
+
+	h := Handler(inst)
+	host := httpHostOf(inst)
+
+	serve := func(n int) {
+		t.Helper()
+		for i := 0; i < n; i++ {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest("GET", "/greet?name=wazy", nil))
+			if rec.Code != 200 {
+				t.Fatalf("request %d: status = %d, want 200", i, rec.Code)
+			}
+		}
+	}
+
+	assertEmpty := func(after int) {
+		t.Helper()
+		host.mu.Lock()
+		defer host.mu.Unlock()
+		for _, m := range []struct {
+			name string
+			n    int
+		}{
+			{"outparams", len(host.outparams)},
+			{"bodies", len(host.bodies)},
+			{"bodyStreams", len(host.bodyStreams)},
+			{"responses", len(host.responses)},
+			{"fields", len(host.fields)},
+			{"incoming", len(host.incoming)},
+		} {
+			if m.n != 0 {
+				t.Errorf("after %d requests: %s holds %d entries, want 0", after, m.name, m.n)
+			}
+		}
+	}
+
+	serve(20)
+	assertEmpty(20)
+
+	// Ten times the load must not leave ten times the state, which is the
+	// difference between "released" and "released late".
+	serve(200)
+	assertEmpty(220)
+}

--- a/imports/wasip2/wasi_http_serve_bench_test.go
+++ b/imports/wasip2/wasi_http_serve_bench_test.go
@@ -1,0 +1,50 @@
+package wasip2
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/samyfodil/wazy"
+	"github.com/samyfodil/wazy/component"
+)
+
+// BenchmarkServeHTTP measures one request end to end through
+// wasi:http/incoming-handler, which is the highest-frequency path a real
+// embedder runs and the one carrying the most complicated WIT types: records
+// holding options holding variants holding resources.
+//
+// It exists for allocs/op rather than ns/op. Per-request heap traffic is what
+// makes the GC the throughput limiter here -- a trivial component call barely
+// flattens anything and runs orders of magnitude faster -- so this is the guard
+// that keeps the canonical ABI from quietly going back to deriving a type's
+// flattened layout on every call. Read the allocs column first; ns/op on a
+// shared machine is noise.
+func BenchmarkServeHTTP(b *testing.B) {
+	ctx := context.Background()
+	r := wazy.NewRuntime(ctx)
+	defer r.Close(ctx)
+
+	inst, err := component.Instantiate(ctx, r, realHTTPIncomingWasm, WithWASI(WASIConfig{EnableHTTP: true})...)
+	if err != nil {
+		b.Fatalf("Instantiate: %v", err)
+	}
+	defer inst.Close(ctx)
+
+	h := Handler(inst)
+	req := httptest.NewRequest("GET", "/greet?name=wazy", nil)
+	rec := httptest.NewRecorder()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rec.Body.Reset()
+		h.ServeHTTP(rec, req)
+	}
+	b.StopTimer()
+
+	// A benchmark measuring a request that failed would measure nothing.
+	if rec.Code != 200 {
+		b.Fatalf("status = %d, want 200", rec.Code)
+	}
+}

--- a/imports/wasip2/wasi_http_serve_bench_test.go
+++ b/imports/wasip2/wasi_http_serve_bench_test.go
@@ -20,6 +20,11 @@ import (
 // that keeps the canonical ABI from quietly going back to deriving a type's
 // flattened layout on every call. Read the allocs column first; ns/op on a
 // shared machine is noise.
+//
+// The recorder is part of what it measures: about nine of the allocations
+// belong to httptest rather than to wazy, and they are left in rather than
+// tuned away, because a number that excludes the caller's own cost is a
+// number that flatters itself.
 func BenchmarkServeHTTP(b *testing.B) {
 	ctx := context.Background()
 	r := wazy.NewRuntime(ctx)
@@ -33,18 +38,20 @@ func BenchmarkServeHTTP(b *testing.B) {
 
 	h := Handler(inst)
 	req := httptest.NewRequest("GET", "/greet?name=wazy", nil)
-	rec := httptest.NewRecorder()
 
+	// A recorder per iteration, not one reset between them: a ResponseRecorder
+	// accumulates header and write state, so reusing it would let each
+	// iteration start from the last one's leftovers and measure something no
+	// real request does. It costs a few allocations of its own, which is the
+	// honest price of measuring a whole request.
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		rec.Body.Reset()
+		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
-	}
-	b.StopTimer()
-
-	// A benchmark measuring a request that failed would measure nothing.
-	if rec.Code != 200 {
-		b.Fatalf("status = %d, want 200", rec.Code)
+		if rec.Code != 200 {
+			b.StopTimer()
+			b.Fatalf("status = %d, want 200", rec.Code)
+		}
 	}
 }

--- a/imports/wasip2/wasi_resource_dtor_test.go
+++ b/imports/wasip2/wasi_resource_dtor_test.go
@@ -1,0 +1,100 @@
+package wasip2
+
+import (
+	"context"
+	"testing"
+)
+
+// The wasi:filesystem and wasi:sockets destructors release the node their rep
+// named, and ignore a rep they do not own.
+//
+// Both packages tracked every descriptor, stream and socket a guest opened in
+// a map, and nothing ever removed one: an instance held all of them for as
+// long as it lived. These are the destructors that release them when the guest
+// drops the handle.
+//
+// The "not mine" cases are not padding. input-stream and output-stream are one
+// tag shared by wasi:filesystem, wasi:sockets and wasi:http, each minting from
+// a disjoint range of reps, so every one of these destructors is called for
+// every stream any of them created. Treating another subsystem's rep as an
+// error would turn a normal drop into a failure.
+func TestFilesystemDestructorsReleaseNodes(t *testing.T) {
+	ctx := context.Background()
+	fs := newWasiFS(nil)
+
+	fs.descs[100] = &fsDescNode{}
+	fs.dirStreams[101] = &fsDirStreamNode{}
+	fs.streams[102] = &fsStreamNode{}
+	fs.writeStreams[103] = &fsWriteStreamNode{}
+
+	for _, tc := range []struct {
+		name string
+		drop func(context.Context, uint32) error
+		rep  uint32
+		size func() int
+	}{
+		{"descriptor", fs.dropDescriptor, 100, func() int { return len(fs.descs) }},
+		{"directory-entry-stream", fs.dropDirStream, 101, func() int { return len(fs.dirStreams) }},
+		{"input-stream", fs.dropInputStream, 102, func() int { return len(fs.streams) }},
+		{"output-stream", fs.dropOutputStream, 103, func() int { return len(fs.writeStreams) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.size(); got != 1 {
+				t.Fatalf("setup: map holds %d entries, want 1", got)
+			}
+			if err := tc.drop(ctx, tc.rep); err != nil {
+				t.Fatalf("drop: %v", err)
+			}
+			if got := tc.size(); got != 0 {
+				t.Errorf("after drop: map holds %d entries, want 0", got)
+			}
+			// A rep from another subsystem sharing this tag.
+			if err := tc.drop(ctx, 1<<24); err != nil {
+				t.Errorf("dropping a rep this package did not mint: %v, want no error", err)
+			}
+		})
+	}
+}
+
+func TestSocketDestructorsReleaseNodes(t *testing.T) {
+	ctx := context.Background()
+	s := newWasiSockets(nil, nil, nil, nil)
+
+	s.tcpSocks[200] = &tcpSockNode{}
+	s.udpSocks[201] = &udpSockNode{}
+	s.resolveStream[202] = &resolveAddrStream{}
+	s.inStreams[203] = &sockInStream{}
+	s.outStreams[204] = &sockOutStream{}
+	s.inDgrams[205] = &incomingDatagramStream{}
+	s.outDgrams[206] = &outgoingDatagramStream{}
+
+	for _, tc := range []struct {
+		name string
+		drop func(context.Context, uint32) error
+		rep  uint32
+		size func() int
+	}{
+		{"tcp-socket", s.dropTCPSock, 200, func() int { return len(s.tcpSocks) }},
+		{"udp-socket", s.dropUDPSock, 201, func() int { return len(s.udpSocks) }},
+		{"resolve-address-stream", s.dropResolveStream, 202, func() int { return len(s.resolveStream) }},
+		{"input-stream", s.dropInputStream, 203, func() int { return len(s.inStreams) }},
+		{"output-stream", s.dropOutputStream, 204, func() int { return len(s.outStreams) }},
+		{"incoming-datagram-stream", s.dropInDgram, 205, func() int { return len(s.inDgrams) }},
+		{"outgoing-datagram-stream", s.dropOutDgram, 206, func() int { return len(s.outDgrams) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.size(); got != 1 {
+				t.Fatalf("setup: map holds %d entries, want 1", got)
+			}
+			if err := tc.drop(ctx, tc.rep); err != nil {
+				t.Fatalf("drop: %v", err)
+			}
+			if got := tc.size(); got != 0 {
+				t.Errorf("after drop: map holds %d entries, want 0", got)
+			}
+			if err := tc.drop(ctx, 7); err != nil {
+				t.Errorf("dropping a rep this package did not mint: %v, want no error", err)
+			}
+		})
+	}
+}

--- a/imports/wasip2/wasi_sockets.go
+++ b/imports/wasip2/wasi_sockets.go
@@ -1251,6 +1251,18 @@ func wasiSocketOptions(sockets *wasiSockets) []component.Option {
 		component.WithResourceTag(wasiIfaceSocketsTCP, "tcp-socket", wasiTCPSocketResType),
 		component.WithResourceTag(wasiIfaceSocketsIPNameLookup, "resolve-address-stream", wasiResolveStreamResType),
 
+		// Releasing the node a dropped handle named; without these an
+		// instance kept every socket and stream a guest had ever opened.
+		// The stream tags are shared with wasi:filesystem and wasi:http, so
+		// each of these ignores a rep it does not own (socket reps start at a
+		// disjoint base -- see this file's "Rep numbering" doc) and
+		// registerDtor composes destructors for a tag rather than replacing
+		// them.
+		component.WithHostResourceDtor(wasiTCPSocketResType, sockets.dropTCPSock),
+		component.WithHostResourceDtor(wasiResolveStreamResType, sockets.dropResolveStream),
+		component.WithHostResourceDtor(wasiInputStreamResType, sockets.dropInputStream),
+		component.WithHostResourceDtor(wasiOutputStreamResType, sockets.dropOutputStream),
+
 		component.WithImportCustom(wasiIfaceSocketsInstanceNet, "instance-network", instanceNetwork, instNetFD, instNetResolve),
 		component.WithImportCustom(wasiIfaceSocketsIPNameLookup, "resolve-addresses", resolveAddresses, resolveFD, resolveResolve),
 		component.WithImportCustom(wasiIfaceSocketsIPNameLookup, "[method]resolve-address-stream.resolve-next-address", resolveNextAddress, resolveNextFD, resolveNextResolve),
@@ -1627,6 +1639,10 @@ func wasiUDPSocketOptions(sockets *wasiSockets) []component.Option {
 		component.WithResourceTag(wasiIfaceSocketsUDP, "udp-socket", wasiUDPSocketResType),
 		component.WithResourceTag(wasiIfaceSocketsUDP, "incoming-datagram-stream", wasiIncomingDatagramStreamResType),
 		component.WithResourceTag(wasiIfaceSocketsUDP, "outgoing-datagram-stream", wasiOutgoingDatagramStreamResType),
+
+		component.WithHostResourceDtor(wasiUDPSocketResType, sockets.dropUDPSock),
+		component.WithHostResourceDtor(wasiIncomingDatagramStreamResType, sockets.dropInDgram),
+		component.WithHostResourceDtor(wasiOutgoingDatagramStreamResType, sockets.dropOutDgram),
 
 		component.WithImportCustom(wasiIfaceSocketsInstanceNet, "instance-network", instanceNetwork, instNetFD, instNetResolve),
 		component.WithImportCustom(wasiIfaceSocketsUDPCreateSoc, "create-udp-socket", createUDPSocket, createUDPFD, createUDPResolve),
@@ -2148,4 +2164,62 @@ func wasiOutgoingSendSig() (component.FuncDesc, component.Resolver) {
 		Results: component.FuncResults{Unnamed: &resultRef},
 	}
 	return fd, tbl.resolver()
+}
+
+// The destructors behind WithHostResourceDtor. Each releases the node its rep
+// named. A rep this package did not mint is ignored: the stream tags are
+// shared with wasi:filesystem and wasi:http, whose reps come from disjoint
+// ranges, so deleting an absent key is the correct no-op rather than an error.
+//
+// Closing the underlying connection is deliberately left to the node's own
+// close paths, which the guest reaches explicitly; these release only the
+// bookkeeping that outlived the handle.
+
+func (s *wasiSockets) dropTCPSock(_ context.Context, rep uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.tcpSocks, rep)
+	return nil
+}
+
+func (s *wasiSockets) dropUDPSock(_ context.Context, rep uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.udpSocks, rep)
+	return nil
+}
+
+func (s *wasiSockets) dropResolveStream(_ context.Context, rep uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.resolveStream, rep)
+	return nil
+}
+
+func (s *wasiSockets) dropInputStream(_ context.Context, rep uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.inStreams, rep)
+	return nil
+}
+
+func (s *wasiSockets) dropOutputStream(_ context.Context, rep uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.outStreams, rep)
+	return nil
+}
+
+func (s *wasiSockets) dropInDgram(_ context.Context, rep uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.inDgrams, rep)
+	return nil
+}
+
+func (s *wasiSockets) dropOutDgram(_ context.Context, rep uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.outDgrams, rep)
+	return nil
 }

--- a/internal/component/abi/coreval.go
+++ b/internal/component/abi/coreval.go
@@ -120,3 +120,50 @@ func (cvi *CoreValueIter) Next() (CoreValue, error) {
 func (cvi *CoreValueIter) Done() bool {
 	return cvi.i == len(cvi.values)
 }
+
+// stackValueIter is CoreValueIter over the two halves a planned caller
+// already holds separately: the flat kind list computed at bind time and the
+// raw bits sitting on the core stack. It exists so LiftFlatKinds can walk a
+// parameter's core values without first materializing a []CoreValue just to
+// pair each kind with its bits -- that pairing was one allocation per
+// parameter per guest->host call. kinds and bits are always the same length
+// (LiftFlatKinds checks before building one).
+type stackValueIter struct {
+	kinds []string
+	bits  []uint64
+	i     int
+}
+
+var stackValueIterPool = sync.Pool{New: func() any { return new(stackValueIter) }}
+
+// getStackValueIter returns a pooled iterator pairing kinds with bits, for
+// the same escapes-as-valueIter reason getCoreValueIter exists. Return it
+// with putStackValueIter once lifting is done.
+func getStackValueIter(kinds []string, bits []uint64) *stackValueIter {
+	it := stackValueIterPool.Get().(*stackValueIter)
+	it.kinds, it.bits, it.i = kinds, bits, 0
+	return it
+}
+
+// putStackValueIter returns an iterator to the pool, clearing both slice
+// references so a pooled-but-idle iterator doesn't pin the caller's stack
+// buffer or a plan's kind list.
+func putStackValueIter(it *stackValueIter) {
+	it.kinds, it.bits = nil, nil
+	stackValueIterPool.Put(it)
+}
+
+// Next returns the next CoreValue and advances the iterator.
+func (svi *stackValueIter) Next() (CoreValue, error) {
+	if svi.i >= len(svi.kinds) {
+		return CoreValue{}, fmt.Errorf("stackValueIter: index out of range")
+	}
+	cv := CoreValue{Kind: svi.kinds[svi.i], Bits: svi.bits[svi.i]}
+	svi.i++
+	return cv, nil
+}
+
+// Done reports whether all core values have been consumed.
+func (svi *stackValueIter) Done() bool {
+	return svi.i == len(svi.kinds)
+}

--- a/internal/component/abi/flat.go
+++ b/internal/component/abi/flat.go
@@ -3,6 +3,7 @@ package abi
 import (
 	"fmt"
 	"math"
+	"sync"
 
 	"github.com/samyfodil/wazy/internal/component/binary"
 )
@@ -56,7 +57,7 @@ func LowerFlatInto(dst []CoreValue, v Value, t binary.TypeDesc, resolve Resolver
 		return append(dst, NewCoreValueI32(ptr)), nil
 	}
 
-	flat, err := lowerFlatImpl(v, t, resolve, realloc, mem)
+	flat, err := lowerFlatImpl(v, t, nil, resolve, realloc, mem)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +66,18 @@ func LowerFlatInto(dst []CoreValue, v Value, t binary.TypeDesc, resolve Resolver
 
 // lowerFlatImpl recursively lowers a value to its flat representation.
 // Does not handle spilling; that is done by LowerFlat.
-func lowerFlatImpl(v Value, t binary.TypeDesc, resolve Resolver, realloc Realloc, mem []byte) ([]CoreValue, error) {
+//
+// flat, when non-nil, is Flatten(t) already computed by the caller -- a
+// bind-time plan (LowerStep.flat), or the enclosing variant/result/option
+// level, which had to flatten this exact type anyway to build its join. Only
+// the variant/result/option cases consult it (they are the only lowers that
+// need their own flat type list, for the join/coercion bookkeeping); nil
+// means "unknown, compute it yourself", preserving the exact prior behavior.
+// Threading the known list down is what keeps the per-VALUE lower of a
+// deeply-cased variant (wasi:http's error-code is the motivating shape) from
+// re-running the full Flatten tree-walk -- and its per-case allocations --
+// on every call.
+func lowerFlatImpl(v Value, t binary.TypeDesc, flat []string, resolve Resolver, realloc Realloc, mem []byte) ([]CoreValue, error) {
 	switch desc := t.(type) {
 	case binary.PrimitiveDesc:
 		return lowerFlatPrimitive(v, desc.Prim, realloc, mem)
@@ -81,7 +93,7 @@ func lowerFlatImpl(v Value, t binary.TypeDesc, resolve Resolver, realloc Realloc
 		return lowerFlatRecord(v, desc, resolve, realloc, mem)
 
 	case binary.VariantDesc:
-		return lowerFlatVariant(v, desc, resolve, realloc, mem)
+		return lowerFlatVariant(v, desc, flat, resolve, realloc, mem)
 
 	case binary.TupleDesc:
 		return lowerFlatTuple(v, desc, resolve, realloc, mem)
@@ -97,10 +109,17 @@ func lowerFlatImpl(v Value, t binary.TypeDesc, resolve Resolver, realloc Realloc
 		if err != nil {
 			return nil, err
 		}
-		return lowerFlatOption(v, elemType, resolve, realloc, mem)
+		// An option's flat list is exactly [i32 discriminant] + Flatten(elem)
+		// (no join happens -- see flattenOption), so the element's own flat
+		// list is recoverable by slicing off the discriminant.
+		var elemFlat []string
+		if flat != nil {
+			elemFlat = flat[1:]
+		}
+		return lowerFlatOption(v, elemType, elemFlat, resolve, realloc, mem)
 
 	case binary.ResultDesc:
-		return lowerFlatResult(v, desc, resolve, realloc, mem)
+		return lowerFlatResult(v, desc, flat, resolve, realloc, mem)
 
 	case binary.OwnDesc, binary.BorrowDesc, binary.StreamDesc, binary.FutureDesc:
 		// stream/future values are opaque i32 handles, same lowering as
@@ -284,7 +303,7 @@ func lowerFlatRecord(v Value, desc binary.RecordDesc, resolve Resolver, realloc 
 		if err != nil {
 			return nil, err
 		}
-		fieldFlat, err := lowerFlatImpl(fields[i], fieldType, resolve, realloc, mem)
+		fieldFlat, err := lowerFlatImpl(fields[i], fieldType, nil, resolve, realloc, mem)
 		if err != nil {
 			return nil, fmt.Errorf("lowerFlat record field %s: %w", field.Name, err)
 		}
@@ -295,7 +314,9 @@ func lowerFlatRecord(v Value, desc binary.RecordDesc, resolve Resolver, realloc 
 
 // lowerFlatVariant lowers a variant value.
 // This is where the JOIN and COERCE operations happen.
-func lowerFlatVariant(v Value, desc binary.VariantDesc, resolve Resolver, realloc Realloc, mem []byte) ([]CoreValue, error) {
+// flat, when non-nil, is Flatten(desc) already known by the caller (see
+// lowerFlatImpl's doc); nil computes it here as before.
+func lowerFlatVariant(v Value, desc binary.VariantDesc, flat []string, resolve Resolver, realloc Realloc, mem []byte) ([]CoreValue, error) {
 	vv, ok := v.(VariantValue)
 	if !ok {
 		return nil, fmt.Errorf("lowerFlat variant: expected VariantValue, got %T", v)
@@ -306,9 +327,13 @@ func lowerFlatVariant(v Value, desc binary.VariantDesc, resolve Resolver, reallo
 	}
 
 	// Get the flattened variant type to know the joined flat types.
-	variantFlat, err := Flatten(desc, resolve)
-	if err != nil {
-		return nil, err
+	variantFlat := flat
+	if variantFlat == nil {
+		var err error
+		variantFlat, err = Flatten(desc, resolve)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// First element is the discriminant (i32).
@@ -328,15 +353,17 @@ func lowerFlatVariant(v Value, desc binary.VariantDesc, resolve Resolver, reallo
 			return nil, err
 		}
 
-		casePayload, err := lowerFlatImpl(vv.Payload, caseType, resolve, realloc, mem)
-		if err != nil {
-			return nil, fmt.Errorf("lowerFlat variant case %d: %w", vv.Disc, err)
-		}
-
-		// Get the native flat types for this case.
+		// Get the native flat types for this case -- before lowering the
+		// payload, so a case that is itself a variant/result/option receives
+		// its own flat list and doesn't re-Flatten it.
 		caseFlat, err := Flatten(caseType, resolve)
 		if err != nil {
 			return nil, err
+		}
+
+		casePayload, err := lowerFlatImpl(vv.Payload, caseType, caseFlat, resolve, realloc, mem)
+		if err != nil {
+			return nil, fmt.Errorf("lowerFlat variant case %d: %w", vv.Disc, err)
 		}
 
 		// Coerce the payload core values to the joined flat types.
@@ -437,7 +464,7 @@ func lowerFlatTuple(v Value, desc binary.TupleDesc, resolve Resolver, realloc Re
 		if err != nil {
 			return nil, err
 		}
-		elemFlat, err := lowerFlatImpl(elements[i], elemType, resolve, realloc, mem)
+		elemFlat, err := lowerFlatImpl(elements[i], elemType, nil, resolve, realloc, mem)
 		if err != nil {
 			return nil, fmt.Errorf("lowerFlat tuple element %d: %w", i, err)
 		}
@@ -474,14 +501,22 @@ func lowerFlatEnum(v Value, desc binary.EnumDesc) ([]CoreValue, error) {
 // carries no payload of its own but must still be zero-padded out to T's
 // flat width, since Flatten(OptionDesc) always reserves that many joined
 // positions regardless of which case is active.
-func lowerFlatOption(v Value, elemType binary.TypeDesc, resolve Resolver, realloc Realloc, mem []byte) ([]CoreValue, error) {
-	elemFlatTypes, err := Flatten(elemType, resolve)
-	if err != nil {
-		return nil, err
-	}
-
+// elemFlat, when non-nil, is Flatten(elemType) already known by the caller
+// (the enclosing option's flat list minus its discriminant -- see
+// lowerFlatImpl's OptionDesc case); nil computes it on the branch that needs
+// it.
+func lowerFlatOption(v Value, elemType binary.TypeDesc, elemFlat []string, resolve Resolver, realloc Realloc, mem []byte) ([]CoreValue, error) {
 	if v == nil {
-		// None: discriminant 0, then zero-padding for the element's width.
+		// None: discriminant 0, then zero-padding for the element's width --
+		// the one branch that needs the element's flat kinds itself.
+		elemFlatTypes := elemFlat
+		if elemFlatTypes == nil {
+			var err error
+			elemFlatTypes, err = Flatten(elemType, resolve)
+			if err != nil {
+				return nil, err
+			}
+		}
 		result := make([]CoreValue, 0, 1+len(elemFlatTypes))
 		result = append(result, NewCoreValueI32(0))
 		for _, ft := range elemFlatTypes {
@@ -497,7 +532,7 @@ func lowerFlatOption(v Value, elemType binary.TypeDesc, resolve Resolver, reallo
 	// Some: discriminant 1, then the element. No coercion is needed here:
 	// Option only ever joins one real case's flat types against zero
 	// padding, which is always a no-op join (join(x, x) == x).
-	elemVals, err := lowerFlatImpl(v, elemType, resolve, realloc, mem)
+	elemVals, err := lowerFlatImpl(v, elemType, elemFlat, resolve, realloc, mem)
 	if err != nil {
 		return nil, err
 	}
@@ -511,15 +546,21 @@ func lowerFlatOption(v Value, elemType binary.TypeDesc, resolve Resolver, reallo
 // variant, the two arms' flat types are joined position-by-position (see
 // join() in coerceValue), and whichever arm is inactive must still be
 // zero-padded/coerced out to the joined width.
-func lowerFlatResult(v Value, desc binary.ResultDesc, resolve Resolver, realloc Realloc, mem []byte) ([]CoreValue, error) {
+// flat, when non-nil, is Flatten(desc) already known by the caller (see
+// lowerFlatImpl's doc); nil computes it here as before.
+func lowerFlatResult(v Value, desc binary.ResultDesc, flat []string, resolve Resolver, realloc Realloc, mem []byte) ([]CoreValue, error) {
 	rv, ok := v.(ResultValue)
 	if !ok {
 		return nil, fmt.Errorf("lowerFlat result: expected ResultValue, got %T", v)
 	}
 
-	resultFlat, err := Flatten(desc, resolve)
-	if err != nil {
-		return nil, err
+	resultFlat := flat
+	if resultFlat == nil {
+		var err error
+		resultFlat, err = Flatten(desc, resolve)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if len(resultFlat) == 0 || resultFlat[0] != "i32" {
 		return nil, fmt.Errorf("lowerFlat result: expected first element to be i32 discriminant")
@@ -542,13 +583,15 @@ func lowerFlatResult(v Value, desc binary.ResultDesc, resolve Resolver, realloc 
 		if err != nil {
 			return nil, err
 		}
-		armVals, err := lowerFlatImpl(rv.Payload, armType, resolve, realloc, mem)
-		if err != nil {
-			return nil, fmt.Errorf("lowerFlat result payload: %w", err)
-		}
+		// Flatten the arm before lowering it, so an arm that is itself a
+		// variant/result/option receives its own flat list.
 		armFlatTypes, err := Flatten(armType, resolve)
 		if err != nil {
 			return nil, err
+		}
+		armVals, err := lowerFlatImpl(rv.Payload, armType, armFlatTypes, resolve, realloc, mem)
+		if err != nil {
+			return nil, fmt.Errorf("lowerFlat result payload: %w", err)
 		}
 		for i := 0; i < len(armVals) && i < len(joinedFlat); i++ {
 			payload = append(payload, coerceValue(armVals[i], armFlatTypes[i], joinedFlat[i]))
@@ -636,8 +679,36 @@ func LiftFlat(vals []CoreValue, t binary.TypeDesc, resolve Resolver, mem []byte)
 	// escapes into liftFlatImpl as a valueIter interface, so a fresh one would
 	// allocate every call); nothing retains it past liftFlatImpl's return.
 	vi := getCoreValueIter(vals)
-	val, err := liftFlatImpl(vi, t, resolve, mem)
+	val, err := liftFlatImpl(vi, t, nil, resolve, mem)
 	putCoreValueIter(vi)
+	return val, err
+}
+
+// LiftFlatKinds is LiftFlat for a caller that precomputed flat = Flatten(t)
+// at bind time (a hostParamPlan) and holds the core values as raw stack bits
+// rather than kind-tagged CoreValues. It exists for the guest->host hot path:
+// pairing each stack slot with its flat kind through a pooled iterator, and
+// handing the known flat list down the lift recursion, replaces both
+// per-call allocations the LiftFlat shape forced on liftHostArgsPlanned --
+// the []CoreValue built per parameter just to tag the bits, and the full
+// Flatten re-run a variant/result parameter's lift performed per VALUE.
+// bits must hold exactly the parameter's core values: len(bits) == len(flat)
+// when the type doesn't spill, or the single spill pointer when it does.
+func LiftFlatKinds(flat []string, bits []uint64, t binary.TypeDesc, resolve Resolver, mem []byte) (Value, error) {
+	if len(flat) > MaxFlatParams {
+		// Spilled: the one core value is a pointer to memory (same rule as
+		// LiftFlat's FlatWidth check, decided here from the precomputed list).
+		if len(bits) != 1 {
+			return nil, fmt.Errorf("LiftFlatKinds: expected 1 value for spilled type, got %d", len(bits))
+		}
+		return Load(mem, uint32(bits[0]), t, resolve)
+	}
+	if len(bits) != len(flat) {
+		return nil, fmt.Errorf("LiftFlatKinds: expected %d core value(s), got %d", len(flat), len(bits))
+	}
+	vi := getStackValueIter(flat, bits)
+	val, err := liftFlatImpl(vi, t, flat, resolve, mem)
+	putStackValueIter(vi)
 	return val, err
 }
 
@@ -651,7 +722,15 @@ type valueIter interface {
 // vi can be either a *CoreValueIter or any other type implementing valueIter.
 // mem is only threaded through for the string/list cases, which must load
 // their backing data from linear memory even in the flat ABI.
-func liftFlatImpl(vi valueIter, t binary.TypeDesc, resolve Resolver, mem []byte) (Value, error) {
+//
+// flat, when non-nil, is Flatten(t) already computed by the caller -- a
+// bind-time plan (hostParamPlan.flat, LiftStep.flat), or the enclosing
+// variant/result/option level, which had to flatten this exact type anyway.
+// Only the variant/result/option cases consult it (they need their own flat
+// list for the join/coercion bookkeeping); nil means "unknown, compute it
+// yourself", preserving the exact prior behavior. See lowerFlatImpl's twin
+// doc for why threading this down matters.
+func liftFlatImpl(vi valueIter, t binary.TypeDesc, flat []string, resolve Resolver, mem []byte) (Value, error) {
 	switch desc := t.(type) {
 	case binary.PrimitiveDesc:
 		return liftFlatPrimitive(vi, desc.Prim, mem)
@@ -667,7 +746,7 @@ func liftFlatImpl(vi valueIter, t binary.TypeDesc, resolve Resolver, mem []byte)
 		return liftFlatRecord(vi, desc, resolve, mem)
 
 	case binary.VariantDesc:
-		return liftFlatVariant(vi, desc, resolve, mem)
+		return liftFlatVariant(vi, desc, flat, resolve, mem)
 
 	case binary.TupleDesc:
 		return liftFlatTuple(vi, desc, resolve, mem)
@@ -683,10 +762,17 @@ func liftFlatImpl(vi valueIter, t binary.TypeDesc, resolve Resolver, mem []byte)
 		if err != nil {
 			return nil, err
 		}
-		return liftFlatOption(vi, elemType, resolve, mem)
+		// An option's flat list is exactly [i32 discriminant] + Flatten(elem)
+		// (no join happens -- see flattenOption), so the element's own flat
+		// list is recoverable by slicing off the discriminant.
+		var elemFlat []string
+		if flat != nil {
+			elemFlat = flat[1:]
+		}
+		return liftFlatOption(vi, elemType, elemFlat, resolve, mem)
 
 	case binary.ResultDesc:
-		return liftFlatResult(vi, desc, resolve, mem)
+		return liftFlatResult(vi, desc, flat, resolve, mem)
 
 	case binary.OwnDesc, binary.BorrowDesc, binary.StreamDesc, binary.FutureDesc:
 		// stream/future values are opaque i32 handles, same lifting as
@@ -812,7 +898,7 @@ func liftFlatList(vi valueIter, elemType binary.TypeDesc, resolve Resolver, mem 
 	if err != nil {
 		return nil, err
 	}
-	list, err := loadListFromRange(mem, ptrCV.AsI32(), lenCV.AsI32(), elemType, resolve)
+	list, err := loadAnyListFromRange(mem, ptrCV.AsI32(), lenCV.AsI32(), elemType, resolve)
 	if err != nil {
 		return nil, fmt.Errorf("liftFlatList: %w", err)
 	}
@@ -827,7 +913,7 @@ func liftFlatRecord(vi valueIter, desc binary.RecordDesc, resolve Resolver, mem 
 		if err != nil {
 			return nil, err
 		}
-		v, err := liftFlatImpl(vi, fieldType, resolve, mem)
+		v, err := liftFlatImpl(vi, fieldType, nil, resolve, mem)
 		if err != nil {
 			return nil, fmt.Errorf("liftFlat record field %s: %w", field.Name, err)
 		}
@@ -837,11 +923,17 @@ func liftFlatRecord(vi valueIter, desc binary.RecordDesc, resolve Resolver, mem 
 }
 
 // liftFlatVariant lifts a variant value.
-func liftFlatVariant(vi valueIter, desc binary.VariantDesc, resolve Resolver, mem []byte) (Value, error) {
+// flat, when non-nil, is Flatten(desc) already known by the caller (see
+// liftFlatImpl's doc); nil computes it here as before.
+func liftFlatVariant(vi valueIter, desc binary.VariantDesc, flat []string, resolve Resolver, mem []byte) (Value, error) {
 	// Get the flattened variant type.
-	variantFlat, err := Flatten(desc, resolve)
-	if err != nil {
-		return nil, err
+	variantFlat := flat
+	if variantFlat == nil {
+		var err error
+		variantFlat, err = Flatten(desc, resolve)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if len(variantFlat) == 0 || variantFlat[0] != "i32" {
@@ -878,29 +970,30 @@ func liftFlatVariant(vi valueIter, desc binary.VariantDesc, resolve Resolver, me
 
 	// Read the case payload THROUGH vi (which may itself be an enclosing
 	// coercingValueIter), so a nested variant/result advances every level's
-	// consumption count -- see coercingValueIter's doc.
-	coerceVI := &coercingValueIter{
-		underlying: vi,
-		joinedFlat: joinedFlat,
-		caseFlat:   caseFlat,
-		idx:        0,
-	}
+	// consumption count -- see coercingValueIter's doc. The iterator is
+	// pooled for the same reason the raw one is (it escapes into
+	// liftFlatImpl as a valueIter); nothing retains it past the payload
+	// lift, so it is released as soon as its consumption count is read.
+	coerceVI := getCoercingValueIter(vi, joinedFlat, caseFlat)
 
 	// Lift the case payload using the coercing iterator (implements valueIter).
 	var payload Value
 	if c.Type != nil {
 		caseType, err := resolveType(c.Type, resolve)
 		if err != nil {
+			putCoercingValueIter(coerceVI)
 			return nil, err
 		}
-		payload, err = liftFlatImpl(coerceVI, caseType, resolve, mem)
+		payload, err = liftFlatImpl(coerceVI, caseType, caseFlat, resolve, mem)
 		if err != nil {
+			putCoercingValueIter(coerceVI)
 			return nil, fmt.Errorf("liftFlat variant case %d: %w", caseIdx, err)
 		}
 	}
 
 	// Consume remaining joined flat values.
 	remainingJoined := len(joinedFlat) - coerceVI.idx
+	putCoercingValueIter(coerceVI)
 	for i := 0; i < remainingJoined; i++ {
 		_, err := vi.Next()
 		if err != nil {
@@ -933,6 +1026,26 @@ type coercingValueIter struct {
 	joinedFlat []string
 	caseFlat   []string
 	idx        int
+}
+
+var coercingValueIterPool = sync.Pool{New: func() any { return new(coercingValueIter) }}
+
+// getCoercingValueIter returns a pooled coercing iterator, for the same
+// escapes-as-valueIter reason getCoreValueIter exists: every variant/result
+// lift otherwise pays one allocation just to coerce its own payload. Return
+// it with putCoercingValueIter as soon as its final idx has been read.
+func getCoercingValueIter(underlying valueIter, joinedFlat, caseFlat []string) *coercingValueIter {
+	it := coercingValueIterPool.Get().(*coercingValueIter)
+	it.underlying, it.joinedFlat, it.caseFlat, it.idx = underlying, joinedFlat, caseFlat, 0
+	return it
+}
+
+// putCoercingValueIter returns an iterator to the pool, clearing every
+// reference so a pooled-but-idle iterator doesn't pin the underlying
+// iterator or a plan's flat lists.
+func putCoercingValueIter(it *coercingValueIter) {
+	it.underlying, it.joinedFlat, it.caseFlat = nil, nil, nil
+	coercingValueIterPool.Put(it)
 }
 
 // Next reads one value from the underlying iterator and coerces it from the
@@ -1008,7 +1121,7 @@ func liftFlatTuple(vi valueIter, desc binary.TupleDesc, resolve Resolver, mem []
 		if err != nil {
 			return nil, err
 		}
-		v, err := liftFlatImpl(vi, elemType, resolve, mem)
+		v, err := liftFlatImpl(vi, elemType, nil, resolve, mem)
 		if err != nil {
 			return nil, fmt.Errorf("liftFlat tuple element %d: %w", i, err)
 		}
@@ -1043,7 +1156,10 @@ func liftFlatEnum(vi valueIter, desc binary.EnumDesc) (Value, error) {
 // Mirrors lowerFlatOption: the "none" case must consume (and discard) the
 // same zero-padding lowerFlatOption emitted for T's flat width, so the
 // value-iterator stays aligned for whatever follows the option.
-func liftFlatOption(vi valueIter, elemType binary.TypeDesc, resolve Resolver, mem []byte) (Value, error) {
+// elemFlat, when non-nil, is Flatten(elemType) already known by the caller
+// (the enclosing option's flat list minus its discriminant -- see
+// liftFlatImpl's OptionDesc case); nil recomputes what each branch needs.
+func liftFlatOption(vi valueIter, elemType binary.TypeDesc, elemFlat []string, resolve Resolver, mem []byte) (Value, error) {
 	cv, err := vi.Next()
 	if err != nil {
 		return nil, err
@@ -1053,9 +1169,12 @@ func liftFlatOption(vi valueIter, elemType binary.TypeDesc, resolve Resolver, me
 	switch disc {
 	case 0:
 		// None: consume and discard the padding.
-		elemWidth, err := FlatWidth(elemType, resolve)
-		if err != nil {
-			return nil, err
+		elemWidth := len(elemFlat)
+		if elemFlat == nil {
+			elemWidth, err = FlatWidth(elemType, resolve)
+			if err != nil {
+				return nil, err
+			}
 		}
 		for range elemWidth {
 			if _, err := vi.Next(); err != nil {
@@ -1065,7 +1184,7 @@ func liftFlatOption(vi valueIter, elemType binary.TypeDesc, resolve Resolver, me
 		return nil, nil
 	case 1:
 		// Some
-		return liftFlatImpl(vi, elemType, resolve, mem)
+		return liftFlatImpl(vi, elemType, elemFlat, resolve, mem)
 	default:
 		return nil, fmt.Errorf("liftFlat option: invalid discriminant %d", disc)
 	}
@@ -1077,16 +1196,21 @@ func liftFlatOption(vi valueIter, elemType binary.TypeDesc, resolve Resolver, me
 // were coerced up to the joined type on the way out are decoded correctly,
 // and any joined positions the active arm didn't fill are consumed and
 // discarded so the outer iterator stays aligned.
-func liftFlatResult(vi valueIter, desc binary.ResultDesc, resolve Resolver, mem []byte) (Value, error) {
+// flat, when non-nil, is Flatten(desc) already known by the caller (see
+// liftFlatImpl's doc); nil computes it here as before.
+func liftFlatResult(vi valueIter, desc binary.ResultDesc, flat []string, resolve Resolver, mem []byte) (Value, error) {
 	cv, err := vi.Next()
 	if err != nil {
 		return nil, err
 	}
 	disc := cv.AsI32()
 
-	resultFlat, err := Flatten(desc, resolve)
-	if err != nil {
-		return nil, err
+	resultFlat := flat
+	if resultFlat == nil {
+		resultFlat, err = Flatten(desc, resolve)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if len(resultFlat) == 0 || resultFlat[0] != "i32" {
 		return nil, fmt.Errorf("liftFlat result: expected first element to be i32 discriminant")
@@ -1117,27 +1241,27 @@ func liftFlatResult(vi valueIter, desc binary.ResultDesc, resolve Resolver, mem 
 
 	// Read the arm payload THROUGH vi (which may be an enclosing
 	// coercingValueIter) so nested variant/result levels compose -- see
-	// coercingValueIter's doc.
-	coerceVI := &coercingValueIter{
-		underlying: vi,
-		joinedFlat: joinedFlat,
-		caseFlat:   armFlatTypes,
-	}
+	// coercingValueIter's doc. Pooled and released exactly as in
+	// liftFlatVariant.
+	coerceVI := getCoercingValueIter(vi, joinedFlat, armFlatTypes)
 
 	var payload Value
 	if armRef != nil {
 		armType, err := resolveType(armRef, resolve)
 		if err != nil {
+			putCoercingValueIter(coerceVI)
 			return nil, err
 		}
-		payload, err = liftFlatImpl(coerceVI, armType, resolve, mem)
+		payload, err = liftFlatImpl(coerceVI, armType, armFlatTypes, resolve, mem)
 		if err != nil {
+			putCoercingValueIter(coerceVI)
 			return nil, fmt.Errorf("liftFlat result payload: %w", err)
 		}
 	}
 
 	// Consume remaining joined flat values the active arm didn't fill.
 	remainingJoined := len(joinedFlat) - coerceVI.idx
+	putCoercingValueIter(coerceVI)
 	for i := 0; i < remainingJoined; i++ {
 		if _, err := vi.Next(); err != nil {
 			return nil, err

--- a/internal/component/abi/flat.go
+++ b/internal/component/abi/flat.go
@@ -40,12 +40,14 @@ func LowerFlatInto(dst []CoreValue, v Value, t binary.TypeDesc, resolve Resolver
 	// it -- only to throw that away and re-store via spillValue: wasted work
 	// AND leaked allocations that shift the bump allocator. (LowerStep.Lower
 	// makes the same spill-first decision; found via the complex ABI battery.)
-	flatTypes, err := Flatten(t, resolve)
+	// Only the width decides the spill, so this asks for the count rather
+	// than building the flattened type list and measuring it.
+	flatWidth, err := FlatWidth(t, resolve)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(flatTypes) > MaxFlatParams {
+	if flatWidth > MaxFlatParams {
 		// Spill: Store the value to memory and return a pointer.
 		ptr, err := spillValue(v, t, mem, resolve, realloc)
 		if err != nil {
@@ -614,12 +616,14 @@ func spillValue(v Value, t binary.TypeDesc, mem []byte, resolve Resolver, reallo
 //
 // This mirrors the canonical ABI lift_flat() function.
 func LiftFlat(vals []CoreValue, t binary.TypeDesc, resolve Resolver, mem []byte) (Value, error) {
-	flatTypes, err := Flatten(t, resolve)
+	// Only the width decides the spill, so this asks for the count rather
+	// than building the flattened type list and measuring it.
+	flatWidth, err := FlatWidth(t, resolve)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(flatTypes) > MaxFlatParams {
+	if flatWidth > MaxFlatParams {
 		// Spilled: first value is a pointer to memory.
 		if len(vals) != 1 {
 			return nil, fmt.Errorf("LiftFlat: expected 1 value for spilled type, got %d", len(vals))
@@ -1049,11 +1053,11 @@ func liftFlatOption(vi valueIter, elemType binary.TypeDesc, resolve Resolver, me
 	switch disc {
 	case 0:
 		// None: consume and discard the padding.
-		elemFlatTypes, err := Flatten(elemType, resolve)
+		elemWidth, err := FlatWidth(elemType, resolve)
 		if err != nil {
 			return nil, err
 		}
-		for range elemFlatTypes {
+		for range elemWidth {
 			if _, err := vi.Next(); err != nil {
 				return nil, err
 			}

--- a/internal/component/abi/flat_kinds_test.go
+++ b/internal/component/abi/flat_kinds_test.go
@@ -1,0 +1,181 @@
+package abi
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samyfodil/wazy/internal/component/binary"
+)
+
+// TestLiftFlatKindsMatchesLiftFlat proves LiftFlatKinds (the planned
+// guest->host entry: precomputed flat kinds + raw stack bits) lifts exactly
+// what LiftFlat lifts from the equivalent []CoreValue, across the whole
+// oracle battery -- including the spilled arm, where both expect a single
+// pointer core value.
+func TestLiftFlatKindsMatchesLiftFlat(t *testing.T) {
+	goldenEntries := loadFlatOracleGolden(t)
+	battery := loadFlatOracleBattery(t)
+
+	for _, entry := range goldenEntries {
+		desc, ok := battery.descByName[entry.Type]
+		if !ok {
+			continue
+		}
+		flat, err := Flatten(desc, battery.resolve)
+		if err != nil {
+			continue
+		}
+		t.Run(entry.Name, func(t *testing.T) {
+			rawValue := battery.valueMap[fmt.Sprintf("%s:%s", entry.Type, entry.Name)]
+			v, err := convertTestValue(rawValue, desc, battery.resolve)
+			if err != nil {
+				t.Fatalf("convert: %v", err)
+			}
+			// Lower to the flat core values a caller would find on the core
+			// stack (a spilling type lowers to its single pointer, exactly
+			// what the guest passes).
+			mem := make([]byte, 65536)
+			core, err := LowerFlat(v, desc, battery.resolve, ReallocFunc(newBumpAllocator(1024).realloc), mem)
+			if err != nil {
+				t.Fatalf("LowerFlat: %v", err)
+			}
+
+			refVal, refErr := LiftFlat(core, desc, battery.resolve, mem)
+
+			bits := make([]uint64, len(core))
+			for i, cv := range core {
+				bits[i] = cv.Bits
+			}
+			kindsVal, kindsErr := LiftFlatKinds(flat, bits, desc, battery.resolve, mem)
+
+			if (refErr == nil) != (kindsErr == nil) {
+				t.Fatalf("error mismatch: LiftFlat err=%v, LiftFlatKinds err=%v", refErr, kindsErr)
+			}
+			if refErr != nil {
+				return
+			}
+			if fmt.Sprintf("%#v", kindsVal) != fmt.Sprintf("%#v", refVal) {
+				t.Errorf("lift mismatch: kinds %#v, ref %#v", kindsVal, refVal)
+			}
+		})
+	}
+}
+
+// TestLiftFlatKindsBitCountMismatch proves the non-spilled arm fails loud
+// when the caller's bits don't match the flat kind list -- the guard that
+// replaces liftHostArgsPlanned's old per-value stack-underflow check.
+func TestLiftFlatKindsBitCountMismatch(t *testing.T) {
+	desc := binary.PrimitiveDesc{Prim: "u32"}
+	_, err := LiftFlatKinds([]string{"i32"}, nil, desc, nil, nil)
+	if err == nil {
+		t.Fatal("expected an error for 0 bits against 1 flat kind")
+	}
+	_, err = LiftFlatKinds([]string{"i32"}, []uint64{1, 2}, desc, nil, nil)
+	if err == nil {
+		t.Fatal("expected an error for 2 bits against 1 flat kind")
+	}
+}
+
+// TestLiftFlatKindsSpilledWrongBitCount proves the spilled arm (flat wider
+// than MaxFlatParams) requires exactly the one pointer core value, matching
+// LiftFlat's own spilled-arity check.
+func TestLiftFlatKindsSpilledWrongBitCount(t *testing.T) {
+	// 17 u32 fields flatten to 17 > MaxFlatParams entries.
+	fields := make([]binary.RecordField, MaxFlatParams+1)
+	for i := range fields {
+		fields[i] = binary.RecordField{Name: fmt.Sprintf("f%d", i), Type: binary.TypeRef{Primitive: "u32"}}
+	}
+	desc := binary.RecordDesc{Fields: fields}
+	flat, err := Flatten(desc, nil)
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	if len(flat) <= MaxFlatParams {
+		t.Fatalf("test type does not spill (width %d)", len(flat))
+	}
+	if _, err := LiftFlatKinds(flat, []uint64{0, 0}, desc, nil, make([]byte, 64)); err == nil {
+		t.Fatal("expected an error for 2 bits against a spilled type")
+	}
+}
+
+// TestStackValueIterExhausted proves the pooled kinds+bits iterator fails
+// loud past its end (a defensive branch: LiftFlatKinds pre-checks the
+// lengths, so only a flat-width bug could reach it) and reports Done
+// correctly.
+func TestStackValueIterExhausted(t *testing.T) {
+	it := getStackValueIter([]string{"i32"}, []uint64{7})
+	defer putStackValueIter(it)
+	if it.Done() {
+		t.Fatal("Done before any Next")
+	}
+	cv, err := it.Next()
+	if err != nil || cv.Kind != "i32" || cv.Bits != 7 {
+		t.Fatalf("Next: got {%s %d}, err %v", cv.Kind, cv.Bits, err)
+	}
+	if !it.Done() {
+		t.Fatal("not Done after consuming the only value")
+	}
+	if _, err := it.Next(); err == nil {
+		t.Fatal("expected an error reading past the end")
+	}
+}
+
+// TestLiftListU8CompactShape pins the compact list<u8> lift: the value is a
+// []byte holding a COPY of the guest bytes (a lifted value must not alias
+// live guest memory), through both the flat path (LiftFlat) and the
+// in-memory path (Load), while a non-u8 list keeps the general []Value
+// shape.
+func TestLiftListU8CompactShape(t *testing.T) {
+	mem := make([]byte, 64)
+	copy(mem[8:], "abc")
+
+	u8List := binary.ListDesc{Element: binary.TypeRef{Primitive: "u8"}}
+	core := []CoreValue{NewCoreValueI32(8), NewCoreValueI32(3)}
+	v, err := LiftFlat(core, u8List, nil, mem)
+	if err != nil {
+		t.Fatalf("LiftFlat: %v", err)
+	}
+	b, ok := v.([]byte)
+	if !ok || string(b) != "abc" {
+		t.Fatalf("lifted list<u8> = %#v, want []byte(\"abc\")", v)
+	}
+	mem[8] = 'z' // mutate the guest memory the lift read from
+	if string(b) != "abc" {
+		t.Fatal("lifted []byte aliases guest memory instead of copying it")
+	}
+
+	// In-memory shape: [ptr:4][len:4] at offset 0 pointing at the same bytes.
+	mem[8] = 'a'
+	mem[0], mem[4] = 8, 3
+	lv, err := Load(mem, 0, u8List, nil)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if lb, ok := lv.([]byte); !ok || string(lb) != "abc" {
+		t.Fatalf("loaded list<u8> = %#v, want []byte(\"abc\")", lv)
+	}
+
+	// A non-u8 element type stays the general []Value shape.
+	u16List := binary.ListDesc{Element: binary.TypeRef{Primitive: "u16"}}
+	mem[8], mem[9] = 0x01, 0x00
+	v16, err := LiftFlat([]CoreValue{NewCoreValueI32(8), NewCoreValueI32(1)}, u16List, nil, mem)
+	if err != nil {
+		t.Fatalf("LiftFlat u16: %v", err)
+	}
+	if _, ok := v16.([]Value); !ok {
+		t.Fatalf("lifted list<u16> = %T, want []Value", v16)
+	}
+}
+
+// TestLiftListU8CompactBounds proves the fast path keeps the general path's
+// bounds check, including the ptr+length wraparound case.
+func TestLiftListU8CompactBounds(t *testing.T) {
+	mem := make([]byte, 16)
+	u8List := binary.ListDesc{Element: binary.TypeRef{Primitive: "u8"}}
+	if _, err := LiftFlat([]CoreValue{NewCoreValueI32(8), NewCoreValueI32(9)}, u8List, nil, mem); err == nil {
+		t.Fatal("expected an out-of-bounds error for len past the end of memory")
+	}
+	if _, err := LiftFlat([]CoreValue{NewCoreValueI32(0xFFFFFFFF), NewCoreValueI32(2)}, u8List, nil, mem); err == nil {
+		t.Fatal("expected an out-of-bounds error for a wrapping ptr+len")
+	}
+}

--- a/internal/component/abi/flat_kinds_test.go
+++ b/internal/component/abi/flat_kinds_test.go
@@ -155,15 +155,16 @@ func TestLiftListU8CompactShape(t *testing.T) {
 		t.Fatalf("loaded list<u8> = %#v, want []byte(\"abc\")", lv)
 	}
 
-	// A non-u8 element type stays the general []Value shape.
+	// Every fixed-width primitive element lifts to its own typed slice, not
+	// only u8.
 	u16List := binary.ListDesc{Element: binary.TypeRef{Primitive: "u16"}}
 	mem[8], mem[9] = 0x01, 0x00
 	v16, err := LiftFlat([]CoreValue{NewCoreValueI32(8), NewCoreValueI32(1)}, u16List, nil, mem)
 	if err != nil {
 		t.Fatalf("LiftFlat u16: %v", err)
 	}
-	if _, ok := v16.([]Value); !ok {
-		t.Fatalf("lifted list<u16> = %T, want []Value", v16)
+	if got, ok := v16.([]uint16); !ok || len(got) != 1 || got[0] != 1 {
+		t.Fatalf("lifted list<u16> = %#v, want []uint16{1}", v16)
 	}
 }
 

--- a/internal/component/abi/flat_oracle_test.go
+++ b/internal/component/abi/flat_oracle_test.go
@@ -492,6 +492,12 @@ func convertTestValue(rawValue any, t binary.TypeDesc, resolve Resolver) (Value,
 			}
 			result[i] = v
 		}
+		// A list of a fixed-width primitive lifts to the typed slice for that
+		// primitive, so that is the shape the oracle expects back. The values
+		// are the battery's either way; only the container differs.
+		if typed, ok := scalarSliceOf(result, elemType); ok {
+			return typed, nil
+		}
 		return result, nil
 
 	case binary.RecordDesc:
@@ -679,4 +685,93 @@ func convertTestPrimitive(rawValue any, prim string) (Value, error) {
 	}
 
 	return nil, fmt.Errorf("cannot convert value %v to primitive %s", rawValue, prim)
+}
+
+// scalarSliceOf packs a []Value of primitive elements into the typed slice
+// lifting produces for that primitive. ok is false for an element type that
+// has no typed slice, which stays []Value.
+//
+// It is written from the element Value types rather than from scalarlist.go's
+// decoders on purpose: if the two ever disagree about what a list<u32> holds,
+// the oracle should fail rather than agree with the code under test.
+func scalarSliceOf(vals []Value, elemType binary.TypeDesc) (Value, bool) {
+	p, ok := elemType.(binary.PrimitiveDesc)
+	if !ok {
+		return nil, false
+	}
+	switch p.Prim {
+	case "u8":
+		out := make([]byte, len(vals))
+		for i, v := range vals {
+			out[i] = byte(v.(uint32))
+		}
+		return out, true
+	case "s8":
+		out := make([]int8, len(vals))
+		for i, v := range vals {
+			out[i] = int8(v.(int32))
+		}
+		return out, true
+	case "bool":
+		out := make([]bool, len(vals))
+		for i, v := range vals {
+			out[i] = v.(bool)
+		}
+		return out, true
+	case "u16":
+		out := make([]uint16, len(vals))
+		for i, v := range vals {
+			out[i] = uint16(v.(uint32))
+		}
+		return out, true
+	case "s16":
+		out := make([]int16, len(vals))
+		for i, v := range vals {
+			out[i] = int16(v.(int32))
+		}
+		return out, true
+	case "u32":
+		out := make([]uint32, len(vals))
+		for i, v := range vals {
+			out[i] = v.(uint32)
+		}
+		return out, true
+	case "s32":
+		out := make([]int32, len(vals))
+		for i, v := range vals {
+			out[i] = v.(int32)
+		}
+		return out, true
+	case "u64":
+		out := make([]uint64, len(vals))
+		for i, v := range vals {
+			out[i] = v.(uint64)
+		}
+		return out, true
+	case "s64":
+		out := make([]int64, len(vals))
+		for i, v := range vals {
+			out[i] = v.(int64)
+		}
+		return out, true
+	case "f32":
+		out := make([]float32, len(vals))
+		for i, v := range vals {
+			out[i] = v.(float32)
+		}
+		return out, true
+	case "f64":
+		out := make([]float64, len(vals))
+		for i, v := range vals {
+			out[i] = v.(float64)
+		}
+		return out, true
+	case "char":
+		out := make([]rune, len(vals))
+		for i, v := range vals {
+			out[i] = v.(rune)
+		}
+		return out, true
+	}
+	return nil, false
 }

--- a/internal/component/abi/flat_string_list_errbranch_test.go
+++ b/internal/component/abi/flat_string_list_errbranch_test.go
@@ -207,7 +207,7 @@ func TestDeCoerceValue(t *testing.T) {
 
 func TestLowerFlatOptionFlattenError(t *testing.T) {
 	mem := make([]byte, 100)
-	_, err := lowerFlatOption(nil, binary.FuncDesc{}, nil, okRealloc, mem)
+	_, err := lowerFlatOption(nil, binary.FuncDesc{}, nil, nil, okRealloc, mem)
 	if err == nil {
 		t.Error("expected error when elemType cannot be flattened")
 	}
@@ -215,7 +215,7 @@ func TestLowerFlatOptionFlattenError(t *testing.T) {
 
 func TestLowerFlatOptionSomePayloadError(t *testing.T) {
 	mem := make([]byte, 100)
-	_, err := lowerFlatOption("not-a-u32", binary.PrimitiveDesc{Prim: "u32"}, nil, okRealloc, mem)
+	_, err := lowerFlatOption("not-a-u32", binary.PrimitiveDesc{Prim: "u32"}, nil, nil, okRealloc, mem)
 	if err == nil {
 		t.Error("expected error propagated from Some payload lowering")
 	}
@@ -226,7 +226,7 @@ func TestLowerFlatOptionSomePayloadError(t *testing.T) {
 // wider than 1 core value.
 func TestLowerFlatOptionNonePaddingWidth(t *testing.T) {
 	mem := make([]byte, 100)
-	result, err := lowerFlatOption(nil, binary.PrimitiveDesc{Prim: "string"}, nil, okRealloc, mem)
+	result, err := lowerFlatOption(nil, binary.PrimitiveDesc{Prim: "string"}, nil, nil, okRealloc, mem)
 	if err != nil {
 		t.Fatalf("lowerFlatOption: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestLowerFlatOptionNonePaddingWidth(t *testing.T) {
 func TestLowerFlatResultFlattenError(t *testing.T) {
 	mem := make([]byte, 100)
 	badRef := binary.TypeRef{}
-	_, err := lowerFlatResult(ResultValue{IsErr: false, Payload: nil}, binary.ResultDesc{Ok: &badRef}, nil, okRealloc, mem)
+	_, err := lowerFlatResult(ResultValue{IsErr: false, Payload: nil}, binary.ResultDesc{Ok: &badRef}, nil, nil, okRealloc, mem)
 	if err == nil {
 		t.Error("expected error when result Ok type cannot be flattened/resolved")
 	}
@@ -251,7 +251,7 @@ func TestLowerFlatResultFlattenError(t *testing.T) {
 
 func TestLowerFlatResultNotAResultValue(t *testing.T) {
 	mem := make([]byte, 100)
-	_, err := lowerFlatResult("not a result", binary.ResultDesc{}, nil, okRealloc, mem)
+	_, err := lowerFlatResult("not a result", binary.ResultDesc{}, nil, nil, okRealloc, mem)
 	if err == nil || !strings.Contains(err.Error(), "expected ResultValue") {
 		t.Errorf("expected type error, got %v", err)
 	}
@@ -260,7 +260,7 @@ func TestLowerFlatResultNotAResultValue(t *testing.T) {
 func TestLowerFlatResultPayloadError(t *testing.T) {
 	mem := make([]byte, 100)
 	okRef := binary.TypeRef{Primitive: "u32"}
-	_, err := lowerFlatResult(ResultValue{IsErr: false, Payload: "bad"}, binary.ResultDesc{Ok: &okRef}, nil, okRealloc, mem)
+	_, err := lowerFlatResult(ResultValue{IsErr: false, Payload: "bad"}, binary.ResultDesc{Ok: &okRef}, nil, nil, okRealloc, mem)
 	if err == nil {
 		t.Error("expected error propagated from Ok payload lowering")
 	}
@@ -277,7 +277,7 @@ func TestLowerFlatResultPadsNarrowerArm(t *testing.T) {
 	errRef := binary.TypeRef{Primitive: "u32"}   // width 1
 	desc := binary.ResultDesc{Ok: &okRef, Err: &errRef}
 
-	result, err := lowerFlatResult(ResultValue{IsErr: true, Payload: uint32(42)}, desc, nil, okRealloc, mem)
+	result, err := lowerFlatResult(ResultValue{IsErr: true, Payload: uint32(42)}, desc, nil, nil, okRealloc, mem)
 	if err != nil {
 		t.Fatalf("lowerFlatResult: %v", err)
 	}
@@ -302,7 +302,7 @@ func TestLowerFlatResultPadsNarrowerArm(t *testing.T) {
 func TestLiftFlatOptionFlattenError(t *testing.T) {
 	mem := make([]byte, 100)
 	vi := NewCoreValueIter([]CoreValue{NewCoreValueI32(0)})
-	_, err := liftFlatOption(vi, binary.FuncDesc{}, nil, mem)
+	_, err := liftFlatOption(vi, binary.FuncDesc{}, nil, nil, mem)
 	if err == nil {
 		t.Error("expected error when elemType cannot be flattened")
 	}
@@ -312,7 +312,7 @@ func TestLiftFlatOptionNonePaddingExhausted(t *testing.T) {
 	mem := make([]byte, 100)
 	// disc=0 (none) but no padding value follows, even though string needs 2.
 	vi := NewCoreValueIter([]CoreValue{NewCoreValueI32(0)})
-	_, err := liftFlatOption(vi, binary.PrimitiveDesc{Prim: "string"}, nil, mem)
+	_, err := liftFlatOption(vi, binary.PrimitiveDesc{Prim: "string"}, nil, nil, mem)
 	if err == nil {
 		t.Error("expected error when none-padding is exhausted early")
 	}
@@ -321,7 +321,7 @@ func TestLiftFlatOptionNonePaddingExhausted(t *testing.T) {
 func TestLiftFlatOptionInvalidDiscriminant(t *testing.T) {
 	mem := make([]byte, 100)
 	vi := NewCoreValueIter([]CoreValue{NewCoreValueI32(7)})
-	_, err := liftFlatOption(vi, binary.PrimitiveDesc{Prim: "u32"}, nil, mem)
+	_, err := liftFlatOption(vi, binary.PrimitiveDesc{Prim: "u32"}, nil, nil, mem)
 	if err == nil {
 		t.Error("expected error for invalid option discriminant")
 	}
@@ -330,7 +330,7 @@ func TestLiftFlatOptionInvalidDiscriminant(t *testing.T) {
 func TestLiftFlatOptionSomePayloadError(t *testing.T) {
 	mem := make([]byte, 100)
 	vi := NewCoreValueIter([]CoreValue{NewCoreValueI32(1), NewCoreValueI32(0x110000)})
-	_, err := liftFlatOption(vi, binary.PrimitiveDesc{Prim: "char"}, nil, mem)
+	_, err := liftFlatOption(vi, binary.PrimitiveDesc{Prim: "char"}, nil, nil, mem)
 	if err == nil {
 		t.Error("expected error propagated from Some payload lifting")
 	}
@@ -342,7 +342,7 @@ func TestLiftFlatResultFlattenError(t *testing.T) {
 	mem := make([]byte, 100)
 	badRef := binary.TypeRef{}
 	vi := NewCoreValueIter([]CoreValue{NewCoreValueI32(0)})
-	_, err := liftFlatResult(vi, binary.ResultDesc{Ok: &badRef}, nil, mem)
+	_, err := liftFlatResult(vi, binary.ResultDesc{Ok: &badRef}, nil, nil, mem)
 	if err == nil {
 		t.Error("expected error when result Ok type cannot be flattened/resolved")
 	}
@@ -351,7 +351,7 @@ func TestLiftFlatResultFlattenError(t *testing.T) {
 func TestLiftFlatResultInvalidDiscriminant(t *testing.T) {
 	mem := make([]byte, 100)
 	vi := NewCoreValueIter([]CoreValue{NewCoreValueI32(9)})
-	_, err := liftFlatResult(vi, binary.ResultDesc{}, nil, mem)
+	_, err := liftFlatResult(vi, binary.ResultDesc{}, nil, nil, mem)
 	if err == nil {
 		t.Error("expected error for invalid result discriminant")
 	}
@@ -361,7 +361,7 @@ func TestLiftFlatResultPayloadError(t *testing.T) {
 	mem := make([]byte, 100)
 	okRef := binary.TypeRef{Primitive: "char"}
 	vi := NewCoreValueIter([]CoreValue{NewCoreValueI32(0), NewCoreValueI32(0x110000)})
-	_, err := liftFlatResult(vi, binary.ResultDesc{Ok: &okRef}, nil, mem)
+	_, err := liftFlatResult(vi, binary.ResultDesc{Ok: &okRef}, nil, nil, mem)
 	if err == nil {
 		t.Error("expected error propagated from Ok payload lifting")
 	}
@@ -384,7 +384,7 @@ func (mockValueIter) Done() bool               { return true }
 func TestLiftFlatResultComposesArbitraryIter(t *testing.T) {
 	mem := make([]byte, 100)
 	okRef := binary.TypeRef{Primitive: "u32"}
-	v, err := liftFlatResult(mockValueIter{}, binary.ResultDesc{Ok: &okRef}, nil, mem)
+	v, err := liftFlatResult(mockValueIter{}, binary.ResultDesc{Ok: &okRef}, nil, nil, mem)
 	if err != nil {
 		t.Fatalf("liftFlatResult with a generic valueIter should succeed, got %v", err)
 	}
@@ -405,7 +405,7 @@ func TestLiftFlatResultRoundTripsPaddedArm(t *testing.T) {
 	desc := binary.ResultDesc{Ok: &okRef, Err: &errRef}
 
 	vi := NewCoreValueIter([]CoreValue{NewCoreValueI32(1), NewCoreValueI32(42), NewCoreValueI32(0)})
-	got, err := liftFlatResult(vi, desc, nil, mem)
+	got, err := liftFlatResult(vi, desc, nil, nil, mem)
 	if err != nil {
 		t.Fatalf("liftFlatResult: %v", err)
 	}

--- a/internal/component/abi/flatten.go
+++ b/internal/component/abi/flatten.go
@@ -209,38 +209,41 @@ func flattenVariant(desc binary.VariantDesc, resolve Resolver) ([]string, error)
 
 	// Collect all case payloads and join their types.
 	//
-	// The counts are known up front (FlatWidth builds nothing), so the two
-	// slices are allocated once at their final size, and the per-slot
-	// candidate list is one buffer reused down the slots rather than one
-	// allocation per slot. The join itself is unchanged.
+	// Each payload is flattened exactly once and the join width is taken
+	// from those results. Asking FlatWidth for the width first and
+	// flattening afterwards would walk every payload twice, and the two
+	// walks are only guaranteed to agree if the resolver returns the same
+	// descriptor both times -- which the public Resolver type does not
+	// promise. A wider second walk would then be silently truncated to the
+	// stale width, which is corrupted layout rather than an error.
+	//
+	// Counting the payload cases needs no resolution, so the slice holding
+	// them is still allocated once, and the per-slot candidate list is one
+	// buffer reused down the slots. The join itself is unchanged.
 	payloads := 0
+	for _, c := range desc.Cases {
+		if c.Type != nil {
+			payloads++
+		}
+	}
+
+	caseFlats := make([][]string, 0, payloads)
 	maxLen := 0
 	for _, c := range desc.Cases {
 		if c.Type == nil {
 			continue
 		}
-		w, err := flatWidthRef(c.Type, resolve)
+		ct, err := resolveType(c.Type, resolve)
 		if err != nil {
 			return nil, err
 		}
-		payloads++
-		if w > maxLen {
-			maxLen = w
+		cFlat, err := Flatten(ct, resolve)
+		if err != nil {
+			return nil, err
 		}
-	}
-
-	caseFlats := make([][]string, 0, payloads)
-	for _, c := range desc.Cases {
-		if c.Type != nil {
-			ct, err := resolveType(c.Type, resolve)
-			if err != nil {
-				return nil, err
-			}
-			cFlat, err := Flatten(ct, resolve)
-			if err != nil {
-				return nil, err
-			}
-			caseFlats = append(caseFlats, cFlat)
+		caseFlats = append(caseFlats, cFlat)
+		if len(cFlat) > maxLen {
+			maxLen = len(cFlat)
 		}
 	}
 

--- a/internal/component/abi/flatten.go
+++ b/internal/component/abi/flatten.go
@@ -48,7 +48,7 @@ func Flatten(t binary.TypeDesc, resolve Resolver) ([]string, error) {
 	// is a PrimitiveDesc (see binary.isPrimValtype), so it flows through the
 	// PrimitiveDesc case above via flattenPrimitive, not this one.
 	case binary.OwnDesc, binary.BorrowDesc, binary.StreamDesc, binary.FutureDesc:
-		return []string{"i32"}, nil
+		return flatKindsI32, nil
 
 	// Unsupported
 	case binary.FuncDesc, binary.InstanceDesc, binary.ComponentDesc, binary.ResourceDesc:
@@ -122,8 +122,9 @@ func FlattenFunc(f binary.FuncDesc, resolve Resolver, context string) (params []
 
 // ------- Primitive Flattening -------
 
-// Shared, read-only flat-type-name slices returned by flattenPrimitive and
-// flattenList. Every element of the flat ABI is content-only ("i32"/"i64"/
+// Shared, read-only flat-type-name slices returned by flattenPrimitive,
+// flattenList, and every other single-i32 flattening (handles, flags, enums).
+// Every element of the flat ABI is content-only ("i32"/"i64"/
 // "f32"/"f64" string constants describing a *type*, never call-specific
 // data), so every call site with a given primitive/list shape can safely
 // share one underlying array instead of allocating a fresh literal each
@@ -290,7 +291,7 @@ func flattenFlagsNumLabels(numLabels int) ([]string, error) {
 		return nil, fmt.Errorf("invalid flags: %d labels", numLabels)
 	}
 	// Flags always flatten to a single i32
-	return []string{"i32"}, nil
+	return flatKindsI32, nil
 }
 
 // flattenEnum flattens an enum to always exactly one core "i32" value,
@@ -301,7 +302,7 @@ func flattenEnum(desc binary.EnumDesc) ([]string, error) {
 	if len(desc.Cases) <= 0 {
 		return nil, fmt.Errorf("invalid enum: %d cases", len(desc.Cases))
 	}
-	return []string{"i32"}, nil
+	return flatKindsI32, nil
 }
 
 func flattenOption(desc binary.OptionDesc, resolve Resolver) ([]string, error) {

--- a/internal/component/abi/flatten.go
+++ b/internal/component/abi/flatten.go
@@ -177,7 +177,13 @@ func flattenList(_ binary.ListDesc, _ Resolver) ([]string, error) {
 }
 
 func flattenRecord(desc binary.RecordDesc, resolve Resolver) ([]string, error) {
-	var flat []string
+	// The width is known without building anything, so the result is
+	// allocated once at its final size rather than grown field by field.
+	width, err := FlatWidth(desc, resolve)
+	if err != nil {
+		return nil, err
+	}
+	flat := make([]string, 0, width)
 	for _, f := range desc.Fields {
 		ft, err := resolveType(&f.Type, resolve)
 		if err != nil {
@@ -200,8 +206,29 @@ func flattenVariant(desc binary.VariantDesc, resolve Resolver) ([]string, error)
 		return nil, err
 	}
 
-	// Collect all case payloads and join their types
-	var caseFlats [][]string
+	// Collect all case payloads and join their types.
+	//
+	// The counts are known up front (FlatWidth builds nothing), so the two
+	// slices are allocated once at their final size, and the per-slot
+	// candidate list is one buffer reused down the slots rather than one
+	// allocation per slot. The join itself is unchanged.
+	payloads := 0
+	maxLen := 0
+	for _, c := range desc.Cases {
+		if c.Type == nil {
+			continue
+		}
+		w, err := flatWidthRef(c.Type, resolve)
+		if err != nil {
+			return nil, err
+		}
+		payloads++
+		if w > maxLen {
+			maxLen = w
+		}
+	}
+
+	caseFlats := make([][]string, 0, payloads)
 	for _, c := range desc.Cases {
 		if c.Type != nil {
 			ct, err := resolveType(c.Type, resolve)
@@ -216,33 +243,30 @@ func flattenVariant(desc binary.VariantDesc, resolve Resolver) ([]string, error)
 		}
 	}
 
-	// Join all case flats together by position
-	var joined []string
-	maxLen := 0
-	for _, cFlat := range caseFlats {
-		if len(cFlat) > maxLen {
-			maxLen = len(cFlat)
-		}
-	}
+	out := make([]string, 0, len(discFlat)+maxLen)
+	out = append(out, discFlat...)
 
+	candidates := make([]string, 0, payloads)
 	for i := 0; i < maxLen; i++ {
-		var candidates []string
+		candidates = candidates[:0]
 		for _, cFlat := range caseFlats {
 			if i < len(cFlat) {
 				candidates = append(candidates, cFlat[i])
 			}
 		}
 		if len(candidates) > 0 {
-			joined = append(joined, joinCoreTypes(candidates))
+			out = append(out, joinCoreTypes(candidates))
 		}
 	}
-
-	// Prepend discriminant
-	return append(discFlat, joined...), nil
+	return out, nil
 }
 
 func flattenTuple(desc binary.TupleDesc, resolve Resolver) ([]string, error) {
-	var flat []string
+	width, err := FlatWidth(desc, resolve)
+	if err != nil {
+		return nil, err
+	}
+	flat := make([]string, 0, width)
 	for _, elem := range desc.Elements {
 		et, err := resolveType(&elem, resolve)
 		if err != nil {
@@ -290,12 +314,10 @@ func flattenOption(desc binary.OptionDesc, resolve Resolver) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Discriminant (u8) + max(element)
-	// u8 flattens to i32, join with element
-	var candidates []string
-	candidates = append(candidates, "i32") // discriminant
-	candidates = append(candidates, elemFlat...)
-	return candidates, nil
+	// Discriminant (u8, which flattens to i32) followed by the element.
+	out := make([]string, 0, 1+len(elemFlat))
+	out = append(out, "i32")
+	return append(out, elemFlat...), nil
 }
 
 func flattenResult(desc binary.ResultDesc, resolve Resolver) ([]string, error) {
@@ -325,12 +347,17 @@ func flattenResult(desc binary.ResultDesc, resolve Resolver) ([]string, error) {
 		}
 	}
 
-	// Join ok and error flats by position
-	var joined []string
+	// Join ok and error flats by position, onto the discriminant (a u8, which
+	// flattens to i32). One allocation at the final size, and a two-element
+	// candidate buffer reused down the slots.
 	maxLen := max(len(errFlat), max(len(okFlat), 0))
 
+	out := make([]string, 0, 1+maxLen)
+	out = append(out, "i32")
+
+	var buf [2]string
 	for i := range maxLen {
-		var candidates []string
+		candidates := buf[:0]
 		if i < len(okFlat) {
 			candidates = append(candidates, okFlat[i])
 		}
@@ -338,12 +365,10 @@ func flattenResult(desc binary.ResultDesc, resolve Resolver) ([]string, error) {
 			candidates = append(candidates, errFlat[i])
 		}
 		if len(candidates) > 0 {
-			joined = append(joined, joinCoreTypes(candidates))
+			out = append(out, joinCoreTypes(candidates))
 		}
 	}
-
-	// Prepend discriminant (u8, flattens to i32)
-	return append([]string{"i32"}, joined...), nil
+	return out, nil
 }
 
 // ------- Helper: Join core types -------

--- a/internal/component/abi/flatwidth.go
+++ b/internal/component/abi/flatwidth.go
@@ -6,6 +6,25 @@ import (
 	"github.com/samyfodil/wazy/internal/component/binary"
 )
 
+// maxFlatWidth bounds a flattened width.
+//
+// Widths are summed over a type graph the resolver hands back, and nothing
+// stops a malformed or hostile component from describing one that expands
+// exponentially -- a record of records, nested deeply enough. Unbounded
+// addition would wrap to a negative width and take the spill decision with
+// it, which is a corrupted lift rather than a rejected type. The bound is far
+// above any real signature (Flatten of such a type would be building a
+// multi-megabyte slice by then), so reaching it means the type is malformed.
+const maxFlatWidth = 1 << 20
+
+// addFlatWidth sums two widths, failing rather than wrapping.
+func addFlatWidth(a, b int) (int, error) {
+	if a > maxFlatWidth-b {
+		return 0, fmt.Errorf("flattened width exceeds %d core values", maxFlatWidth)
+	}
+	return a + b, nil
+}
+
 // FlatWidth returns how many core values t flattens to, without building the
 // flattened type list.
 //
@@ -35,7 +54,9 @@ func FlatWidth(t binary.TypeDesc, resolve Resolver) (int, error) {
 			if err != nil {
 				return 0, err
 			}
-			total += w
+			if total, err = addFlatWidth(total, w); err != nil {
+				return 0, err
+			}
 		}
 		return total, nil
 
@@ -46,7 +67,9 @@ func FlatWidth(t binary.TypeDesc, resolve Resolver) (int, error) {
 			if err != nil {
 				return 0, err
 			}
-			total += w
+			if total, err = addFlatWidth(total, w); err != nil {
+				return 0, err
+			}
 		}
 		return total, nil
 
@@ -70,14 +93,14 @@ func FlatWidth(t binary.TypeDesc, resolve Resolver) (int, error) {
 		if err != nil {
 			return 0, err
 		}
-		return disc + widest, nil
+		return addFlatWidth(disc, widest)
 
 	case binary.OptionDesc:
 		w, err := flatWidthRef(&desc.Element, resolve)
 		if err != nil {
 			return 0, err
 		}
-		return 1 + w, nil
+		return addFlatWidth(1, w)
 
 	case binary.ResultDesc:
 		var okW, errW int
@@ -95,7 +118,7 @@ func FlatWidth(t binary.TypeDesc, resolve Resolver) (int, error) {
 		if errW > okW {
 			okW = errW
 		}
-		return 1 + okW, nil
+		return addFlatWidth(1, okW)
 
 	case binary.FlagsDesc:
 		// Reuses flattenFlagsNumLabels rather than repeating its label cap,

--- a/internal/component/abi/flatwidth.go
+++ b/internal/component/abi/flatwidth.go
@@ -1,0 +1,144 @@
+package abi
+
+import (
+	"fmt"
+
+	"github.com/samyfodil/wazy/internal/component/binary"
+)
+
+// FlatWidth returns how many core values t flattens to, without building the
+// flattened type list.
+//
+// It answers exactly len(Flatten(t, resolve)) -- flatwidth_test.go asserts that
+// on every shape, including the errors -- and exists because most callers only
+// ever wanted the count. Flatten allocates a []string per node of the type
+// graph, so asking it for a number means allocating a tree and reading its
+// length: on the wasi:http path that was the single largest source of garbage,
+// since every option::none rebuilt its element's whole flattened layout just to
+// learn how many core slots to skip.
+//
+// Callers that need the flattened types themselves (variant and result lifting
+// coerce each slot against the joined types) still use Flatten.
+func FlatWidth(t binary.TypeDesc, resolve Resolver) (int, error) {
+	switch desc := t.(type) {
+	case binary.PrimitiveDesc:
+		return flatWidthPrimitive(desc.Prim)
+
+	case binary.ListDesc:
+		// A dynamic list is a pointer and a length.
+		return 2, nil
+
+	case binary.RecordDesc:
+		total := 0
+		for i := range desc.Fields {
+			w, err := flatWidthRef(&desc.Fields[i].Type, resolve)
+			if err != nil {
+				return 0, err
+			}
+			total += w
+		}
+		return total, nil
+
+	case binary.TupleDesc:
+		total := 0
+		for i := range desc.Elements {
+			w, err := flatWidthRef(&desc.Elements[i], resolve)
+			if err != nil {
+				return 0, err
+			}
+			total += w
+		}
+		return total, nil
+
+	case binary.VariantDesc:
+		// A discriminant, then the join of the case payloads -- and a join is
+		// as wide as its widest member.
+		widest := 0
+		for _, c := range desc.Cases {
+			if c.Type == nil {
+				continue
+			}
+			w, err := flatWidthRef(c.Type, resolve)
+			if err != nil {
+				return 0, err
+			}
+			if w > widest {
+				widest = w
+			}
+		}
+		disc, err := flatWidthPrimitive(DiscriminantType(len(desc.Cases)))
+		if err != nil {
+			return 0, err
+		}
+		return disc + widest, nil
+
+	case binary.OptionDesc:
+		w, err := flatWidthRef(&desc.Element, resolve)
+		if err != nil {
+			return 0, err
+		}
+		return 1 + w, nil
+
+	case binary.ResultDesc:
+		var okW, errW int
+		var err error
+		if desc.Ok != nil {
+			if okW, err = flatWidthRef(desc.Ok, resolve); err != nil {
+				return 0, err
+			}
+		}
+		if desc.Err != nil {
+			if errW, err = flatWidthRef(desc.Err, resolve); err != nil {
+				return 0, err
+			}
+		}
+		if errW > okW {
+			okW = errW
+		}
+		return 1 + okW, nil
+
+	case binary.FlagsDesc:
+		// Reuses flattenFlagsNumLabels rather than repeating its label cap,
+		// so an invalid flags set fails identically either way.
+		f, err := flattenFlagsNumLabels(len(desc.Names))
+		if err != nil {
+			return 0, err
+		}
+		return len(f), nil
+
+	case binary.EnumDesc:
+		f, err := flattenEnum(desc)
+		if err != nil {
+			return 0, err
+		}
+		return len(f), nil
+
+	case binary.OwnDesc, binary.BorrowDesc, binary.StreamDesc, binary.FutureDesc:
+		return 1, nil
+
+	case binary.FuncDesc, binary.InstanceDesc, binary.ComponentDesc, binary.ResourceDesc:
+		return 0, fmt.Errorf("cannot flatten unsupported type: %T", t)
+
+	default:
+		return 0, fmt.Errorf("unknown type descriptor: %T", t)
+	}
+}
+
+// flatWidthRef resolves ref and returns its flat width.
+func flatWidthRef(ref *binary.TypeRef, resolve Resolver) (int, error) {
+	t, err := resolveType(ref, resolve)
+	if err != nil {
+		return 0, err
+	}
+	return FlatWidth(t, resolve)
+}
+
+// flatWidthPrimitive is flattenPrimitive's width, sharing its unknown-primitive
+// error so the two cannot disagree about what is valid.
+func flatWidthPrimitive(prim string) (int, error) {
+	f, err := flattenPrimitive(prim)
+	if err != nil {
+		return 0, err
+	}
+	return len(f), nil
+}

--- a/internal/component/abi/flatwidth_test.go
+++ b/internal/component/abi/flatwidth_test.go
@@ -64,6 +64,10 @@ func flatWidthCases() (map[string]binary.TypeDesc, Resolver) {
 		"flags":  binary.FlagsDesc{Names: []string{"x", "y"}},
 		"own":    binary.OwnDesc{ResourceType: 1},
 		"borrow": binary.BorrowDesc{ResourceType: 1},
+		// Async handles flatten as a bare i32 like own/borrow: the element
+		// type they carry is not flattened.
+		"stream": binary.StreamDesc{},
+		"future": binary.FutureDesc{},
 
 		"record":       binary.RecordDesc{Fields: []binary.RecordField{{Name: "a", Type: prim("u32")}}},
 		"record empty": binary.RecordDesc{},
@@ -184,21 +188,29 @@ func TestFlatWidthErrorsMatchFlatten(t *testing.T) {
 // reason it exists.
 func TestFlatWidthDoesNotAllocate(t *testing.T) {
 	cases, resolve := flatWidthCases()
+
+	// Every shape, not one: the flags and enum arms reach different helpers
+	// than the rest, so a single deep case would leave them unproven -- and
+	// they did in fact allocate until those helpers stopped returning fresh
+	// literals.
+	for name, desc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Warm any lazily built state so it is not counted.
+			if _, err := FlatWidth(desc, resolve); err != nil {
+				t.Fatal(err)
+			}
+			allocs := testing.AllocsPerRun(100, func() {
+				if _, err := FlatWidth(desc, resolve); err != nil {
+					t.Fatal(err)
+				}
+			})
+			if allocs != 0 {
+				t.Errorf("FlatWidth allocated %v objects per call, want 0", allocs)
+			}
+		})
+	}
+
 	desc := cases["deeply nested"]
-
-	// Warm any lazily built state so it is not counted.
-	if _, err := FlatWidth(desc, resolve); err != nil {
-		t.Fatal(err)
-	}
-
-	allocs := testing.AllocsPerRun(100, func() {
-		if _, err := FlatWidth(desc, resolve); err != nil {
-			t.Fatal(err)
-		}
-	})
-	if allocs != 0 {
-		t.Errorf("FlatWidth allocated %v objects per call, want 0", allocs)
-	}
 
 	// For contrast, and to document why this function exists at all.
 	flatAllocs := testing.AllocsPerRun(100, func() {
@@ -209,5 +221,5 @@ func TestFlatWidthDoesNotAllocate(t *testing.T) {
 	if flatAllocs == 0 {
 		t.Skip("Flatten no longer allocates; FlatWidth may be redundant")
 	}
-	t.Logf("Flatten allocates %v objects per call, FlatWidth %v", flatAllocs, allocs)
+	t.Logf("Flatten allocates %v objects per call for the same shape; FlatWidth 0", flatAllocs)
 }

--- a/internal/component/abi/flatwidth_test.go
+++ b/internal/component/abi/flatwidth_test.go
@@ -1,0 +1,213 @@
+package abi
+
+import (
+	"testing"
+
+	"github.com/samyfodil/wazy/internal/component/binary"
+)
+
+// FlatWidth exists only as a cheaper way to ask len(Flatten(...)). The moment
+// the two disagree, a lift reads the wrong number of core values and the guest
+// gets silently mangled data, so the contract is checked directly against
+// Flatten over every shape rather than assumed.
+
+// prim is a TypeRef for a primitive.
+func prim(p string) binary.TypeRef { return binary.TypeRef{Primitive: p} }
+
+// tableResolver interns descs and resolves them by index, standing in for a
+// component's own type table.
+type tableResolver struct{ entries []binary.TypeDesc }
+
+func (r *tableResolver) add(d binary.TypeDesc) binary.TypeRef {
+	idx := uint32(len(r.entries))
+	r.entries = append(r.entries, d)
+	return binary.TypeRef{TypeIndex: &idx}
+}
+
+func (r *tableResolver) resolver() Resolver {
+	return func(i uint32) binary.TypeDesc {
+		if int(i) >= len(r.entries) {
+			return nil
+		}
+		return r.entries[i]
+	}
+}
+
+// flatWidthCases builds a corpus covering every descriptor kind, each nested
+// inside the composites that join rather than concatenate.
+func flatWidthCases() (map[string]binary.TypeDesc, Resolver) {
+	r := &tableResolver{}
+
+	strRec := r.add(binary.RecordDesc{Fields: []binary.RecordField{
+		{Name: "a", Type: prim("string")},
+		{Name: "b", Type: prim("u64")},
+	}})
+	wideRec := r.add(binary.RecordDesc{Fields: []binary.RecordField{
+		{Name: "a", Type: prim("f64")},
+		{Name: "b", Type: prim("string")},
+		{Name: "c", Type: prim("s8")},
+	}})
+
+	cases := map[string]binary.TypeDesc{
+		// Primitives: string is the one that is two slots wide.
+		"bool":          binary.PrimitiveDesc{Prim: "bool"},
+		"u8":            binary.PrimitiveDesc{Prim: "u8"},
+		"s64":           binary.PrimitiveDesc{Prim: "s64"},
+		"f32":           binary.PrimitiveDesc{Prim: "f32"},
+		"f64":           binary.PrimitiveDesc{Prim: "f64"},
+		"char":          binary.PrimitiveDesc{Prim: "char"},
+		"string":        binary.PrimitiveDesc{Prim: "string"},
+		"error-context": binary.PrimitiveDesc{Prim: "error-context"},
+
+		"list":   binary.ListDesc{Element: prim("u8")},
+		"enum":   binary.EnumDesc{Cases: []string{"a", "b", "c"}},
+		"flags":  binary.FlagsDesc{Names: []string{"x", "y"}},
+		"own":    binary.OwnDesc{ResourceType: 1},
+		"borrow": binary.BorrowDesc{ResourceType: 1},
+
+		"record":       binary.RecordDesc{Fields: []binary.RecordField{{Name: "a", Type: prim("u32")}}},
+		"record empty": binary.RecordDesc{},
+		"record nested": binary.RecordDesc{Fields: []binary.RecordField{
+			{Name: "a", Type: strRec},
+			{Name: "b", Type: wideRec},
+		}},
+
+		"tuple":       binary.TupleDesc{Elements: []binary.TypeRef{prim("u32"), prim("string")}},
+		"tuple empty": binary.TupleDesc{},
+
+		"option":        binary.OptionDesc{Element: prim("u32")},
+		"option string": binary.OptionDesc{Element: prim("string")},
+		"option record": binary.OptionDesc{Element: wideRec},
+
+		// A variant whose cases are of different widths: the join is as wide
+		// as the widest, which is the rule most easily got wrong.
+		"variant mixed widths": binary.VariantDesc{Cases: []binary.VariantCase{
+			{Name: "none"},
+			{Name: "one", Type: refOf(prim("u32"))},
+			{Name: "wide", Type: refOf(wideRec)},
+		}},
+		"variant all empty": binary.VariantDesc{Cases: []binary.VariantCase{
+			{Name: "a"}, {Name: "b"},
+		}},
+		"variant one case": binary.VariantDesc{Cases: []binary.VariantCase{
+			{Name: "only", Type: refOf(prim("f64"))},
+		}},
+
+		"result both":  binary.ResultDesc{Ok: refOf(prim("u32")), Err: refOf(prim("string"))},
+		"result ok":    binary.ResultDesc{Ok: refOf(prim("u64"))},
+		"result err":   binary.ResultDesc{Err: refOf(wideRec)},
+		"result empty": binary.ResultDesc{},
+		"result nested": binary.ResultDesc{
+			Ok:  refOf(binary.TypeRef{TypeIndex: strRec.TypeIndex}),
+			Err: refOf(prim("string")),
+		},
+	}
+
+	// Deeply nested: the shape the wasi:http path actually carries.
+	deep := binary.RecordDesc{Fields: []binary.RecordField{
+		{Name: "opt", Type: r.add(binary.OptionDesc{Element: wideRec})},
+		{Name: "res", Type: r.add(binary.ResultDesc{Ok: refOf(strRec), Err: refOf(prim("string"))})},
+		{Name: "var", Type: r.add(binary.VariantDesc{Cases: []binary.VariantCase{
+			{Name: "a", Type: refOf(prim("u32"))},
+			{Name: "b", Type: refOf(wideRec)},
+		}})},
+	}}
+	cases["deeply nested"] = deep
+
+	return cases, r.resolver()
+}
+
+func refOf(r binary.TypeRef) *binary.TypeRef { return &r }
+
+func TestFlatWidthMatchesFlatten(t *testing.T) {
+	cases, resolve := flatWidthCases()
+
+	for name, desc := range cases {
+		t.Run(name, func(t *testing.T) {
+			flat, flatErr := Flatten(desc, resolve)
+			width, widthErr := FlatWidth(desc, resolve)
+
+			if (flatErr == nil) != (widthErr == nil) {
+				t.Fatalf("Flatten err = %v but FlatWidth err = %v", flatErr, widthErr)
+			}
+			if flatErr != nil {
+				return
+			}
+			if width != len(flat) {
+				t.Fatalf("FlatWidth = %d, len(Flatten) = %d (%v)", width, len(flat), flat)
+			}
+		})
+	}
+}
+
+// The unsupported and malformed descriptors have to fail the same way, since a
+// caller that swapped Flatten for FlatWidth must not start accepting a type the
+// other rejects.
+func TestFlatWidthErrorsMatchFlatten(t *testing.T) {
+	_, resolve := flatWidthCases()
+
+	bad := map[string]binary.TypeDesc{
+		"func":              binary.FuncDesc{},
+		"instance":          binary.InstanceDesc{},
+		"component":         binary.ComponentDesc{},
+		"resource":          binary.ResourceDesc{},
+		"unknown primitive": binary.PrimitiveDesc{Prim: "not-a-primitive"},
+		"flags none":        binary.FlagsDesc{},
+		"flags too many":    binary.FlagsDesc{Names: make([]string, 33)},
+		"enum none":         binary.EnumDesc{},
+		"record bad field": binary.RecordDesc{Fields: []binary.RecordField{
+			{Name: "a", Type: prim("nope")},
+		}},
+		"option bad element":  binary.OptionDesc{Element: prim("nope")},
+		"variant bad payload": binary.VariantDesc{Cases: []binary.VariantCase{{Name: "a", Type: refOf(prim("nope"))}}},
+		"result bad ok":       binary.ResultDesc{Ok: refOf(prim("nope"))},
+		"result bad err":      binary.ResultDesc{Err: refOf(prim("nope"))},
+		"tuple bad element":   binary.TupleDesc{Elements: []binary.TypeRef{prim("nope")}},
+	}
+
+	for name, desc := range bad {
+		t.Run(name, func(t *testing.T) {
+			_, flatErr := Flatten(desc, resolve)
+			_, widthErr := FlatWidth(desc, resolve)
+
+			if flatErr == nil {
+				t.Fatalf("expected Flatten to reject %s", name)
+			}
+			if widthErr == nil {
+				t.Fatalf("Flatten rejected %s but FlatWidth accepted it", name)
+			}
+		})
+	}
+}
+
+// FlatWidth is only worth having if it does not allocate; that is the entire
+// reason it exists.
+func TestFlatWidthDoesNotAllocate(t *testing.T) {
+	cases, resolve := flatWidthCases()
+	desc := cases["deeply nested"]
+
+	// Warm any lazily built state so it is not counted.
+	if _, err := FlatWidth(desc, resolve); err != nil {
+		t.Fatal(err)
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		if _, err := FlatWidth(desc, resolve); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if allocs != 0 {
+		t.Errorf("FlatWidth allocated %v objects per call, want 0", allocs)
+	}
+
+	// For contrast, and to document why this function exists at all.
+	flatAllocs := testing.AllocsPerRun(100, func() {
+		if _, err := Flatten(desc, resolve); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if flatAllocs == 0 {
+		t.Skip("Flatten no longer allocates; FlatWidth may be redundant")
+	}
+	t.Logf("Flatten allocates %v objects per call, FlatWidth %v", flatAllocs, allocs)
+}

--- a/internal/component/abi/layout.go
+++ b/internal/component/abi/layout.go
@@ -561,11 +561,28 @@ func sizeResult(desc binary.ResultDesc, resolve Resolver) (uint32, error) {
 
 // ------- Helper: resolveType -------
 
+// primDescs holds each primitive pre-boxed into the TypeDesc interface.
+// Returning binary.PrimitiveDesc{...} directly boxes a fresh value on every
+// call, and resolveType runs once per node of every type walk.
+var primDescs = func() map[string]binary.TypeDesc {
+	m := map[string]binary.TypeDesc{}
+	for _, p := range []string{
+		"bool", "s8", "u8", "s16", "u16", "s32", "u32", "s64", "u64",
+		"f32", "f64", "char", "string", "error-context",
+	} {
+		m[p] = binary.PrimitiveDesc{Prim: p}
+	}
+	return m
+}()
+
 func resolveType(ref *binary.TypeRef, resolve Resolver) (binary.TypeDesc, error) {
 	if ref == nil {
 		return nil, fmt.Errorf("nil type reference")
 	}
 	if ref.Primitive != "" {
+		if d, ok := primDescs[ref.Primitive]; ok {
+			return d, nil
+		}
 		return binary.PrimitiveDesc{Prim: ref.Primitive}, nil
 	}
 	if ref.TypeIndex != nil {

--- a/internal/component/abi/memory.go
+++ b/internal/component/abi/memory.go
@@ -302,7 +302,34 @@ func loadList(mem []byte, ptr uint32, elemType bintype.TypeDesc, resolve Resolve
 		return nil, err
 	}
 
-	return loadListFromRange(mem, listPtr.(uint32), listLen.(uint32), elemType, resolve)
+	return loadAnyListFromRange(mem, listPtr.(uint32), listLen.(uint32), elemType, resolve)
+}
+
+// loadAnyListFromRange is loadListFromRange behind the list<u8> fast path:
+// a byte list is read as ONE copied []byte -- the compact shape the store
+// side already accepts (byteListValue) and the public ListDesc doc already
+// names for list<u8> -- rather than a []Value costing a boxed interface per
+// BYTE plus a per-element load. Every non-u8 element type takes the general
+// []Value path unchanged. Both lift directions go through here (loadList for
+// the in-memory shape, liftFlatList for the flat ABI) so the two shapes a
+// consumer can observe for list<u8> stay the same everywhere.
+func loadAnyListFromRange(mem []byte, ptr, length uint32, elemType bintype.TypeDesc, resolve Resolver) (Value, error) {
+	if p, isPrim := elemType.(bintype.PrimitiveDesc); isPrim && p.Prim == "u8" {
+		// u8's size and alignment are both 1, so the only check the general
+		// path would apply is the bounds check. The bytes are copied out:
+		// mem is live guest memory, and a lifted value must not alias it.
+		if uint32(len(mem)) < ptr+length || ptr+length < ptr {
+			return nil, fmt.Errorf("loadListFromRange: list buffer overflow at ptr=%d len=%d mem_len=%d", ptr, length, len(mem))
+		}
+		b := make([]byte, length)
+		copy(b, mem[ptr:ptr+length])
+		return b, nil
+	}
+	list, err := loadListFromRange(mem, ptr, length, elemType, resolve)
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
 }
 
 // loadListFromRange reads `length` elements of elemType starting at ptr.

--- a/internal/component/abi/memory.go
+++ b/internal/component/abi/memory.go
@@ -194,13 +194,15 @@ func loadInt(mem []byte, ptr uint32, nbytes uint32, signed bool) (Value, error) 
 	bytes := mem[ptr : ptr+nbytes]
 	switch nbytes {
 	case 1:
-		v := uint32(bytes[0])
+		// A signed byte lifts as int32 whatever its sign. Returning early only
+		// for negatives, as this did, meant a non-negative s8 came back as a
+		// uint32 -- which storePrimitive then refused, so an s8 the host lifted
+		// could not be stored back unless it happened to be negative. The wider
+		// signed widths below never had the split.
 		if signed {
-			if bytes[0]&0x80 != 0 {
-				return int32(int8(bytes[0])), nil
-			}
+			return int32(int8(bytes[0])), nil
 		}
-		return v, nil
+		return uint32(bytes[0]), nil
 
 	case 2:
 		v := binary.LittleEndian.Uint16(bytes)
@@ -305,31 +307,22 @@ func loadList(mem []byte, ptr uint32, elemType bintype.TypeDesc, resolve Resolve
 	return loadAnyListFromRange(mem, listPtr.(uint32), listLen.(uint32), elemType, resolve)
 }
 
-// loadAnyListFromRange is loadListFromRange behind the list<u8> fast path:
-// a byte list is read as ONE copied []byte -- the compact shape the store
-// side already accepts (byteListValue) and the public ListDesc doc already
-// names for list<u8> -- rather than a []Value costing a boxed interface per
-// BYTE plus a per-element load. Every non-u8 element type takes the general
-// []Value path unchanged. Both lift directions go through here (loadList for
-// the in-memory shape, liftFlatList for the flat ABI) so the two shapes a
-// consumer can observe for list<u8> stay the same everywhere.
+// loadAnyListFromRange is loadListFromRange behind the typed-slice rule: a
+// list of a fixed-width primitive is read into the Go slice of that primitive
+// -- []byte for list<u8>, []uint32 for list<u32>, and so on -- rather than a
+// []Value costing a machine word per element. Every other element type takes
+// the general []Value path unchanged.
+//
+// Both lift directions go through here (loadList for the in-memory shape,
+// liftFlatList for the flat ABI) so the two shapes a consumer can observe for
+// one list type stay the same everywhere.
 func loadAnyListFromRange(mem []byte, ptr, length uint32, elemType bintype.TypeDesc, resolve Resolver) (Value, error) {
-	if p, isPrim := elemType.(bintype.PrimitiveDesc); isPrim && p.Prim == "u8" {
-		// u8's size and alignment are both 1, so the only check the general
-		// path would apply is the bounds check. The bytes are copied out:
-		// mem is live guest memory, and a lifted value must not alias it.
-		if uint32(len(mem)) < ptr+length || ptr+length < ptr {
-			return nil, fmt.Errorf("loadListFromRange: list buffer overflow at ptr=%d len=%d mem_len=%d", ptr, length, len(mem))
+	if prim, ok := scalarPrim(elemType); ok {
+		if v, handled, err := liftScalarList(mem, ptr, length, prim); handled {
+			return v, err
 		}
-		b := make([]byte, length)
-		copy(b, mem[ptr:ptr+length])
-		return b, nil
 	}
-	list, err := loadListFromRange(mem, ptr, length, elemType, resolve)
-	if err != nil {
-		return nil, err
-	}
-	return list, nil
+	return loadListFromRange(mem, ptr, length, elemType, resolve)
 }
 
 // loadListFromRange reads `length` elements of elemType starting at ptr.
@@ -880,33 +873,22 @@ func storeList(mem []byte, ptr uint32, v Value, elemType bintype.TypeDesc, resol
 	return storeInt(mem, ptr+ptrSize, length, ptrSize)
 }
 
-// allocStoreAnyList stores a list value that is EITHER the general
-// []Value shape or, for list<u8> only, a raw []byte -- see byteListValue.
+// allocStoreAnyList stores a list value that is EITHER the general []Value
+// shape or the typed slice for a fixed-width primitive element -- []byte for
+// list<u8>, []uint32 for list<u32>, and so on. Both are accepted for every
+// such list; the typed one is what lifting now produces, and the one a host
+// func writing a numeric list already holds.
 func allocStoreAnyList(mem []byte, v Value, elemType bintype.TypeDesc, resolve Resolver, realloc Realloc) (uint32, uint32, error) {
-	if b, ok := byteListValue(v, elemType); ok {
-		return allocStoreBytes(mem, b, realloc)
+	if prim, ok := scalarPrim(elemType); ok {
+		if ptr, n, handled, err := storeScalarList(mem, v, prim, realloc); handled {
+			return ptr, n, err
+		}
 	}
 	list, ok := v.([]Value)
 	if !ok {
-		return 0, 0, fmt.Errorf("expected []Value (or []byte for list<u8>), got %T", v)
+		return 0, 0, fmt.Errorf("expected []Value (or the typed slice for a primitive element), got %T", v)
 	}
 	return allocStoreList(mem, list, elemType, resolve, realloc)
-}
-
-// byteListValue reports whether v is a raw []byte being stored as a
-// `list<u8>`. Value's general shape for a list is []Value (one interface per
-// element), which for a byte list costs a machine word per BYTE -- ~16x the
-// data on 64-bit. Since a host func producing bytes (a file read, an HTTP
-// body, a header value) already holds a []byte, letting it hand that over
-// directly turns the whole lowering into one copy. []Value stays valid
-// everywhere; this is a fast path, not a replacement.
-func byteListValue(v Value, elemType bintype.TypeDesc) ([]byte, bool) {
-	b, ok := v.([]byte)
-	if !ok {
-		return nil, false
-	}
-	p, isPrim := elemType.(bintype.PrimitiveDesc)
-	return b, isPrim && p.Prim == "u8"
 }
 
 // allocStoreBytes is allocStoreList's list<u8> fast path: one realloc and one

--- a/internal/component/abi/plan.go
+++ b/internal/component/abi/plan.go
@@ -34,6 +34,7 @@ type LowerStep struct {
 	t       binary.TypeDesc // kind==composite: the resolved type
 	resolve Resolver        // kind==composite: for the tree-walk body
 	spills  bool            // kind==composite: precomputed len(Flatten(t)) > MaxFlatParams
+	flat    []string        // kind==composite, non-spilling: Flatten(t), handed down the tree-walk
 }
 
 // CompileLower builds the LowerStep for an already-resolved top-level parameter
@@ -56,7 +57,10 @@ func CompileLower(t binary.TypeDesc, resolve Resolver) (LowerStep, error) {
 		if err != nil {
 			return LowerStep{}, err
 		}
-		return LowerStep{kind: lowerKindComposite, t: t, resolve: resolve, spills: len(flat) > MaxFlatParams}, nil
+		// The flat list computed for the spill decision is kept: Lower hands
+		// it down the tree-walk so a variant/result at the top of the tree
+		// doesn't re-Flatten itself on every call (see lowerFlatImpl's doc).
+		return LowerStep{kind: lowerKindComposite, t: t, resolve: resolve, spills: len(flat) > MaxFlatParams, flat: flat}, nil
 	}
 }
 
@@ -103,7 +107,7 @@ func (s *LowerStep) Lower(dst []CoreValue, v Value, realloc Realloc, mem []byte)
 			}
 			return append(dst, NewCoreValueI32(ptr)), nil
 		}
-		flat, err := lowerFlatImpl(v, s.t, s.resolve, realloc, mem)
+		flat, err := lowerFlatImpl(v, s.t, s.flat, s.resolve, realloc, mem)
 		if err != nil {
 			return nil, err
 		}
@@ -128,6 +132,7 @@ type LiftStep struct {
 	prim    string          // kind==liftPrimitive
 	t       binary.TypeDesc // kind==liftSpilled/liftFlatAgg
 	resolve Resolver        // kind==liftSpilled/liftFlatAgg
+	flat    []string        // kind==liftFlatAgg: Flatten(t), handed down the tree-walk
 }
 
 type liftKind uint8
@@ -162,7 +167,10 @@ func CompileLift(t binary.TypeDesc, resolve Resolver) (LiftStep, error) {
 		if len(flat) > MaxFlatResults {
 			return LiftStep{kind: liftSpilled, t: t, resolve: resolve}, nil
 		}
-		return LiftStep{kind: liftFlatAgg, t: t, resolve: resolve}, nil
+		// Keep the flat list computed for the spill decision: Lift hands it
+		// down the tree-walk so the aggregate doesn't re-Flatten itself on
+		// every call (see liftFlatImpl's doc).
+		return LiftStep{kind: liftFlatAgg, t: t, resolve: resolve, flat: flat}, nil
 	}
 }
 
@@ -181,7 +189,7 @@ func (s *LiftStep) Lift(coreResults []CoreValue, mem []byte) (Value, error) {
 		return Load(mem, coreResults[0].AsI32(), s.t, s.resolve)
 	default: // liftFlatAgg
 		vi := getCoreValueIter(coreResults)
-		val, err := liftFlatImpl(vi, s.t, s.resolve, mem)
+		val, err := liftFlatImpl(vi, s.t, s.flat, s.resolve, mem)
 		putCoreValueIter(vi)
 		return val, err
 	}

--- a/internal/component/abi/scalarlist.go
+++ b/internal/component/abi/scalarlist.go
@@ -1,0 +1,333 @@
+package abi
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	bintype "github.com/samyfodil/wazy/internal/component/binary"
+)
+
+// A list of a fixed-width primitive lifts to the Go slice of that primitive --
+// []uint32 for list<u32>, []float64 for list<f64>, []byte for list<u8> -- rather
+// than to a []Value holding one interface per element.
+//
+// The general shape costs a machine word per element on 64-bit, sixteen bytes
+// to carry four, and every consumer of a numeric list converts it back to a
+// typed slice anyway. The typed form is one allocation of exactly the data,
+// laid out contiguously, and it is what a caller wanted in the first place.
+//
+// Only fixed-width primitives qualify: bool, the integers, the floats, and
+// char. A list of strings or of records has no single Go element type, and
+// stays []Value.
+//
+// The encodings here are deliberately identical to what loadPrimitive and
+// storePrimitive produce element by element, and scalarlist_test.go asserts
+// that against them for every type rather than trusting the reading -- a
+// disagreement would not fail, it would hand a guest silently wrong numbers.
+
+// scalarListLen bounds-checks a list of length elements of elemSize bytes at
+// ptr and returns the byte span.
+func scalarListSpan(mem []byte, ptr, length, elemSize uint32) ([]byte, error) {
+	byteLen := length * elemSize
+	// The multiply and the add both have to be checked: a length near 2^32
+	// wraps, and a wrapped span would read somewhere else entirely.
+	if elemSize != 0 && length > (1<<32-1)/elemSize {
+		return nil, fmt.Errorf("loadListFromRange: list length %d overflows at %d bytes per element", length, elemSize)
+	}
+	if ptr+byteLen < ptr || uint32(len(mem)) < ptr+byteLen {
+		return nil, fmt.Errorf("loadListFromRange: list buffer overflow at ptr=%d len=%d mem_len=%d", ptr, byteLen, len(mem))
+	}
+	return mem[ptr : ptr+byteLen], nil
+}
+
+// decodeScalarList reads length elements of elemSize bytes each through dec.
+// dec sees exactly one element's bytes.
+func decodeScalarList[T any](mem []byte, ptr, length, elemSize uint32, dec func([]byte) (T, error)) ([]T, error) {
+	span, err := scalarListSpan(mem, ptr, length, elemSize)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]T, length)
+	for i := range out {
+		v, err := dec(span[uint32(i)*elemSize:])
+		if err != nil {
+			return nil, err
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+// liftScalarList lifts a list of fixed-width primitives into the typed slice
+// for that primitive. handled is false for an element type that has no such
+// slice, which the caller lifts as []Value instead.
+func liftScalarList(mem []byte, ptr, length uint32, prim string) (v Value, handled bool, err error) {
+	switch prim {
+	case "u8":
+		// u8 needs no decode at all, so this is one copy. The bytes are
+		// copied rather than aliased: mem is live guest memory and a lifted
+		// value must not point into it.
+		span, err := scalarListSpan(mem, ptr, length, 1)
+		if err != nil {
+			return nil, true, err
+		}
+		out := make([]byte, length)
+		copy(out, span)
+		return out, true, nil
+
+	case "s8":
+		out, err := decodeScalarList(mem, ptr, length, 1, func(b []byte) (int8, error) { return int8(b[0]), nil })
+		return out, true, err
+
+	case "bool":
+		// Any non-zero byte is true, matching loadPrimitive.
+		out, err := decodeScalarList(mem, ptr, length, 1, func(b []byte) (bool, error) { return b[0] != 0, nil })
+		return out, true, err
+
+	case "u16":
+		out, err := decodeScalarList(mem, ptr, length, 2, func(b []byte) (uint16, error) {
+			return binary.LittleEndian.Uint16(b), nil
+		})
+		return out, true, err
+
+	case "s16":
+		out, err := decodeScalarList(mem, ptr, length, 2, func(b []byte) (int16, error) {
+			return int16(binary.LittleEndian.Uint16(b)), nil
+		})
+		return out, true, err
+
+	case "u32":
+		out, err := decodeScalarList(mem, ptr, length, 4, func(b []byte) (uint32, error) {
+			return binary.LittleEndian.Uint32(b), nil
+		})
+		return out, true, err
+
+	case "s32":
+		out, err := decodeScalarList(mem, ptr, length, 4, func(b []byte) (int32, error) {
+			return int32(binary.LittleEndian.Uint32(b)), nil
+		})
+		return out, true, err
+
+	case "u64":
+		out, err := decodeScalarList(mem, ptr, length, 8, func(b []byte) (uint64, error) {
+			return binary.LittleEndian.Uint64(b), nil
+		})
+		return out, true, err
+
+	case "s64":
+		out, err := decodeScalarList(mem, ptr, length, 8, func(b []byte) (int64, error) {
+			return int64(binary.LittleEndian.Uint64(b)), nil
+		})
+		return out, true, err
+
+	case "f32":
+		out, err := decodeScalarList(mem, ptr, length, 4, func(b []byte) (float32, error) {
+			return math.Float32frombits(binary.LittleEndian.Uint32(b)), nil
+		})
+		return out, true, err
+
+	case "f64":
+		out, err := decodeScalarList(mem, ptr, length, 8, func(b []byte) (float64, error) {
+			return math.Float64frombits(binary.LittleEndian.Uint64(b)), nil
+		})
+		return out, true, err
+
+	case "char":
+		// Validated per element exactly as loadPrimitive does: a list is not
+		// a way to smuggle in an unpaired surrogate.
+		out, err := decodeScalarList(mem, ptr, length, 4, func(b []byte) (rune, error) {
+			i := binary.LittleEndian.Uint32(b)
+			if i >= 0x110000 {
+				return 0, fmt.Errorf("load char: value %d out of range", i)
+			}
+			if i >= 0xD800 && i <= 0xDFFF {
+				return 0, fmt.Errorf("load char: surrogate half %d not allowed", i)
+			}
+			return rune(i), nil
+		})
+		return out, true, err
+	}
+	return nil, false, nil
+}
+
+// encodeScalarList writes each element of in through enc into a freshly
+// allocated guest buffer, and returns its pointer and element count.
+func encodeScalarList[T any](mem []byte, in []T, elemSize, align uint32, realloc Realloc, enc func([]byte, T) error) (uint32, uint32, error) {
+	length := uint32(len(in))
+	if elemSize != 0 && length > (1<<32-1)/elemSize {
+		return 0, 0, fmt.Errorf("list length %d overflows at %d bytes per element", length, elemSize)
+	}
+	byteLen := length * elemSize
+
+	ptr, err := realloc.Grow(0, 0, align, byteLen)
+	if err != nil {
+		return 0, 0, fmt.Errorf("realloc failed: %w", err)
+	}
+	if ptr+byteLen < ptr || uint32(len(mem)) < ptr+byteLen {
+		return 0, 0, fmt.Errorf("allocated memory out of bounds: ptr=%d size=%d", ptr, byteLen)
+	}
+	span := mem[ptr : ptr+byteLen]
+	for i, v := range in {
+		if err := enc(span[uint32(i)*elemSize:], v); err != nil {
+			return 0, 0, err
+		}
+	}
+	return ptr, length, nil
+}
+
+// storeScalarList stores a typed slice as a list of the matching primitive.
+// handled is false when v is not the typed slice for prim, which the caller
+// then stores from its []Value shape instead -- both shapes stay accepted.
+func storeScalarList(mem []byte, v Value, prim string, realloc Realloc) (ptr, n uint32, handled bool, err error) {
+	switch prim {
+	case "u8":
+		b, ok := v.([]byte)
+		if !ok {
+			return 0, 0, false, nil
+		}
+		ptr, n, err = allocStoreBytes(mem, b, realloc)
+		return ptr, n, true, err
+
+	case "s8":
+		in, ok := v.([]int8)
+		if !ok {
+			return 0, 0, false, nil
+		}
+		ptr, n, err = encodeScalarList(mem, in, 1, 1, realloc, func(b []byte, e int8) error {
+			b[0] = byte(e)
+			return nil
+		})
+		return ptr, n, true, err
+
+	case "bool":
+		in, ok := v.([]bool)
+		if !ok {
+			return 0, 0, false, nil
+		}
+		ptr, n, err = encodeScalarList(mem, in, 1, 1, realloc, func(b []byte, e bool) error {
+			b[0] = 0
+			if e {
+				b[0] = 1
+			}
+			return nil
+		})
+		return ptr, n, true, err
+
+	case "u16":
+		in, ok := v.([]uint16)
+		if !ok {
+			return 0, 0, false, nil
+		}
+		ptr, n, err = encodeScalarList(mem, in, 2, 2, realloc, func(b []byte, e uint16) error {
+			binary.LittleEndian.PutUint16(b, e)
+			return nil
+		})
+		return ptr, n, true, err
+
+	case "s16":
+		in, ok := v.([]int16)
+		if !ok {
+			return 0, 0, false, nil
+		}
+		ptr, n, err = encodeScalarList(mem, in, 2, 2, realloc, func(b []byte, e int16) error {
+			binary.LittleEndian.PutUint16(b, uint16(e))
+			return nil
+		})
+		return ptr, n, true, err
+
+	case "u32":
+		in, ok := v.([]uint32)
+		if !ok {
+			return 0, 0, false, nil
+		}
+		ptr, n, err = encodeScalarList(mem, in, 4, 4, realloc, func(b []byte, e uint32) error {
+			binary.LittleEndian.PutUint32(b, e)
+			return nil
+		})
+		return ptr, n, true, err
+
+	case "s32":
+		in, ok := v.([]int32)
+		if !ok {
+			return 0, 0, false, nil
+		}
+		ptr, n, err = encodeScalarList(mem, in, 4, 4, realloc, func(b []byte, e int32) error {
+			binary.LittleEndian.PutUint32(b, uint32(e))
+			return nil
+		})
+		return ptr, n, true, err
+
+	case "u64":
+		in, ok := v.([]uint64)
+		if !ok {
+			return 0, 0, false, nil
+		}
+		ptr, n, err = encodeScalarList(mem, in, 8, 8, realloc, func(b []byte, e uint64) error {
+			binary.LittleEndian.PutUint64(b, e)
+			return nil
+		})
+		return ptr, n, true, err
+
+	case "s64":
+		in, ok := v.([]int64)
+		if !ok {
+			return 0, 0, false, nil
+		}
+		ptr, n, err = encodeScalarList(mem, in, 8, 8, realloc, func(b []byte, e int64) error {
+			binary.LittleEndian.PutUint64(b, uint64(e))
+			return nil
+		})
+		return ptr, n, true, err
+
+	case "f32":
+		in, ok := v.([]float32)
+		if !ok {
+			return 0, 0, false, nil
+		}
+		ptr, n, err = encodeScalarList(mem, in, 4, 4, realloc, func(b []byte, e float32) error {
+			binary.LittleEndian.PutUint32(b, math.Float32bits(e))
+			return nil
+		})
+		return ptr, n, true, err
+
+	case "f64":
+		in, ok := v.([]float64)
+		if !ok {
+			return 0, 0, false, nil
+		}
+		ptr, n, err = encodeScalarList(mem, in, 8, 8, realloc, func(b []byte, e float64) error {
+			binary.LittleEndian.PutUint64(b, math.Float64bits(e))
+			return nil
+		})
+		return ptr, n, true, err
+
+	case "char":
+		in, ok := v.([]rune)
+		if !ok {
+			return 0, 0, false, nil
+		}
+		ptr, n, err = encodeScalarList(mem, in, 4, 4, realloc, func(b []byte, e rune) error {
+			if e < 0 || e >= 0x110000 {
+				return fmt.Errorf("store char: value %d out of range", e)
+			}
+			if e >= 0xD800 && e <= 0xDFFF {
+				return fmt.Errorf("store char: surrogate half %d not allowed", e)
+			}
+			binary.LittleEndian.PutUint32(b, uint32(e))
+			return nil
+		})
+		return ptr, n, true, err
+	}
+	return 0, 0, false, nil
+}
+
+// scalarPrim returns the primitive name of a list's element type, if the
+// element is a primitive at all.
+func scalarPrim(elemType bintype.TypeDesc) (string, bool) {
+	p, ok := elemType.(bintype.PrimitiveDesc)
+	if !ok {
+		return "", false
+	}
+	return p.Prim, true
+}

--- a/internal/component/abi/scalarlist_bench_test.go
+++ b/internal/component/abi/scalarlist_bench_test.go
@@ -1,0 +1,55 @@
+package abi
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samyfodil/wazy/internal/component/binary"
+)
+
+// What the typed-slice rule buys, per element type, against the general
+// []Value path it replaced. Both are the real lifting functions, not stand-ins.
+//
+// The general path is kept for lists whose elements are not fixed-width
+// primitives, so it is not dead code being benchmarked for show: this is the
+// comparison that decides which path a given element type should take.
+func BenchmarkScalarListLift(b *testing.B) {
+	const n = 256
+
+	for _, prim := range []string{"u8", "u16", "u32", "u64", "s32", "f64", "bool"} {
+		elemType := binary.PrimitiveDesc{Prim: prim}
+		size, err := Size(elemType, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		mem := make([]byte, 16+n*size)
+		// Varied, non-zero bytes. Zero-filled memory would let every boxed
+		// element on the general path hit the runtime's small-integer cache
+		// and allocate nothing, which is not what real data does.
+		for i := range mem {
+			mem[i] = byte(i*7 + 1)
+		}
+
+		b.Run(fmt.Sprintf("%s/typed", prim), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				v, _, err := liftScalarList(mem, 16, n, prim)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_ = v
+			}
+		})
+
+		b.Run(fmt.Sprintf("%s/general", prim), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				v, err := loadListFromRange(mem, 16, n, elemType, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_ = v
+			}
+		})
+	}
+}

--- a/internal/component/abi/scalarlist_test.go
+++ b/internal/component/abi/scalarlist_test.go
@@ -1,0 +1,300 @@
+package abi
+
+import (
+	"context"
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/samyfodil/wazy/internal/component/binary"
+)
+
+// A list of a fixed-width primitive lifts to the typed slice for that
+// primitive. The typed path decodes bytes itself rather than going through
+// loadPrimitive per element, so it could drift from the general path in a way
+// nothing would report: the guest would simply receive different numbers.
+//
+// Every test here therefore compares the two paths against each other rather
+// than against hand-written expectations, over values chosen to catch the ways
+// a decode goes wrong -- sign extension, endianness, float bit patterns, and
+// the extremes of each width.
+
+// scalarListCases is one entry per fixed-width primitive: the WIT name, the
+// element size, and values spanning that type's range.
+var scalarListCases = []struct {
+	prim  string
+	size  uint32
+	elems []Value // in the element Value shape loadPrimitive produces
+}{
+	{"bool", 1, []Value{true, false, true}},
+	{"u8", 1, []Value{uint32(0), uint32(1), uint32(127), uint32(255)}},
+	{"s8", 1, []Value{int32(0), int32(1), int32(-1), int32(127), int32(-128)}},
+	{"u16", 2, []Value{uint32(0), uint32(1), uint32(0x00FF), uint32(0xFFFF)}},
+	{"s16", 2, []Value{int32(0), int32(-1), int32(32767), int32(-32768)}},
+	{"u32", 4, []Value{uint32(0), uint32(1), uint32(0xDEADBEEF), uint32(math.MaxUint32)}},
+	{"s32", 4, []Value{int32(0), int32(-1), int32(math.MaxInt32), int32(math.MinInt32)}},
+	{"u64", 8, []Value{uint64(0), uint64(1), uint64(math.MaxUint64)}},
+	{"s64", 8, []Value{int64(0), int64(-1), int64(math.MaxInt64), int64(math.MinInt64)}},
+	// negative zero is a distinct bit pattern from zero, and float32(-0) is
+	// not it -- Go folds that to positive zero, so it has to be built.
+	{"f32", 4, []Value{float32(0), float32(math.Copysign(0, -1)), float32(1.5), float32(math.Inf(-1))}},
+	{"f64", 8, []Value{float64(0), math.Copysign(0, -1), float64(1.5), math.Inf(1), math.MaxFloat64}},
+	{"char", 4, []Value{rune(0), rune('a'), rune(0x10FFFF), rune(0xD7FF)}},
+}
+
+// storeElems writes elems into mem at ptr using storePrimitive -- the general
+// path -- so the typed decode is read against bytes it did not write.
+func storeElems(t *testing.T, mem []byte, ptr uint32, prim string, size uint32, elems []Value) {
+	t.Helper()
+	for i, e := range elems {
+		if err := storePrimitive(mem, ptr+uint32(i)*size, prim, e, Realloc{}); err != nil {
+			t.Fatalf("storePrimitive %s[%d]: %v", prim, i, err)
+		}
+	}
+}
+
+// TestScalarListLiftMatchesGeneralPath is the contract: the typed slice holds
+// exactly the values the []Value path would have held, element for element.
+func TestScalarListLiftMatchesGeneralPath(t *testing.T) {
+	for _, tc := range scalarListCases {
+		t.Run(tc.prim, func(t *testing.T) {
+			mem := make([]byte, 256)
+			const ptr = 16
+			storeElems(t, mem, ptr, tc.prim, tc.size, tc.elems)
+
+			elemType := binary.PrimitiveDesc{Prim: tc.prim}
+			n := uint32(len(tc.elems))
+
+			general, err := loadListFromRange(mem, ptr, n, elemType, nil)
+			if err != nil {
+				t.Fatalf("general path: %v", err)
+			}
+			typed, handled, err := liftScalarList(mem, ptr, n, tc.prim)
+			if err != nil {
+				t.Fatalf("typed path: %v", err)
+			}
+			if !handled {
+				t.Fatalf("%s should have a typed slice", tc.prim)
+			}
+
+			rv := reflect.ValueOf(typed)
+			if rv.Kind() != reflect.Slice {
+				t.Fatalf("typed path returned %T, want a slice", typed)
+			}
+			if rv.Len() != len(general) {
+				t.Fatalf("typed path has %d elements, general path %d", rv.Len(), len(general))
+			}
+			for i := range general {
+				// Compare numerically: the typed element is the natural Go
+				// type of the primitive's width, the general one is widened to
+				// the element Value type, so identical values differ in Go type.
+				if !sameNumber(t, rv.Index(i).Interface(), general[i]) {
+					t.Errorf("element %d: typed %#v, general %#v", i, rv.Index(i).Interface(), general[i])
+				}
+			}
+		})
+	}
+}
+
+// TestScalarListRoundTrip stores a typed slice and lifts it back, which is the
+// path a host func writing a numeric list actually takes.
+func TestScalarListRoundTrip(t *testing.T) {
+	for _, tc := range scalarListCases {
+		t.Run(tc.prim, func(t *testing.T) {
+			mem := make([]byte, 256)
+			const ptr = 16
+			storeElems(t, mem, ptr, tc.prim, tc.size, tc.elems)
+
+			n := uint32(len(tc.elems))
+			typed, _, err := liftScalarList(mem, ptr, n, tc.prim)
+			if err != nil {
+				t.Fatalf("lift: %v", err)
+			}
+
+			// Store it back into a fresh arena through the typed path.
+			out := make([]byte, 256)
+			gotPtr, gotN, handled, err := storeScalarList(out, typed, tc.prim, bumpRealloc(64))
+			if err != nil {
+				t.Fatalf("store: %v", err)
+			}
+			if !handled {
+				t.Fatalf("%s typed slice should have been stored by the typed path", tc.prim)
+			}
+			if gotN != n {
+				t.Fatalf("stored %d elements, want %d", gotN, n)
+			}
+
+			again, _, err := liftScalarList(out, gotPtr, gotN, tc.prim)
+			if err != nil {
+				t.Fatalf("re-lift: %v", err)
+			}
+			if !reflect.DeepEqual(typed, again) {
+				t.Errorf("round trip changed the list:\n got %#v\nwant %#v", again, typed)
+			}
+		})
+	}
+}
+
+// The general []Value shape stays acceptable for storing, since an embedder
+// written before the typed shape existed still hands one over.
+func TestScalarListStoreAcceptsValueShape(t *testing.T) {
+	for _, tc := range scalarListCases {
+		t.Run(tc.prim, func(t *testing.T) {
+			mem := make([]byte, 256)
+			elemType := binary.PrimitiveDesc{Prim: tc.prim}
+
+			ptr, n, err := allocStoreAnyList(mem, tc.elems, elemType, nil, bumpRealloc(64))
+			if err != nil {
+				t.Fatalf("store []Value: %v", err)
+			}
+			if n != uint32(len(tc.elems)) {
+				t.Fatalf("stored %d elements, want %d", n, len(tc.elems))
+			}
+
+			back, err := loadListFromRange(mem, ptr, n, elemType, nil)
+			if err != nil {
+				t.Fatalf("load back: %v", err)
+			}
+			for i := range tc.elems {
+				if !sameNumber(t, tc.elems[i], back[i]) {
+					t.Errorf("element %d: stored %#v, read back %#v", i, tc.elems[i], back[i])
+				}
+			}
+		})
+	}
+}
+
+// An element type with no typed slice keeps the general shape.
+func TestScalarListLeavesAggregatesAlone(t *testing.T) {
+	for _, prim := range []string{"string", "error-context"} {
+		t.Run(prim, func(t *testing.T) {
+			if _, handled, _ := liftScalarList(nil, 0, 0, prim); handled {
+				t.Errorf("%s should not have a typed slice", prim)
+			}
+			if _, _, handled, _ := storeScalarList(nil, []Value{}, prim, Realloc{}); handled {
+				t.Errorf("%s should not be stored by the typed path", prim)
+			}
+		})
+	}
+}
+
+// The typed path keeps the general path's bounds checks, including the
+// wraparound a length near the address space produces.
+func TestScalarListBounds(t *testing.T) {
+	mem := make([]byte, 32)
+
+	if _, _, err := liftScalarList(mem, 8, 100, "u32"); err == nil {
+		t.Error("reading past the end of memory should fail")
+	}
+	// ptr + length*size wraps, so an unchecked bound would pass.
+	if _, _, err := liftScalarList(mem, 8, 1<<30, "u32"); err == nil {
+		t.Error("a length whose byte span overflows should fail")
+	}
+	if _, _, err := liftScalarList(mem, 0, 0, "u32"); err != nil {
+		t.Errorf("an empty list should lift cleanly: %v", err)
+	}
+}
+
+// A char list is validated per element, exactly as a lone char is: a list is
+// not a way to smuggle in a surrogate half.
+func TestScalarListCharValidation(t *testing.T) {
+	mem := make([]byte, 32)
+	// 0xD800 is the low end of the surrogate range.
+	mem[0], mem[1], mem[2], mem[3] = 0x00, 0xD8, 0x00, 0x00
+	if _, _, err := liftScalarList(mem, 0, 1, "char"); err == nil {
+		t.Error("a surrogate half should not lift as a char")
+	}
+
+	mem[0], mem[1], mem[2], mem[3] = 0x00, 0x00, 0x11, 0x00 // 0x110000
+	if _, _, err := liftScalarList(mem, 0, 1, "char"); err == nil {
+		t.Error("a code point above the Unicode range should not lift")
+	}
+
+	if _, _, _, err := storeScalarList(make([]byte, 32), []rune{0xD800}, "char", bumpRealloc(0)); err == nil {
+		t.Error("a surrogate half should not store as a char")
+	}
+}
+
+// sameNumber compares two values that may be the same number in different Go
+// types (uint16 from the typed path against uint32 from the general one).
+func sameNumber(t *testing.T, a, b any) bool {
+	t.Helper()
+	norm := func(v any) any {
+		switch n := v.(type) {
+		case bool:
+			return n
+		case int8:
+			return int64(n)
+		case int16:
+			return int64(n)
+		case int32: // rune is int32, so this covers char too
+			return int64(n)
+		case int64:
+			return n
+		case byte:
+			return uint64(n)
+		case uint16:
+			return uint64(n)
+		case uint32:
+			return uint64(n)
+		case uint64:
+			return n
+		case float32:
+			return float64(n)
+		case float64:
+			return n
+		}
+		return v
+	}
+	na, nb := norm(a), norm(b)
+	if f, ok := na.(float64); ok {
+		g, ok := nb.(float64)
+		// NaN never equals itself; none of the cases use it, and a bit
+		// comparison would be the way if they did.
+		return ok && f == g
+	}
+	return na == nb
+}
+
+// bumpRealloc hands out memory from base upward, which is all these tests need
+// of an allocator.
+func bumpRealloc(base uint32) Realloc {
+	next := base
+	return Realloc{Call: func(_ context.Context, _, _, align, size uint32) (uint32, error) {
+		if align > 1 {
+			next = (next + align - 1) &^ (align - 1)
+		}
+		p := next
+		next += size
+		return p, nil
+	}}
+}
+
+// A signed byte lifts as int32 whatever its sign, so what the host receives can
+// be stored back.
+//
+// loadInt used to return early only for negatives, leaving a non-negative s8 to
+// fall through as a uint32 -- which storePrimitive refused, so an s8 a host
+// lifted could not be handed back unless it happened to be negative. The wider
+// signed widths never had the split, which is why this only ever bit s8.
+func TestSignedByteLiftsSigned(t *testing.T) {
+	mem := make([]byte, 16)
+	for _, v := range []int8{0, 1, 127, -1, -128} {
+		mem[0] = byte(v)
+
+		lifted, err := loadPrimitive(mem, 0, "s8")
+		if err != nil {
+			t.Fatalf("load s8 %d: %v", v, err)
+		}
+		got, ok := lifted.(int32)
+		if !ok {
+			t.Fatalf("s8 %d lifted as %T, want int32", v, lifted)
+		}
+		if got != int32(v) {
+			t.Errorf("s8 %d lifted as %d", v, got)
+		}
+		if err := storePrimitive(mem, 8, "s8", lifted, Realloc{}); err != nil {
+			t.Errorf("storing back the lifted s8 %d: %v", v, err)
+		}
+	}
+}

--- a/internal/component/instance/async_host_import.go
+++ b/internal/component/instance/async_host_import.go
@@ -315,10 +315,11 @@ func buildAsyncHostWrapper(in *Instance, iface, funcName string, hi *hostImport,
 		paramTupleDesc = binary.TupleDesc{Elements: elems}
 	}
 
-	resultCount, resultType, resultUsesMem, err := buildHostResultPlan(fd, resolve)
+	resultPlan, err := buildHostResultPlan(fd, resolve)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("component/instance: async import %q func %q results: %w", iface, funcName, err)
 	}
+	resultCount, resultType, resultUsesMem := resultPlan.count, resultPlan.rt, resultPlan.usesMem
 	if resultCount > 1 {
 		return nil, nil, nil, fmt.Errorf("component/instance: async import %q func %q declares %d results; multiple async-import results are not supported by this milestone", iface, funcName, resultCount)
 	}

--- a/internal/component/instance/host_import.go
+++ b/internal/component/instance/host_import.go
@@ -732,6 +732,10 @@ func buildHostWrapper(in *Instance, iface, funcName string, hi *hostImport, reso
 		var realloc abi.Realloc
 		if reallocOverride != nil {
 			realloc = reallocOfFunc(ctx, reallocOverride)
+		} else {
+			// Resolved through the instance's memo rather than left to
+			// lowerHostResultsPlanned's per-call reallocOf fallback.
+			realloc = in.reallocFor(ctx, memMod)
 		}
 		if err := lowerHostResultsPlanned(ctx, resultCount, resultPT, resultUsesMem, resolve, results, stack, memMod, resources, outPtrIdx, realloc); err != nil {
 			panic(fmt.Errorf("component/instance: host import %q %q: %w", iface, funcName, err))

--- a/internal/component/instance/host_import.go
+++ b/internal/component/instance/host_import.go
@@ -635,9 +635,17 @@ func buildHostWrapper(in *Instance, iface, funcName string, hi *hostImport, reso
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("component/instance: import %q func %q params: %w", iface, funcName, err)
 	}
-	resultCount, resultPT, resultUsesMem, err := buildHostResultPlan(fd, resolve)
+	resultPlan, err := buildHostResultPlan(fd, resolve)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("component/instance: import %q func %q results: %w", iface, funcName, err)
+	}
+
+	// reallocOverride is fixed at bind time, so its ctx-free Call closure is
+	// built once here rather than letting reallocOfFunc mint a fresh closure
+	// inside every guest->host call below.
+	var overrideReallocCall reallocCall
+	if reallocOverride != nil {
+		overrideReallocCall = coreReallocCall(reallocOverride)
 	}
 
 	fn := api.GoModuleFunc(func(ctx context.Context, mod api.Module, stack []uint64) {
@@ -730,14 +738,14 @@ func buildHostWrapper(in *Instance, iface, funcName string, hi *hostImport, reso
 			panic(fmt.Errorf("component/instance: host import %q %q: %w", iface, funcName, err))
 		}
 		var realloc abi.Realloc
-		if reallocOverride != nil {
-			realloc = reallocOfFunc(ctx, reallocOverride)
+		if overrideReallocCall != nil {
+			realloc = abi.Realloc{Ctx: ctx, Call: overrideReallocCall}
 		} else {
 			// Resolved through the instance's memo rather than left to
 			// lowerHostResultsPlanned's per-call reallocOf fallback.
 			realloc = in.reallocFor(ctx, memMod)
 		}
-		if err := lowerHostResultsPlanned(ctx, resultCount, resultPT, resultUsesMem, resolve, results, stack, memMod, resources, outPtrIdx, realloc); err != nil {
+		if err := lowerHostResultsPlanned(ctx, resultPlan, resolve, results, stack, memMod, resources, outPtrIdx, realloc); err != nil {
 			panic(fmt.Errorf("component/instance: host import %q %q: %w", iface, funcName, err))
 		}
 	})
@@ -877,14 +885,14 @@ func liftHostArgsPlanned(in *Instance, plans []hostParamPlan, resolve abi.Resolv
 		if pp.usesMem && !memAvailable {
 			return nil, lent, fmt.Errorf("param %d requires linear memory (string/list), but the calling module has none", i)
 		}
-		cvs := make([]abi.CoreValue, len(pp.flat))
-		for k := range pp.flat {
-			if pos+k >= len(stack) {
-				return nil, lent, fmt.Errorf("param %d: core stack underflow (need %d values, have %d)", i, pos+len(pp.flat), len(stack))
-			}
-			cvs[k] = abi.CoreValue{Kind: pp.flat[k], Bits: stack[pos+k]}
+		if pos+len(pp.flat) > len(stack) {
+			return nil, lent, fmt.Errorf("param %d: core stack underflow (need %d values, have %d)", i, pos+len(pp.flat), len(stack))
 		}
-		v, err := abi.LiftFlat(cvs, pp.pt, resolve, mem)
+		// LiftFlatKinds pairs the plan's flat kinds with the raw stack bits
+		// through a pooled iterator -- no per-param []CoreValue -- and hands
+		// pp.flat down the lift so a variant/result param doesn't re-Flatten
+		// itself per call.
+		v, err := abi.LiftFlatKinds(pp.flat, stack[pos:pos+len(pp.flat)], pp.pt, resolve, mem)
 		if err != nil {
 			return nil, lent, fmt.Errorf("param %d: lift: %w", i, err)
 		}
@@ -1157,53 +1165,68 @@ func allocHandleResult(resources *handleTable, rt binary.TypeDesc, v abi.Value) 
 // multi-module graph may need to supply the canon's own declared realloc
 // rather than deriving one from mod).
 func lowerHostResults(ctx context.Context, fd binary.FuncDesc, resolve abi.Resolver, results []abi.Value, stack []uint64, mod api.Module, resources *handleTable, outPtrIdx int, realloc abi.Realloc) error {
-	resultCount, rt, resultUsesMem, err := buildHostResultPlan(fd, resolve)
+	plan, err := buildHostResultPlan(fd, resolve)
 	if err != nil {
 		return err
 	}
-	return lowerHostResultsPlanned(ctx, resultCount, rt, resultUsesMem, resolve, results, stack, mod, resources, outPtrIdx, realloc)
+	return lowerHostResultsPlanned(ctx, plan, resolve, results, stack, mod, resources, outPtrIdx, realloc)
 }
 
-// buildHostResultPlan precomputes the result-lower facts for fd: the declared
-// result count, and (when exactly one) the resolved result type and whether it
-// needs linear memory. resultCount 0 or >1 is left for lowerHostResultsPlanned
-// to handle at call time, exactly as before (the >1 case is a milestone limit,
-// not a bind-time error).
-func buildHostResultPlan(fd binary.FuncDesc, resolve abi.Resolver) (resultCount int, rt binary.TypeDesc, usesMem bool, err error) {
+// hostResultPlan is the bind-time-precomputed lower plan for a host import's
+// results: the declared count and (when exactly one) the resolved result
+// type, whether it needs linear memory, and the compiled abi.LowerStep that
+// lowers it without re-deriving the type facts per call.
+type hostResultPlan struct {
+	count   int
+	rt      binary.TypeDesc // valid when count == 1
+	usesMem bool            // valid when count == 1
+	step    abi.LowerStep   // valid when count == 1
+}
+
+// buildHostResultPlan precomputes the result-lower facts for fd. A count of
+// 0 or >1 is left for lowerHostResultsPlanned to handle at call time, exactly
+// as before (the >1 case is a milestone limit, not a bind-time error).
+func buildHostResultPlan(fd binary.FuncDesc, resolve abi.Resolver) (hostResultPlan, error) {
 	refs := funcResultTypeRefs(fd)
-	resultCount = len(refs)
-	if resultCount != 1 {
-		return resultCount, nil, false, nil
+	plan := hostResultPlan{count: len(refs)}
+	if plan.count != 1 {
+		return plan, nil
 	}
-	rt, err = resolveTypeRef(&refs[0], resolve)
+	rt, err := resolveTypeRef(&refs[0], resolve)
 	if err != nil {
-		return resultCount, nil, false, fmt.Errorf("result: %w", err)
+		return plan, fmt.Errorf("result: %w", err)
 	}
 	if typeContainsAsyncValueNested(rt, resolve, 0) {
-		return resultCount, nil, false, fmt.Errorf("result: stream/future/error-context nested inside a composite type is not supported by this milestone")
+		return plan, fmt.Errorf("result: stream/future/error-context nested inside a composite type is not supported by this milestone")
 	}
-	return resultCount, rt, usesMemory(rt, resolve), nil
+	step, err := abi.CompileLower(rt, resolve)
+	if err != nil {
+		return plan, fmt.Errorf("result: %w", err)
+	}
+	plan.rt, plan.usesMem, plan.step = rt, usesMemory(rt, resolve), step
+	return plan, nil
 }
 
 // lowerHostResultsPlanned is lowerHostResults with the result count / resolved
-// type / memory-need precomputed (see buildHostResultPlan). resolve is still
-// needed for LowerFlat/Store's composite tree-walk.
-func lowerHostResultsPlanned(ctx context.Context, resultCount int, rt binary.TypeDesc, resultUsesMem bool, resolve abi.Resolver, results []abi.Value, stack []uint64, mod api.Module, resources *handleTable, outPtrIdx int, realloc abi.Realloc) error {
-	if len(results) != resultCount {
-		return fmt.Errorf("returned %d result(s), but the import declares %d", len(results), resultCount)
+// type / memory-need / lower step precomputed (see buildHostResultPlan).
+// resolve is still needed for Store's composite tree-walk on the out-pointer
+// path.
+func lowerHostResultsPlanned(ctx context.Context, plan hostResultPlan, resolve abi.Resolver, results []abi.Value, stack []uint64, mod api.Module, resources *handleTable, outPtrIdx int, realloc abi.Realloc) error {
+	if len(results) != plan.count {
+		return fmt.Errorf("returned %d result(s), but the import declares %d", len(results), plan.count)
 	}
-	if resultCount == 0 {
+	if plan.count == 0 {
 		return nil
 	}
-	if resultCount > 1 {
-		return fmt.Errorf("declares %d results; multiple host-func results are not supported by this milestone", resultCount)
+	if plan.count > 1 {
+		return fmt.Errorf("declares %d results; multiple host-func results are not supported by this milestone", plan.count)
 	}
 
 	mem, memAvailable := memoryBytesOf(mod)
-	if resultUsesMem && !memAvailable {
+	if plan.usesMem && !memAvailable {
 		return fmt.Errorf("result requires linear memory (string/list), but the calling module has none")
 	}
-	resultVal, err := allocHandleResult(resources, rt, results[0])
+	resultVal, err := allocHandleResult(resources, plan.rt, results[0])
 	if err != nil {
 		return fmt.Errorf("result: %w", err)
 	}
@@ -1219,13 +1242,17 @@ func lowerHostResultsPlanned(ctx context.Context, resultCount int, rt binary.Typ
 			return fmt.Errorf("result: out-pointer stack slot %d out of range (stack has %d value(s))", outPtrIdx, len(stack))
 		}
 		ptr := api.DecodeU32(stack[outPtrIdx])
-		if err := abi.Store(mem, ptr, rt, resultVal, resolve, realloc); err != nil {
+		if err := abi.Store(mem, ptr, plan.rt, resultVal, resolve, realloc); err != nil {
 			return fmt.Errorf("result: store spilled result: %w", err)
 		}
 		return nil
 	}
 
-	flat, err := abi.LowerFlat(resultVal, rt, resolve, realloc, mem)
+	// A result lowered flat here is at most MaxFlatResults core values wide
+	// (anything wider took the outPtrIdx path above), so a small fixed
+	// buffer covers it -- no per-call result slice.
+	var flatBuf [abi.MaxFlatResults]abi.CoreValue
+	flat, err := plan.step.Lower(flatBuf[:0], resultVal, realloc, mem)
 	if err != nil {
 		return fmt.Errorf("result: lower: %w", err)
 	}

--- a/internal/component/instance/host_import_test.go
+++ b/internal/component/instance/host_import_test.go
@@ -474,6 +474,13 @@ func TestLowerHostResults(t *testing.T) {
 	if err := lowerHostResults(ctx, fdMulti, resMulti, []abi.Value{uint32(1), uint32(2)}, make([]uint64, 2), mod, newHandleTable(), -1, abi.Realloc{}); err == nil {
 		t.Fatal("expected multiple-results error")
 	}
+
+	// a result type that resolves but cannot be flattened fails at plan time
+	// (buildHostResultPlan's CompileLower arm)
+	fdBad, resBad := synthFuncDesc(nil, []binary.TypeDesc{binary.ResourceDesc{}})
+	if err := lowerHostResults(ctx, fdBad, resBad, []abi.Value{uint32(1)}, stack, mod, newHandleTable(), -1, abi.Realloc{}); err == nil {
+		t.Fatal("expected a compile error for an unflattenable result type")
+	}
 }
 
 // TestLowerHostResults_Spilled proves the out-pointer path itself (not just

--- a/internal/component/instance/instance.go
+++ b/internal/component/instance/instance.go
@@ -139,6 +139,16 @@ func putCoreValueSlice(p *[]abi.CoreValue) {
 type Instance struct {
 	resolve abi.Resolver
 
+	// reallocCalls memoizes each core module's cabi_realloc, keyed by the
+	// module. Resolving an export mints a fresh api.Function -- and with it a
+	// call engine -- so doing it per host call made every host import that
+	// returns a string or list allocate one, which on the wasi:http path was
+	// the largest single object allocated per request. The bound-export path
+	// has always cached this (boundExport.reallocCall); this is the same fact
+	// for the guest->host direction, which cannot cache it at bind time
+	// because the calling module is only known per call.
+	reallocCalls sync.Map // api.Module -> reallocCall
+
 	// --- CallAsync (host-side non-blocking calls, callasync.go) ---
 	asyncActive atomic.Bool       // a CallAsync is outstanding; external AsyncCall.Resolve queues instead of erroring
 	amu         sync.Mutex        // guards mailbox, pending, PendingCall.closed, and acond
@@ -2117,6 +2127,29 @@ func coreReallocCall(fn api.Function) func(context.Context, uint32, uint32, uint
 		}
 		return uint32(buf[0]), nil
 	}
+}
+
+// reallocCall is the ctx-free realloc closure an abi.Realloc holds.
+type reallocCall = func(context.Context, uint32, uint32, uint32, uint32) (uint32, error)
+
+// reallocFor is reallocOf with the export resolution memoized per module.
+//
+// Caching the resolved function for the instance's lifetime is what
+// finalizeBoundExport already does for an export's own realloc, so the
+// lifetime is not a new assumption. A module exporting no cabi_realloc caches
+// a nil call, which Realloc.grow reports as "not present" exactly as the
+// uncached path does.
+func (in *Instance) reallocFor(ctx context.Context, mod api.Module) abi.Realloc {
+	if in == nil || mod == nil {
+		return reallocOf(ctx, mod)
+	}
+	if v, ok := in.reallocCalls.Load(mod); ok {
+		call, _ := v.(reallocCall)
+		return abi.Realloc{Ctx: ctx, Call: call}
+	}
+	call := coreReallocCall(mod.ExportedFunction("cabi_realloc"))
+	in.reallocCalls.Store(mod, call)
+	return abi.Realloc{Ctx: ctx, Call: call}
 }
 
 // reallocOfFunc builds an abi.Realloc for a caller that already resolved the

--- a/internal/component/instance/resource.go
+++ b/internal/component/instance/resource.go
@@ -205,14 +205,39 @@ func (t *handleTable) liveCountLocked(typeIdx uint32) int {
 	return n
 }
 
-// registerDtor records the destructor callback for a resource type tag.
+// registerDtor records a destructor callback for a resource type tag.
+//
+// Registering a second destructor for a tag composes with the first rather
+// than replacing it, because one tag can name resources owned by several
+// independent host implementations: wasi:filesystem, wasi:sockets and
+// wasi:http all mint input-stream and output-stream handles under the shared
+// stream tags, each backed by its own state and its own disjoint range of
+// reps. Replacing would have let whichever registered last silently take over
+// releasing every stream, so the others would keep leaking with nothing to
+// report it.
+//
+// Every registered destructor runs, in registration order, and each is
+// expected to ignore a rep it does not own -- deleting an absent key. The
+// first error is returned, after the rest have run: a destructor that fails
+// must not stop the others from releasing what they own.
 func (t *handleTable) registerDtor(typeIdx uint32, dtor func(ctx context.Context, rep uint32) error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.dtors == nil {
 		t.dtors = make(map[uint32]func(ctx context.Context, rep uint32) error)
 	}
-	t.dtors[typeIdx] = dtor
+	prev := t.dtors[typeIdx]
+	if prev == nil {
+		t.dtors[typeIdx] = dtor
+		return
+	}
+	t.dtors[typeIdx] = func(ctx context.Context, rep uint32) error {
+		err := prev(ctx, rep)
+		if err2 := dtor(ctx, rep); err == nil {
+			err = err2
+		}
+		return err
+	}
 }
 
 // dtorFor returns the destructor callback registered for a resource type tag,

--- a/internal/component/instance/resource.go
+++ b/internal/component/instance/resource.go
@@ -123,6 +123,10 @@ type handleTable struct {
 	// and dense per instance rather than monotonically growing.
 	free []uint32
 
+	// slab is the unspent tail of the current resourceEntry batch (see
+	// newResourceEntry). Guarded by mu like everything else here.
+	slab []resourceEntry
+
 	// dtors maps a resource type tag to the destructor run when a handle of that
 	// tag is dropped by canon resource.drop. A GUEST-defined resource's dtor
 	// invokes its core func (registered lazily -- see resourceDtor -- because the
@@ -239,11 +243,43 @@ func newHandleTable() *handleTable {
 	return &handleTable{entries: make(map[uint32]tableEntry), next: 1}
 }
 
+// resourceEntrySlab is how many resourceEntry values newResourceEntry carves
+// from one allocation.
+//
+// A slab is not a free list: a slot is handed out once and never handed out
+// again, so a pointer into it names one entry for as long as anything holds it.
+// That matters because a lender keeps a *resourceEntry alive well past the call
+// that produced it (see entryForLend), which is exactly why these cannot be
+// recycled -- reuse would let one entry become another under a live pointer.
+// Batching only makes them cheaper to create, which is safe in a way that
+// reuse is not.
+//
+// The cost is that a slab stays alive while any one of its entries does. At
+// this size that is a few hundred bytes held by a straggler, against one
+// allocation per entry saved on a path that mints several per request.
+const resourceEntrySlab = 32
+
+// newResourceEntry returns the next unused entry, carving a fresh slab when
+// the current one is spent. Callers hold t.mu.
+func (t *handleTable) newResourceEntry(typeIdx, rep uint32, own bool) *resourceEntry {
+	if len(t.slab) == 0 {
+		t.slab = make([]resourceEntry, resourceEntrySlab)
+	}
+	e := &t.slab[0]
+	t.slab = t.slab[1:]
+	e.typeIdx, e.rep, e.own = typeIdx, rep, own
+	return e
+}
+
 // add allocates a new resourceEntry via addEntry. It is a thin, kind-specific
 // wrapper: every entry kind the table can hold shares the same allocation
 // (free-list) policy, implemented once in addEntry.
 func (t *handleTable) add(typeIdx, rep uint32, own bool) uint32 {
-	return t.addEntry(&resourceEntry{typeIdx: typeIdx, rep: rep, own: own})
+	// Carving the entry and installing it happen under one acquisition: both
+	// need the lock, and this is the hottest path onto the table.
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.addEntryLocked(t.newResourceEntry(typeIdx, rep, own))
 }
 
 // addEntry allocates a handle index -- reusing a freed index first (reference
@@ -253,6 +289,11 @@ func (t *handleTable) add(typeIdx, rep uint32, own bool) uint32 {
 func (t *handleTable) addEntry(e tableEntry) uint32 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	return t.addEntryLocked(e)
+}
+
+// addEntryLocked is addEntry's body, for callers that already hold t.mu.
+func (t *handleTable) addEntryLocked(e tableEntry) uint32 {
 	var h uint32
 	if n := len(t.free); n > 0 { // reuse a freed index (reference Table.free)
 		h = t.free[n-1]

--- a/internal/component/instance/resource_dtor_compose_test.go
+++ b/internal/component/instance/resource_dtor_compose_test.go
@@ -1,0 +1,109 @@
+package instance
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// Destructors for one resource type tag compose rather than replace.
+//
+// These call what dtorFor resolves, which is what the guest's resource.drop
+// canon invokes (graph.go). handleTable.Drop is the host-side removal and
+// deliberately runs no destructor, so it is the wrong door for this.
+//
+// A tag is not owned by a single host implementation: wasi:filesystem,
+// wasi:sockets and wasi:http all mint input-stream and output-stream handles
+// under the shared stream tags, each backed by its own state and its own
+// disjoint range of reps. Replacing on a second registration would have let
+// whichever registered last take over releasing every stream, and the others
+// would have gone on leaking with nothing to report it -- which is exactly the
+// bug this behavior exists to prevent.
+func TestRegisterDtorComposes(t *testing.T) {
+	const tag uint32 = 42
+
+	t.Run("every destructor runs", func(t *testing.T) {
+		tbl := newHandleTable()
+		var order []string
+		tbl.registerDtor(tag, func(context.Context, uint32) error {
+			order = append(order, "first")
+			return nil
+		})
+		tbl.registerDtor(tag, func(context.Context, uint32) error {
+			order = append(order, "second")
+			return nil
+		})
+
+		if err := tbl.dtorFor(tag)(context.Background(), 7); err != nil {
+			t.Fatalf("dtor: %v", err)
+		}
+		if len(order) != 2 || order[0] != "first" || order[1] != "second" {
+			t.Errorf("destructors ran %v, want [first second] in registration order", order)
+		}
+	})
+
+	t.Run("each sees the rep", func(t *testing.T) {
+		tbl := newHandleTable()
+		var seen []uint32
+		for range 2 {
+			tbl.registerDtor(tag, func(_ context.Context, rep uint32) error {
+				seen = append(seen, rep)
+				return nil
+			})
+		}
+		if err := tbl.dtorFor(tag)(context.Background(), 99); err != nil {
+			t.Fatalf("dtor: %v", err)
+		}
+		if len(seen) != 2 || seen[0] != 99 || seen[1] != 99 {
+			t.Errorf("destructors saw %v, want both to see rep 99", seen)
+		}
+	})
+
+	// A destructor that fails must not stop the others from releasing what
+	// they own, or one subsystem's error becomes another's leak.
+	t.Run("a failure does not skip the rest", func(t *testing.T) {
+		tbl := newHandleTable()
+		boom := errors.New("boom")
+		ran := false
+		tbl.registerDtor(tag, func(context.Context, uint32) error { return boom })
+		tbl.registerDtor(tag, func(context.Context, uint32) error {
+			ran = true
+			return nil
+		})
+
+		err := tbl.dtorFor(tag)(context.Background(), 1)
+		if !errors.Is(err, boom) {
+			t.Errorf("dtor error = %v, want it to report the failing destructor", err)
+		}
+		if !ran {
+			t.Error("the second destructor did not run after the first failed")
+		}
+	})
+
+	t.Run("the first error is the one reported", func(t *testing.T) {
+		tbl := newHandleTable()
+		first, second := errors.New("first"), errors.New("second")
+		tbl.registerDtor(tag, func(context.Context, uint32) error { return first })
+		tbl.registerDtor(tag, func(context.Context, uint32) error { return second })
+
+		if err := tbl.dtorFor(tag)(context.Background(), 1); !errors.Is(err, first) {
+			t.Errorf("dtor error = %v, want the first failure", err)
+		}
+	})
+
+	// One registration is still just that registration, with no wrapper.
+	t.Run("a single destructor is unaffected", func(t *testing.T) {
+		tbl := newHandleTable()
+		calls := 0
+		tbl.registerDtor(tag, func(context.Context, uint32) error {
+			calls++
+			return nil
+		})
+		if err := tbl.dtorFor(tag)(context.Background(), 3); err != nil {
+			t.Fatalf("dtor: %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("destructor ran %d times, want 1", calls)
+		}
+	})
+}

--- a/internal/component/instance/stdout_test.go
+++ b/internal/component/instance/stdout_test.go
@@ -64,17 +64,23 @@ func stdoutStreamsImportOpts(out *bytes.Buffer, streamRep uint32) []Option {
 		if rep != streamRep {
 			return nil, fmt.Errorf("write: self names rep %d, not the stream get-stdout returned (%d)", rep, streamRep)
 		}
-		contents, ok := args[1].([]abi.Value)
-		if !ok {
-			return nil, fmt.Errorf("write: contents: expected []abi.Value (list<u8>), got %T", args[1])
-		}
-		buf := make([]byte, len(contents))
-		for i, v := range contents {
-			b, ok := v.(uint32)
-			if !ok {
-				return nil, fmt.Errorf("write: contents[%d]: expected uint32 byte, got %T", i, v)
+		// list<u8> arrives in either documented shape: the compact []byte
+		// (what the abi lift produces) or the general []abi.Value.
+		var buf []byte
+		switch contents := args[1].(type) {
+		case []byte:
+			buf = contents
+		case []abi.Value:
+			buf = make([]byte, len(contents))
+			for i, v := range contents {
+				b, ok := v.(uint32)
+				if !ok {
+					return nil, fmt.Errorf("write: contents[%d]: expected uint32 byte, got %T", i, v)
+				}
+				buf[i] = byte(b)
 			}
-			buf[i] = byte(b)
+		default:
+			return nil, fmt.Errorf("write: contents: expected []byte or []abi.Value (list<u8>), got %T", args[1])
 		}
 		out.Write(buf)
 		return nil, nil


### PR DESCRIPTION
A request through `wasi:http/incoming-handler` allocated 507 objects and 31 KB. It now allocates 76 and 3.5 KB.

**Apple M4, darwin/arm64**

| | main | this branch | change |
| --- | --- | --- | --- |
| **allocs/op** | 507 | **76** | **-85%** |
| **B/op** | 31,022 | **3,491** | **-89%** |
| ns/op | ~16,480 | **~6,590** | **2.5x** |

**i9-12900HK, linux/amd64**

| | main | this branch | change |
| --- | --- | --- | --- |
| **allocs/op** | 507 | **76** | **-85%** |
| **B/op** | 31,073 | **3,496** | **-89%** |
| ns/op | ~35,200 | ~13,200 | ~2.7x |

`BenchmarkServeHTTP`, `-benchtime 3000x -count 5`, both ends measured back to back on the same machine, on both architectures.

The allocation counts are deterministic and identical across the two: 507 and 76 on every run at both ends, on both machines, which is what pure-Go changes should do.

Take the timing from the arm64 row. That machine was quiet and its five runs spread 6,530 to 6,624 ns, about 1.4%. The amd64 box was not idle (load average 2.8 to 4.7) and spread 12,364 to 15,181 ns, so its ratio is a direction rather than a measurement. Allocation count is what this change is aimed at either way, and it is the number worth holding it to.

The full `imports/wasip2`, `internal/component/instance` and `internal/component/abi` suites were run natively on the M4 as well, not only cross-compiled.

None of this is specific to HTTP. It is the cost of moving values whose WIT types are not trivial -- records holding options holding variants holding resources -- so every non-trivial component call gets it. A guest calling `add(u32, u32)` barely flattens anything and was already fast; that is why this only became visible on the HTTP path.

It also fixes an unbounded memory leak across three host implementations, which matters more than any of the above.

## The leak

`wasi:http`, `wasi:filesystem` and `wasi:sockets` each tracked their resources in maps that nothing ever deleted from. Dropping a handle freed the guest's index and left the host state it named behind for as long as the instance lived, so a long-lived server grew with every request it served and a guest doing repeated file or socket work grew the host's memory with it.

It surfaced from the other direction: `[]component.Value{handle}` was costing two allocations rather than one, which only happens when the boxed handle exceeds 255, which meant reps were climbing, which meant nothing was being released.

Three things were wrong, in order of discovery:

**Server-side http state was never released.** The incoming request, the response-outparam and the outgoing-body the guest takes from the response are reachable only through the call that created them. After 250 requests an instance still held 250 of each. `serveHTTPCall` now releases them on every exit, including the error ones.

**No host implementation registered a destructor.** Eleven resource types in `wasi:http`, six in `wasi:filesystem`, ten in `wasi:sockets` -- tags registered, destructors none, so nothing was released when a guest dropped a handle on its own. That is the whole `wasi:http` client side (a future, an incoming response and an incoming body leaked per outbound request) and every descriptor, stream and socket any guest ever opened.

**Registering a destructor replaced rather than composed**, which would have made the obvious fix silently half-work. A tag is not owned by one host implementation: filesystem, sockets and http all mint `input-stream` and `output-stream` handles under the shared stream tags, each from a disjoint range of reps. Whichever registered last would have taken over releasing every stream, and the others would have gone on leaking with nothing to report it. Destructors now compose, every one runs, and the first error is returned after the rest have run so one subsystem's failure does not become another's leak.

Each regression test counts the maps after two different volumes, because a leak and a late release are indistinguishable at one. That is what caught the incoming-request case, which the first fix missed.

## Where the allocations went

Each stage measured on its own; ns/op is ignored throughout, since the number that matters here is heap traffic and the machine is shared.

| change | allocs/op |
| --- | --- |
| baseline | 507 |
| stop boxing a primitive descriptor on every type resolve | 294 |
| ask for a type's flat width without flattening it | 202 |
| size the flattened type lists up front | 166 |
| resolve a module's `cabi_realloc` once, not per host call | 152 |
| pass a type's flattened layout down the lift | 75 |
| lift `list<u8>` as bytes rather than a value per byte | 73 |
| stop rebuilding call-invariant host results per request | 72 |
| release per-request http state | 81 * |
| carve resource entries from a slab | **75** |

The destructor work that follows is a correctness fix and does not move the benchmark: the resources it releases were already being released on this path by `serveHTTPCall`.

\* the benchmark was corrected at this point to build a `ResponseRecorder` per iteration rather than reuse one, which raised both ends of the comparison by about nine allocations of httptest's own. The 507 baseline is the corrected measurement; the earlier figure of 498 was taken the flawed way. Numbers above the correction are as measured at the time.

Two of these are worth explaining.

**A primitive descriptor was boxed on every node of every type walk.** `resolveType` returned `binary.PrimitiveDesc{...}` as a `binary.TypeDesc`, which allocates. One line, 40% of all allocations in the request path. The primitives are a closed set, so each is boxed once into a package table.

**Lifting re-derived the flattened layout of every type it walked through**, because each level called `Flatten` on the descriptor it had just been handed. Caching it looks like the answer and is not: a `binary.TypeDesc` cannot be a map key (a record holds a slice), `Resolver` is a bare func with nowhere to hang state and is publicly aliased, and a map keyed by the type reference would retain type data for the process lifetime -- for pointers that are not stable identities anyway, since descriptors are copied by value.

None of that is needed, because every one of those calls sits directly below a caller that already holds the answer. A result's flattened layout is the param plan's. A nested variant case's is what the enclosing level just computed. An option's element is its own layout minus the discriminant, since options concatenate rather than join. So the layout is threaded down the recursion instead of recomputed, sourced from plans that were already computing it for the spill decision and discarding it. No cache: nothing to key, nothing to invalidate, no lifetime to manage, and no dependence on a resolver returning the same answer twice.

## One behavioral change

A list of a fixed-width primitive now lifts to the Go slice of that primitive -- `[]byte` for `list<u8>`, `[]uint32` for `list<u32>`, `[]float64`, `[]bool`, `[]rune` for `list<char>` -- rather than to a `[]Value` holding one interface per element. A list of strings or of records has no single element type and stays `[]Value`.

The general shape costs a machine word per element on 64-bit, sixteen bytes to carry four, and every consumer of a numeric list converted it back to a typed slice anyway.

`BenchmarkScalarListLift`, 256-element lists, both paths as they are actually called:

Each row is one list of 256 elements, before against after -- the general `[]Value` path it used to take, and the typed slice it takes now.

<table>
<thead>
<tr>
<th rowspan="2">element</th>
<th colspan="2">ns/op</th>
<th rowspan="2">speedup</th>
<th colspan="2">allocs/op</th>
<th colspan="2">B/op</th>
</tr>
<tr>
<th>before</th><th>after</th>
<th>before</th><th>after</th>
<th>before</th><th>after</th>
</tr>
</thead>
<tbody>
<tr><td><code>u8</code></td><td>2,760</td><td><b>84</b></td><td><b>33x</b></td><td>2</td><td>2</td><td>4,880</td><td><b>280</b></td></tr>
<tr><td><code>u16</code></td><td>4,763</td><td><b>696</b></td><td><b>6.8x</b></td><td>256</td><td><b>2</b></td><td>5,896</td><td><b>536</b></td></tr>
<tr><td><code>u32</code></td><td>5,036</td><td><b>795</b></td><td><b>6.3x</b></td><td>258</td><td><b>2</b></td><td>5,904</td><td><b>1,048</b></td></tr>
<tr><td><code>s32</code></td><td>4,729</td><td><b>756</b></td><td><b>6.3x</b></td><td>258</td><td><b>2</b></td><td>5,904</td><td><b>1,048</b></td></tr>
<tr><td><code>u64</code></td><td>5,141</td><td><b>958</b></td><td><b>5.4x</b></td><td>258</td><td><b>2</b></td><td>6,928</td><td><b>2,072</b></td></tr>
<tr><td><code>f64</code></td><td>7,669</td><td><b>929</b></td><td><b>8.3x</b></td><td>514</td><td><b>2</b></td><td>8,976</td><td><b>2,072</b></td></tr>
<tr><td><code>bool</code></td><td>2,626</td><td><b>762</b></td><td><b>3.4x</b></td><td>2</td><td>2</td><td>4,880</td><td><b>280</b></td></tr>
</tbody>
</table>

Read a row as: a 256-element `list<f64>` used to take 7,669ns, 514 allocations and 8,976 bytes; it now takes 929ns, 2 allocations and 2,072 bytes. The 514 is two allocations per element -- the boxed interface and its payload -- against a fixed two for the whole list however long it is.

`u8` is the outlier because it needs no per-element decode at all -- one copy. `u8` and `bool` also stay at two allocations on the general path, since byte values and bools land in the runtime's small-integer cache; their win is memory and decode cost rather than allocation count. Everything wider boxes per element.

The benchmark fills memory with varied non-zero bytes on purpose. Zero-filled memory puts every element in that same small-integer cache, which reports the general path at 2 allocs/op instead of 258 and flatters it by two orders of magnitude.

This does not move `BenchmarkServeHTTP`: the wasi:http path carries no numeric lists.

`list<u8>` was already a documented carve-out. Nothing made it special except that it was the case that hurt first, so this generalises it rather than adding a second exception. That matters beyond tidiness: the contract change costs the same whether it covers one element type or all of them, so extending it later would have meant breaking embedders twice, and "`list<u8>` is `[]byte` but `list<u32>` is not" is a rule nobody can predict from first principles.

`component.ListOf` is the accessor for this, and for lists generally:

```go
names, err := component.ListOf[string](args[0])   // list<string>, always []Value
sizes, err := component.ListOf[uint32](args[1])   // list<u32>, typed
```

It takes either shape, returns the typed one as it arrived rather than copying when it is already typed, and narrows the widened element values the `[]Value` shape carries. It is worth having beyond the migration: a list of strings or of records has no typed shape and never will, so walking one was already every embedder's job. `imports/wasi_otel` reads its lists through it, so it is exercised by the same code an embedder would write.

**Breaking.** A host function that type-asserts `[]Value` for a list of a fixed-width primitive must accept the typed slice instead, or read it through `ListOf`. Lowering still takes either shape, so a host func *producing* a list is unaffected; only reading a lifted one changes. `imports/wasi_otel` was the one consumer in this repository asserting the old shape, for `list<f64>` and `list<u64>`, and now accepts both.

The typed path decodes bytes itself rather than going through `loadPrimitive` per element, so it could have drifted from the general path in a way nothing would report -- the guest would simply receive different numbers. Every element type is therefore tested against the general path element by element, over the values that catch a bad decode: sign extension, both zeroes, infinities, and each width's extremes. `char` keeps its per-element validation, since a list is not a way to smuggle in a surrogate half.

That differential test also turned up a pre-existing bug it was not looking for: `loadInt` returned early only for a *negative* `s8`, so a non-negative one came back as a `uint32`. `storePrimitive` requires an `int32` for `s8`, which meant an `s8` a host lifted could not be handed back unless it happened to be negative, and a host asserting `int32` -- as the type says -- saw that fail for half the range. Fixed in `542c7a3`; the wider signed widths never had the split.

## Correctness

The ABI layer lifts and lowers guest memory, so a wrong flat width silently mangles data rather than failing. `FlatWidth` is therefore checked directly against `len(Flatten(...))` over every descriptor kind, the composites that join rather than concatenate, the malformed types both must reject, and a deeply nested shape of the sort wasi:http carries.

An outside review found four defects in the earlier commits here, all fixed in `128c2e3`: `flattenVariant` walked each payload twice and could have silently truncated a join to a stale width; the claim that `FlatWidth` allocates nothing was proven on one shape while the flags and enum arms did allocate; the corpus described itself as covering every descriptor kind while omitting stream and future; and width addition was unbounded, so a malformed type graph could wrap it negative and take the spill decision with it.

`handleTable.Drop`, the host-side removal, deliberately runs no destructor -- they are resolved through `dtorFor` by the guest's `resource.drop` canon. The tests exercise them the same way.

Resource entries are batched, not recycled. A lender keeps a `*resourceEntry` alive past the call that produced it, which is why `entryForLend` hands out a pointer at all, so returning entries to a free list would let one entry become another under a live pointer. A slab slot is carved once and never handed out again; only the cost of creating it changes.

- Full repository suite green
- `-race` clean across component, wasip2 and wasi_otel
- golangci-lint clean
- Cross-builds green, plan9 and aix included

## Not done

About 17 allocations per request remain in the argument and result slices the host-call boundary builds (`liftHostArgsPlanned` and the WASI host functions' single-element results). Pooling them is straightforward and is deliberately not done here: `HostFunc` is public and its documentation says nothing about retention, so an embedder holding onto `args` today is doing nothing wrong, and pooling would corrupt it silently rather than loudly. That needs a documented contract change -- "arguments and results are valid only for the duration of the call" -- which is a promise to embedders rather than an implementation detail, and belongs in its own change.
